### PR TITLE
feat(flutter): feature MVPs — dashboard/diet/exercise/my_health/coach/noti/place/auth (stage 4)

### DIFF
--- a/frontend/flutter/README.md
+++ b/frontend/flutter/README.md
@@ -3,7 +3,7 @@
 [Oncare Prototype (React/TS)](https://github.com/subin21cc/Oncareprototype) 를 Flutter로 재구성하는 프로젝트입니다.
 **Android / iOS / Web** 3개 타깃을 단일 코드베이스로 빌드하며, 웹은 GitHub Pages에 CI 배포됩니다.
 
-> 현재 상태: **Stage 3 — Design System 완료** → Stage 4 (Features) 진입 예정
+> 현재 상태: **Stage 4 — Features MVP 완료** → Stage 5 (Integration & Polish) 진입 예정
 
 ## 문서
 
@@ -62,7 +62,7 @@ flutter build ios --release      # Xcode에서 archive
 - [x] **Stage 1 — Bootstrap** (flutter create, deps, lint, AppConfig, CI/CD)
 - [x] **Stage 2 — Core Infrastructure** (router, theme, dio, drift, errors, l10n)
 - [x] **Stage 3 — Design System** (tokens / atoms / molecules / charts / responsive / UI 카탈로그)
-- [ ] Stage 4 — Features (Dashboard / Diet / Exercise / MyHealth / AICoach / Notification / Place / Auth)
+- [x] **Stage 4 — Features MVP** (Dashboard / Diet / Exercise / MyHealth / AICoach / Notification / Place / Auth — 모두 mock 데이터)
 - [ ] Stage 5 — Integration & Polish
 - [ ] Stage 6 — Quality
 - [ ] Stage 7 — Release

--- a/frontend/flutter/lib/features/ai_coach/data/repositories/mock_ai_coach_repository.dart
+++ b/frontend/flutter/lib/features/ai_coach/data/repositories/mock_ai_coach_repository.dart
@@ -1,0 +1,36 @@
+import 'package:oncare/features/ai_coach/domain/entities/ai_coach_state.dart';
+import 'package:oncare/features/ai_coach/domain/repositories/ai_coach_repository.dart';
+
+class MockAiCoachRepository implements AiCoachRepository {
+  const MockAiCoachRepository();
+
+  @override
+  Future<AiCoachState> fetchState() async {
+    await Future<void>.delayed(const Duration(milliseconds: 250));
+    return const AiCoachState(
+      greeting: '안녕하세요, 오늘 컨디션은 어떠세요?',
+      suggestions: <AiSuggestion>[
+        AiSuggestion(
+          tag: AiSuggestionTag.diet,
+          title: '점심에 단백질을 +10g 추가해 보세요',
+          body: '오전 운동량을 보면 점심에 단백질을 조금 더 채우는 것이 좋아요.',
+        ),
+        AiSuggestion(
+          tag: AiSuggestionTag.exercise,
+          title: '저녁 산책 15분',
+          body: '저녁 시간대 가벼운 유산소는 수면의 질도 함께 끌어올립니다.',
+        ),
+        AiSuggestion(
+          tag: AiSuggestionTag.hydration,
+          title: '수분 보충',
+          body: '오늘 평소보다 활동량이 많았어요. 물 한 컵 더 마셔봐요.',
+        ),
+        AiSuggestion(
+          tag: AiSuggestionTag.sleep,
+          title: '취침 1시간 전 화면 줄이기',
+          body: '깊은 수면 비율이 낮은 패턴이 보입니다. 자극을 줄여보세요.',
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/flutter/lib/features/ai_coach/domain/entities/ai_coach_state.dart
+++ b/frontend/flutter/lib/features/ai_coach/domain/entities/ai_coach_state.dart
@@ -1,0 +1,19 @@
+enum AiSuggestionTag { diet, exercise, sleep, hydration }
+
+class AiSuggestion {
+  const AiSuggestion({
+    required this.title,
+    required this.body,
+    required this.tag,
+  });
+
+  final String title;
+  final String body;
+  final AiSuggestionTag tag;
+}
+
+class AiCoachState {
+  const AiCoachState({required this.greeting, required this.suggestions});
+  final String greeting;
+  final List<AiSuggestion> suggestions;
+}

--- a/frontend/flutter/lib/features/ai_coach/domain/repositories/ai_coach_repository.dart
+++ b/frontend/flutter/lib/features/ai_coach/domain/repositories/ai_coach_repository.dart
@@ -1,0 +1,5 @@
+import 'package:oncare/features/ai_coach/domain/entities/ai_coach_state.dart';
+
+abstract class AiCoachRepository {
+  Future<AiCoachState> fetchState();
+}

--- a/frontend/flutter/lib/features/ai_coach/presentation/controllers/ai_coach_controller.dart
+++ b/frontend/flutter/lib/features/ai_coach/presentation/controllers/ai_coach_controller.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare/features/ai_coach/data/repositories/mock_ai_coach_repository.dart';
+import 'package:oncare/features/ai_coach/domain/entities/ai_coach_state.dart';
+import 'package:oncare/features/ai_coach/domain/repositories/ai_coach_repository.dart';
+
+final aiCoachRepositoryProvider = Provider<AiCoachRepository>(
+  (ref) => const MockAiCoachRepository(),
+  name: 'aiCoachRepository',
+);
+
+final aiCoachStateProvider = FutureProvider<AiCoachState>((ref) {
+  return ref.watch(aiCoachRepositoryProvider).fetchState();
+}, name: 'aiCoachState');

--- a/frontend/flutter/lib/features/ai_coach/presentation/pages/ai_coach_page.dart
+++ b/frontend/flutter/lib/features/ai_coach/presentation/pages/ai_coach_page.dart
@@ -1,16 +1,95 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:oncare/core/errors/app_error.dart';
+import 'package:oncare/design_system/atoms/app_badge.dart';
+import 'package:oncare/design_system/atoms/app_card.dart';
+import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/ai_coach/domain/entities/ai_coach_state.dart';
+import 'package:oncare/features/ai_coach/presentation/controllers/ai_coach_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/error_view.dart';
 
-class AICoachPage extends StatelessWidget {
+({String label, AppBadgeTone tone}) _tagDisplay(AiSuggestionTag t) =>
+    switch (t) {
+      AiSuggestionTag.diet => (label: '식단', tone: AppBadgeTone.warning),
+      AiSuggestionTag.exercise => (label: '운동', tone: AppBadgeTone.success),
+      AiSuggestionTag.sleep => (label: '수면', tone: AppBadgeTone.info),
+      AiSuggestionTag.hydration => (label: '수분', tone: AppBadgeTone.info),
+    };
+
+class AICoachPage extends ConsumerWidget {
   const AICoachPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l = AppLocalizations.of(context);
+    final async = ref.watch(aiCoachStateProvider);
     return Scaffold(
       appBar: AppBar(title: Text(l.pageAiCoachTitle)),
-      body: Center(child: Text(l.placeholderAiCoach)),
+      body: async.when(
+        data: (s) => _Body(state: s),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (Object e, _) => ErrorView(
+          error: e is AppError ? e : UnknownError(message: e.toString()),
+          onRetry: () => ref.invalidate(aiCoachStateProvider),
+        ),
+      ),
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  const _Body({required this.state});
+  final AiCoachState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListView(
+      padding: const EdgeInsets.all(AppSpacing.lg),
+      children: <Widget>[
+        AppCard(
+          color: AppColors.domainAiCoach.withValues(alpha: 0.12),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              const Icon(
+                Icons.smart_toy_outlined,
+                color: AppColors.domainAiCoach,
+              ),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Text(state.greeting, style: theme.textTheme.bodyLarge),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: AppSpacing.lg),
+        for (final s in state.suggestions) ...<Widget>[
+          AppCard(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    AppBadge(
+                      label: _tagDisplay(s.tag).label,
+                      tone: _tagDisplay(s.tag).tone,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                Text(s.title, style: theme.textTheme.titleMedium),
+                const SizedBox(height: AppSpacing.xs),
+                Text(s.body, style: theme.textTheme.bodyMedium),
+              ],
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+        ],
+      ],
     );
   }
 }

--- a/frontend/flutter/lib/features/auth/data/repositories/mock_auth_repository.dart
+++ b/frontend/flutter/lib/features/auth/data/repositories/mock_auth_repository.dart
@@ -1,0 +1,23 @@
+import 'package:oncare/features/auth/domain/entities/auth_state.dart';
+import 'package:oncare/features/auth/domain/repositories/auth_repository.dart';
+
+/// Mock implementation used until the real social SDKs (Apple / Google /
+/// Kakao / Naver) are wired in Stage 4 follow-up with real keys.
+class MockAuthRepository implements AuthRepository {
+  const MockAuthRepository();
+
+  @override
+  Future<AuthUser> signIn(AuthProvider provider) async {
+    await Future<void>.delayed(const Duration(milliseconds: 400));
+    return AuthUser(
+      id: 'mock-${provider.name}-1',
+      name: 'Demo (${provider.name})',
+      provider: provider,
+    );
+  }
+
+  @override
+  Future<void> signOut() async {
+    await Future<void>.delayed(const Duration(milliseconds: 150));
+  }
+}

--- a/frontend/flutter/lib/features/auth/domain/entities/auth_state.dart
+++ b/frontend/flutter/lib/features/auth/domain/entities/auth_state.dart
@@ -1,0 +1,19 @@
+enum AuthProvider { apple, google, kakao, naver }
+
+class AuthUser {
+  const AuthUser({
+    required this.id,
+    required this.name,
+    required this.provider,
+  });
+
+  final String id;
+  final String name;
+  final AuthProvider provider;
+}
+
+class AuthState {
+  const AuthState({this.user});
+  final AuthUser? user;
+  bool get isSignedIn => user != null;
+}

--- a/frontend/flutter/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/frontend/flutter/lib/features/auth/domain/repositories/auth_repository.dart
@@ -1,0 +1,6 @@
+import 'package:oncare/features/auth/domain/entities/auth_state.dart';
+
+abstract class AuthRepository {
+  Future<AuthUser> signIn(AuthProvider provider);
+  Future<void> signOut();
+}

--- a/frontend/flutter/lib/features/auth/presentation/controllers/auth_controller.dart
+++ b/frontend/flutter/lib/features/auth/presentation/controllers/auth_controller.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare/features/auth/data/repositories/mock_auth_repository.dart';
+import 'package:oncare/features/auth/domain/entities/auth_state.dart';
+import 'package:oncare/features/auth/domain/repositories/auth_repository.dart';
+
+final authRepositoryProvider = Provider<AuthRepository>(
+  (ref) => const MockAuthRepository(),
+  name: 'authRepository',
+);
+
+class AuthController extends StateNotifier<AsyncValue<AuthState>> {
+  AuthController(this._repo)
+    : super(const AsyncValue<AuthState>.data(AuthState()));
+
+  final AuthRepository _repo;
+
+  Future<void> signIn(AuthProvider provider) async {
+    state = const AsyncValue<AuthState>.loading();
+    try {
+      final user = await _repo.signIn(provider);
+      state = AsyncValue<AuthState>.data(AuthState(user: user));
+    } catch (e, st) {
+      state = AsyncValue<AuthState>.error(e, st);
+    }
+  }
+
+  Future<void> signOut() async {
+    await _repo.signOut();
+    state = const AsyncValue<AuthState>.data(AuthState());
+  }
+}
+
+final authControllerProvider =
+    StateNotifierProvider<AuthController, AsyncValue<AuthState>>(
+      (ref) => AuthController(ref.watch(authRepositoryProvider)),
+      name: 'auth',
+    );

--- a/frontend/flutter/lib/features/auth/presentation/pages/sign_in_page.dart
+++ b/frontend/flutter/lib/features/auth/presentation/pages/sign_in_page.dart
@@ -1,16 +1,131 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:oncare/design_system/atoms/app_button.dart';
+import 'package:oncare/design_system/atoms/app_card.dart';
+import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/auth/domain/entities/auth_state.dart';
+import 'package:oncare/features/auth/presentation/controllers/auth_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 
-class SignInPage extends StatelessWidget {
+class SignInPage extends ConsumerWidget {
   const SignInPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l = AppLocalizations.of(context);
+    final async = ref.watch(authControllerProvider);
+    final controller = ref.read(authControllerProvider.notifier);
+    final theme = Theme.of(context);
+
     return Scaffold(
       appBar: AppBar(title: Text(l.pageSignInTitle)),
-      body: Center(child: Text(l.placeholderSignIn)),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.lg),
+          child: async.when(
+            data: (state) => state.isSignedIn
+                ? _SignedIn(state: state, onSignOut: controller.signOut)
+                : _SignInForm(onSignIn: controller.signIn),
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (Object e, StackTrace _) => Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  Text('로그인에 실패했습니다', style: theme.textTheme.titleMedium),
+                  const SizedBox(height: AppSpacing.sm),
+                  Text(e.toString()),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SignInForm extends StatelessWidget {
+  const _SignInForm({required this.onSignIn});
+  final Future<void> Function(AuthProvider) onSignIn;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        const SizedBox(height: AppSpacing.xl),
+        Text(
+          'Oncare에 오신 것을 환영합니다',
+          style: theme.textTheme.titleLarge,
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        Text(
+          '소셜 로그인은 실제 SDK 키 통합 전까지 mock 응답으로 동작합니다.',
+          style: theme.textTheme.bodyMedium,
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: AppSpacing.xl),
+        AppButton(
+          label: 'Continue with Apple',
+          icon: Icons.apple,
+          fullWidth: true,
+          onPressed: () => onSignIn(AuthProvider.apple),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        AppButton(
+          label: 'Continue with Google',
+          icon: Icons.g_mobiledata,
+          fullWidth: true,
+          variant: AppButtonVariant.secondary,
+          onPressed: () => onSignIn(AuthProvider.google),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        AppButton(
+          label: 'Continue with Kakao',
+          icon: Icons.chat_bubble_outline,
+          fullWidth: true,
+          variant: AppButtonVariant.secondary,
+          onPressed: () => onSignIn(AuthProvider.kakao),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        AppButton(
+          label: 'Continue with Naver',
+          icon: Icons.eco_outlined,
+          fullWidth: true,
+          variant: AppButtonVariant.secondary,
+          onPressed: () => onSignIn(AuthProvider.naver),
+        ),
+      ],
+    );
+  }
+}
+
+class _SignedIn extends StatelessWidget {
+  const _SignedIn({required this.state, required this.onSignOut});
+  final AuthState state;
+  final Future<void> Function() onSignOut;
+
+  @override
+  Widget build(BuildContext context) {
+    final user = state.user!;
+    return AppCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text('로그인됨', style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: AppSpacing.sm),
+          Text('${user.name} (${user.provider.name})'),
+          const SizedBox(height: AppSpacing.lg),
+          AppButton(
+            label: 'Sign out',
+            variant: AppButtonVariant.ghost,
+            onPressed: onSignOut,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/frontend/flutter/lib/features/dashboard/data/repositories/mock_dashboard_repository.dart
+++ b/frontend/flutter/lib/features/dashboard/data/repositories/mock_dashboard_repository.dart
@@ -1,0 +1,18 @@
+import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
+import 'package:oncare/features/dashboard/domain/repositories/dashboard_repository.dart';
+
+class MockDashboardRepository implements DashboardRepository {
+  const MockDashboardRepository();
+
+  @override
+  Future<DashboardSummary> fetchSummary() async {
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+    return const DashboardSummary(
+      caloriesToday: 1420,
+      caloriesGoal: 2000,
+      exerciseMinutesToday: 38,
+      weightKg: 68.2,
+      weeklyWeight: <double>[70.4, 70.1, 69.8, 69.4, 69.0, 68.6, 68.2],
+    );
+  }
+}

--- a/frontend/flutter/lib/features/dashboard/domain/entities/dashboard_summary.dart
+++ b/frontend/flutter/lib/features/dashboard/domain/entities/dashboard_summary.dart
@@ -1,0 +1,18 @@
+/// Snapshot of a user's day surfaced on the dashboard.
+class DashboardSummary {
+  const DashboardSummary({
+    required this.caloriesToday,
+    required this.caloriesGoal,
+    required this.exerciseMinutesToday,
+    required this.weightKg,
+    required this.weeklyWeight,
+  });
+
+  final int caloriesToday;
+  final int caloriesGoal;
+  final int exerciseMinutesToday;
+  final double weightKg;
+
+  /// Most-recent first (7 days).
+  final List<double> weeklyWeight;
+}

--- a/frontend/flutter/lib/features/dashboard/domain/repositories/dashboard_repository.dart
+++ b/frontend/flutter/lib/features/dashboard/domain/repositories/dashboard_repository.dart
@@ -1,0 +1,5 @@
+import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
+
+abstract class DashboardRepository {
+  Future<DashboardSummary> fetchSummary();
+}

--- a/frontend/flutter/lib/features/dashboard/presentation/controllers/dashboard_controller.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/controllers/dashboard_controller.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare/features/dashboard/data/repositories/mock_dashboard_repository.dart';
+import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
+import 'package:oncare/features/dashboard/domain/repositories/dashboard_repository.dart';
+
+final dashboardRepositoryProvider = Provider<DashboardRepository>(
+  (ref) => const MockDashboardRepository(),
+  name: 'dashboardRepository',
+);
+
+final dashboardSummaryProvider = FutureProvider<DashboardSummary>((ref) {
+  final repo = ref.watch(dashboardRepositoryProvider);
+  return repo.fetchSummary();
+}, name: 'dashboardSummary');

--- a/frontend/flutter/lib/features/dashboard/presentation/pages/dashboard_page.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/pages/dashboard_page.dart
@@ -4,7 +4,11 @@ import 'package:go_router/go_router.dart';
 
 import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/core/errors/app_error.dart';
+import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
+import 'package:oncare/features/dashboard/presentation/widgets/dashboard_content.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/error_view.dart';
 
 class DashboardPage extends ConsumerWidget {
   const DashboardPage({super.key});
@@ -13,6 +17,8 @@ class DashboardPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l = AppLocalizations.of(context);
     final config = ref.watch(appConfigProvider);
+    final summary = ref.watch(dashboardSummaryProvider);
+
     return Scaffold(
       appBar: AppBar(
         title: Text(l.pageDashboardTitle),
@@ -22,44 +28,28 @@ class DashboardPage extends ConsumerWidget {
             icon: const Icon(Icons.notifications_outlined),
             onPressed: () => context.push(AppRoutes.notification),
           ),
+          if (!config.isProd)
+            IconButton(
+              tooltip: 'UI Catalog',
+              icon: const Icon(Icons.palette_outlined),
+              onPressed: () => context.push(AppRoutes.uiCatalog),
+            ),
         ],
       ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
-            Text(l.placeholderDashboard, style: const TextStyle(fontSize: 16)),
-            const SizedBox(height: 24),
-            FilledButton.icon(
-              icon: const Icon(Icons.smart_toy_outlined),
-              label: Text(l.actionOpenAiCoach),
-              onPressed: () => context.push(AppRoutes.aiCoach),
-            ),
-            const SizedBox(height: 8),
-            OutlinedButton.icon(
-              icon: const Icon(Icons.place_outlined),
-              label: Text(l.actionFindPlace),
-              onPressed: () => context.push(AppRoutes.place),
-            ),
-            const SizedBox(height: 8),
-            TextButton.icon(
-              icon: const Icon(Icons.login),
-              label: Text(l.actionSignInPlaceholder),
-              onPressed: () => context.push(AppRoutes.signIn),
-            ),
-            if (!config.isProd) ...<Widget>[
-              const SizedBox(height: 16),
-              const Divider(),
-              const SizedBox(height: 8),
-              TextButton.icon(
-                icon: const Icon(Icons.palette_outlined),
-                label: const Text('UI Catalog (dev)'),
-                onPressed: () => context.push(AppRoutes.uiCatalog),
-              ),
-            ],
-          ],
+      body: summary.when(
+        data: (s) => DashboardContent(summary: s),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (Object error, StackTrace _) => ErrorView(
+          error: error is AppError
+              ? error
+              : UnknownError(message: error.toString()),
+          onRetry: () => ref.invalidate(dashboardSummaryProvider),
         ),
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        icon: const Icon(Icons.smart_toy_outlined),
+        label: Text(l.actionOpenAiCoach),
+        onPressed: () => context.push(AppRoutes.aiCoach),
       ),
     );
   }

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -1,0 +1,84 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import 'package:oncare/design_system/charts/app_line_chart.dart';
+import 'package:oncare/design_system/molecules/chart_card.dart';
+import 'package:oncare/design_system/molecules/metric_card.dart';
+import 'package:oncare/design_system/molecules/section_header.dart';
+import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
+
+class DashboardContent extends StatelessWidget {
+  const DashboardContent({required this.summary, super.key});
+
+  final DashboardSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final caloriesPct = (summary.caloriesToday / summary.caloriesGoal * 100)
+        .round();
+    final weightSpots = <FlSpot>[
+      for (int i = 0; i < summary.weeklyWeight.length; i++)
+        FlSpot(i.toDouble(), summary.weeklyWeight[i]),
+    ];
+    final firstWeight = summary.weeklyWeight.first;
+    final lastWeight = summary.weeklyWeight.last;
+    final weightDelta = lastWeight - firstWeight;
+
+    return ListView(
+      padding: const EdgeInsets.all(AppSpacing.lg),
+      children: <Widget>[
+        const SectionHeader('오늘의 요약'),
+        Row(
+          children: <Widget>[
+            Expanded(
+              child: MetricCard(
+                title: '칼로리',
+                value: summary.caloriesToday.toString(),
+                unit: 'kcal',
+                delta: '$caloriesPct% of ${summary.caloriesGoal}',
+                icon: Icons.restaurant,
+                accentColor: AppColors.domainDiet,
+              ),
+            ),
+            const SizedBox(width: AppSpacing.md),
+            Expanded(
+              child: MetricCard(
+                title: '운동',
+                value: summary.exerciseMinutesToday.toString(),
+                unit: '분',
+                icon: Icons.fitness_center,
+                accentColor: AppColors.domainExercise,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.md),
+        MetricCard(
+          title: '체중',
+          value: summary.weightKg.toStringAsFixed(1),
+          unit: 'kg',
+          delta:
+              '${weightDelta >= 0 ? '+' : ''}${weightDelta.toStringAsFixed(1)} '
+              'vs 지난주',
+          deltaTone: weightDelta <= 0
+              ? MetricDeltaTone.positive
+              : MetricDeltaTone.negative,
+          icon: Icons.favorite_outline,
+          accentColor: AppColors.domainHealth,
+        ),
+        const SizedBox(height: AppSpacing.xl),
+        const SectionHeader('체중 추이 (7일)'),
+        ChartCard(
+          title: '주간 체중',
+          height: 160,
+          child: AppLineChart(
+            color: AppColors.domainHealth,
+            spots: weightSpots,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/flutter/lib/features/diet/data/repositories/mock_diet_repository.dart
+++ b/frontend/flutter/lib/features/diet/data/repositories/mock_diet_repository.dart
@@ -1,0 +1,45 @@
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+import 'package:oncare/features/diet/domain/repositories/diet_repository.dart';
+
+class MockDietRepository implements DietRepository {
+  const MockDietRepository();
+
+  @override
+  Future<DietDay> fetchToday() async {
+    await Future<void>.delayed(const Duration(milliseconds: 150));
+    return const DietDay(
+      entries: <DietEntry>[
+        DietEntry(
+          mealType: MealType.breakfast,
+          timeLabel: '08:20',
+          totalCalories: 315,
+          foods: <FoodItem>[
+            FoodItem(name: '오트밀', calories: 220),
+            FoodItem(name: '바나나 1개', calories: 90),
+            FoodItem(name: '아메리카노', calories: 5),
+          ],
+        ),
+        DietEntry(
+          mealType: MealType.lunch,
+          timeLabel: '12:40',
+          totalCalories: 530,
+          foods: <FoodItem>[
+            FoodItem(name: '닭가슴살 샐러드', calories: 380),
+            FoodItem(name: '현미밥 반공기', calories: 150),
+          ],
+        ),
+        DietEntry(
+          mealType: MealType.dinner,
+          timeLabel: '19:00',
+          totalCalories: 575,
+          foods: <FoodItem>[
+            FoodItem(name: '연어 스테이크', calories: 420),
+            FoodItem(name: '구운 야채', calories: 155),
+          ],
+        ),
+      ],
+      totalCalories: 1420,
+      macros: DietMacros(carbsPct: 50, proteinPct: 30, fatPct: 20),
+    );
+  }
+}

--- a/frontend/flutter/lib/features/diet/domain/entities/diet_day.dart
+++ b/frontend/flutter/lib/features/diet/domain/entities/diet_day.dart
@@ -1,0 +1,45 @@
+enum MealType { breakfast, lunch, dinner, snack }
+
+class FoodItem {
+  const FoodItem({required this.name, required this.calories});
+  final String name;
+  final int calories;
+}
+
+class DietEntry {
+  const DietEntry({
+    required this.mealType,
+    required this.timeLabel,
+    required this.foods,
+    required this.totalCalories,
+  });
+
+  final MealType mealType;
+  final String timeLabel;
+  final List<FoodItem> foods;
+  final int totalCalories;
+}
+
+class DietMacros {
+  const DietMacros({
+    required this.carbsPct,
+    required this.proteinPct,
+    required this.fatPct,
+  });
+
+  final int carbsPct;
+  final int proteinPct;
+  final int fatPct;
+}
+
+class DietDay {
+  const DietDay({
+    required this.entries,
+    required this.totalCalories,
+    required this.macros,
+  });
+
+  final List<DietEntry> entries;
+  final int totalCalories;
+  final DietMacros macros;
+}

--- a/frontend/flutter/lib/features/diet/domain/repositories/diet_repository.dart
+++ b/frontend/flutter/lib/features/diet/domain/repositories/diet_repository.dart
@@ -1,0 +1,5 @@
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+
+abstract class DietRepository {
+  Future<DietDay> fetchToday();
+}

--- a/frontend/flutter/lib/features/diet/presentation/controllers/diet_controller.dart
+++ b/frontend/flutter/lib/features/diet/presentation/controllers/diet_controller.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+import 'package:oncare/features/diet/domain/repositories/diet_repository.dart';
+
+final dietRepositoryProvider = Provider<DietRepository>(
+  (ref) => const MockDietRepository(),
+  name: 'dietRepository',
+);
+
+final dietTodayProvider = FutureProvider<DietDay>((ref) {
+  return ref.watch(dietRepositoryProvider).fetchToday();
+}, name: 'dietToday');

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -1,16 +1,86 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:oncare/core/errors/app_error.dart';
+import 'package:oncare/design_system/charts/app_donut_chart.dart';
+import 'package:oncare/design_system/molecules/chart_card.dart';
+import 'package:oncare/design_system/molecules/metric_card.dart';
+import 'package:oncare/design_system/molecules/section_header.dart';
+import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
+import 'package:oncare/features/diet/presentation/widgets/meal_card.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/error_view.dart';
 
-class DietRecordPage extends StatelessWidget {
+class DietRecordPage extends ConsumerWidget {
   const DietRecordPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l = AppLocalizations.of(context);
+    final async = ref.watch(dietTodayProvider);
     return Scaffold(
       appBar: AppBar(title: Text(l.pageDietTitle)),
-      body: Center(child: Text(l.placeholderDiet)),
+      body: async.when(
+        data: (day) => _Body(day: day),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (Object e, _) => ErrorView(
+          error: e is AppError ? e : UnknownError(message: e.toString()),
+          onRetry: () => ref.invalidate(dietTodayProvider),
+        ),
+      ),
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  const _Body({required this.day});
+  final DietDay day;
+
+  @override
+  Widget build(BuildContext context) {
+    final macros = <AppDonutSegment>[
+      AppDonutSegment(
+        label: '탄수화물',
+        value: day.macros.carbsPct.toDouble(),
+        color: AppColors.domainDiet,
+      ),
+      AppDonutSegment(
+        label: '단백질',
+        value: day.macros.proteinPct.toDouble(),
+        color: AppColors.domainExercise,
+      ),
+      AppDonutSegment(
+        label: '지방',
+        value: day.macros.fatPct.toDouble(),
+        color: AppColors.domainHealth,
+      ),
+    ];
+    return ListView(
+      padding: const EdgeInsets.all(AppSpacing.lg),
+      children: <Widget>[
+        MetricCard(
+          title: '오늘 총 칼로리',
+          value: day.totalCalories.toString(),
+          unit: 'kcal',
+          icon: Icons.restaurant,
+          accentColor: AppColors.domainDiet,
+        ),
+        const SizedBox(height: AppSpacing.md),
+        ChartCard(
+          title: '영양소 분포',
+          height: 180,
+          child: AppDonutChart(segments: macros),
+        ),
+        const SizedBox(height: AppSpacing.lg),
+        const SectionHeader('오늘의 식단'),
+        for (final entry in day.entries) ...<Widget>[
+          MealCard(entry: entry),
+          const SizedBox(height: AppSpacing.sm),
+        ],
+      ],
     );
   }
 }

--- a/frontend/flutter/lib/features/diet/presentation/widgets/meal_card.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/meal_card.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+import 'package:oncare/design_system/atoms/app_badge.dart';
+import 'package:oncare/design_system/atoms/app_card.dart';
+import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+
+String _mealLabel(MealType m) => switch (m) {
+  MealType.breakfast => '아침',
+  MealType.lunch => '점심',
+  MealType.dinner => '저녁',
+  MealType.snack => '간식',
+};
+
+class MealCard extends StatelessWidget {
+  const MealCard({required this.entry, super.key});
+  final DietEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AppCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              AppBadge(label: _mealLabel(entry.mealType)),
+              const SizedBox(width: AppSpacing.sm),
+              Text(entry.timeLabel, style: theme.textTheme.bodySmall),
+              const Spacer(),
+              Text(
+                '${entry.totalCalories} kcal',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  color: AppColors.domainDiet,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          for (final f in entry.foods)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 2),
+              child: Row(
+                children: <Widget>[
+                  Expanded(
+                    child: Text(f.name, style: theme.textTheme.bodyMedium),
+                  ),
+                  Text('${f.calories} kcal', style: theme.textTheme.bodySmall),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
@@ -1,0 +1,54 @@
+import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
+import 'package:oncare/features/exercise/domain/repositories/exercise_repository.dart';
+
+class MockExerciseRepository implements ExerciseRepository {
+  const MockExerciseRepository();
+
+  @override
+  Future<ExerciseWeek> fetchThisWeek() async {
+    await Future<void>.delayed(const Duration(milliseconds: 150));
+    return const ExerciseWeek(
+      dailyMinutes: <double>[30, 0, 45, 20, 60, 35, 50],
+      dayLabels: <String>['월', '화', '수', '목', '금', '토', '일'],
+      totalMinutes: 240,
+      sessions: <ExerciseSession>[
+        ExerciseSession(
+          dayLabel: '월',
+          type: ExerciseType.cardio,
+          minutes: 30,
+          calories: 250,
+        ),
+        ExerciseSession(
+          dayLabel: '수',
+          type: ExerciseType.strength,
+          minutes: 45,
+          calories: 320,
+        ),
+        ExerciseSession(
+          dayLabel: '목',
+          type: ExerciseType.yoga,
+          minutes: 20,
+          calories: 100,
+        ),
+        ExerciseSession(
+          dayLabel: '금',
+          type: ExerciseType.cardio,
+          minutes: 60,
+          calories: 480,
+        ),
+        ExerciseSession(
+          dayLabel: '토',
+          type: ExerciseType.walking,
+          minutes: 35,
+          calories: 180,
+        ),
+        ExerciseSession(
+          dayLabel: '일',
+          type: ExerciseType.strength,
+          minutes: 50,
+          calories: 360,
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/flutter/lib/features/exercise/domain/entities/exercise_week.dart
+++ b/frontend/flutter/lib/features/exercise/domain/entities/exercise_week.dart
@@ -1,0 +1,33 @@
+enum ExerciseType { cardio, strength, yoga, walking }
+
+class ExerciseSession {
+  const ExerciseSession({
+    required this.dayLabel,
+    required this.type,
+    required this.minutes,
+    required this.calories,
+  });
+
+  final String dayLabel;
+  final ExerciseType type;
+  final int minutes;
+  final int calories;
+}
+
+class ExerciseWeek {
+  const ExerciseWeek({
+    required this.sessions,
+    required this.dailyMinutes,
+    required this.dayLabels,
+    required this.totalMinutes,
+  });
+
+  final List<ExerciseSession> sessions;
+  final List<double> dailyMinutes;
+  final List<String> dayLabels;
+  final int totalMinutes;
+
+  double get averageMinutes => dailyMinutes.isEmpty
+      ? 0
+      : dailyMinutes.fold<double>(0, (a, b) => a + b) / dailyMinutes.length;
+}

--- a/frontend/flutter/lib/features/exercise/domain/repositories/exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/domain/repositories/exercise_repository.dart
@@ -1,0 +1,5 @@
+import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
+
+abstract class ExerciseRepository {
+  Future<ExerciseWeek> fetchThisWeek();
+}

--- a/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare/features/exercise/data/repositories/mock_exercise_repository.dart';
+import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
+import 'package:oncare/features/exercise/domain/repositories/exercise_repository.dart';
+
+final exerciseRepositoryProvider = Provider<ExerciseRepository>(
+  (ref) => const MockExerciseRepository(),
+  name: 'exerciseRepository',
+);
+
+final exerciseWeekProvider = FutureProvider<ExerciseWeek>((ref) {
+  return ref.watch(exerciseRepositoryProvider).fetchThisWeek();
+}, name: 'exerciseWeek');

--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -1,16 +1,110 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:oncare/core/errors/app_error.dart';
+import 'package:oncare/design_system/atoms/app_badge.dart';
+import 'package:oncare/design_system/atoms/app_card.dart';
+import 'package:oncare/design_system/charts/app_bar_chart.dart';
+import 'package:oncare/design_system/molecules/chart_card.dart';
+import 'package:oncare/design_system/molecules/metric_card.dart';
+import 'package:oncare/design_system/molecules/section_header.dart';
+import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/error_view.dart';
 
-class ExercisePage extends StatelessWidget {
+String _typeLabel(ExerciseType t) => switch (t) {
+  ExerciseType.cardio => '유산소',
+  ExerciseType.strength => '근력',
+  ExerciseType.yoga => '요가',
+  ExerciseType.walking => '걷기',
+};
+
+class ExercisePage extends ConsumerWidget {
   const ExercisePage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l = AppLocalizations.of(context);
+    final async = ref.watch(exerciseWeekProvider);
     return Scaffold(
       appBar: AppBar(title: Text(l.pageExerciseTitle)),
-      body: Center(child: Text(l.placeholderExercise)),
+      body: async.when(
+        data: (w) => _Body(week: w),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (Object e, _) => ErrorView(
+          error: e is AppError ? e : UnknownError(message: e.toString()),
+          onRetry: () => ref.invalidate(exerciseWeekProvider),
+        ),
+      ),
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  const _Body({required this.week});
+  final ExerciseWeek week;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListView(
+      padding: const EdgeInsets.all(AppSpacing.lg),
+      children: <Widget>[
+        Row(
+          children: <Widget>[
+            Expanded(
+              child: MetricCard(
+                title: '이번 주 총 시간',
+                value: week.totalMinutes.toString(),
+                unit: '분',
+                icon: Icons.timer_outlined,
+                accentColor: AppColors.domainExercise,
+              ),
+            ),
+            const SizedBox(width: AppSpacing.md),
+            Expanded(
+              child: MetricCard(
+                title: '하루 평균',
+                value: week.averageMinutes.toStringAsFixed(0),
+                unit: '분',
+                icon: Icons.show_chart,
+                accentColor: AppColors.domainExercise,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.md),
+        ChartCard(
+          title: '주간 운동 시간',
+          child: AppBarChart(
+            color: AppColors.domainExercise,
+            values: week.dailyMinutes,
+            labels: week.dayLabels,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.lg),
+        const SectionHeader('세션 기록'),
+        for (final s in week.sessions) ...<Widget>[
+          AppCard(
+            child: Row(
+              children: <Widget>[
+                AppBadge(label: _typeLabel(s.type)),
+                const SizedBox(width: AppSpacing.sm),
+                Text(s.dayLabel, style: theme.textTheme.bodySmall),
+                const Spacer(),
+                Text(
+                  '${s.minutes}분 · ${s.calories} kcal',
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+        ],
+      ],
     );
   }
 }

--- a/frontend/flutter/lib/features/my_health/data/repositories/mock_my_health_repository.dart
+++ b/frontend/flutter/lib/features/my_health/data/repositories/mock_my_health_repository.dart
@@ -1,0 +1,65 @@
+import 'package:oncare/features/my_health/domain/entities/health_history.dart';
+import 'package:oncare/features/my_health/domain/repositories/my_health_repository.dart';
+
+class MockMyHealthRepository implements MyHealthRepository {
+  const MockMyHealthRepository();
+
+  @override
+  Future<HealthHistory> fetchHistory() async {
+    await Future<void>.delayed(const Duration(milliseconds: 150));
+    return const HealthHistory(
+      goalWeight: 65.0,
+      readings: <VitalsReading>[
+        VitalsReading(
+          dayLabel: '월',
+          weightKg: 70.4,
+          systolic: 118,
+          diastolic: 76,
+          heartRate: 72,
+        ),
+        VitalsReading(
+          dayLabel: '화',
+          weightKg: 70.1,
+          systolic: 116,
+          diastolic: 75,
+          heartRate: 70,
+        ),
+        VitalsReading(
+          dayLabel: '수',
+          weightKg: 69.8,
+          systolic: 119,
+          diastolic: 78,
+          heartRate: 74,
+        ),
+        VitalsReading(
+          dayLabel: '목',
+          weightKg: 69.4,
+          systolic: 117,
+          diastolic: 75,
+          heartRate: 71,
+        ),
+        VitalsReading(
+          dayLabel: '금',
+          weightKg: 69.0,
+          systolic: 115,
+          diastolic: 74,
+          heartRate: 69,
+        ),
+        VitalsReading(
+          dayLabel: '토',
+          weightKg: 68.6,
+          systolic: 116,
+          diastolic: 73,
+          heartRate: 68,
+        ),
+        VitalsReading(
+          dayLabel: '일',
+          weightKg: 68.2,
+          systolic: 114,
+          diastolic: 72,
+          heartRate: 67,
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/flutter/lib/features/my_health/domain/entities/health_history.dart
+++ b/frontend/flutter/lib/features/my_health/domain/entities/health_history.dart
@@ -1,0 +1,26 @@
+class VitalsReading {
+  const VitalsReading({
+    required this.dayLabel,
+    required this.weightKg,
+    required this.systolic,
+    required this.diastolic,
+    required this.heartRate,
+  });
+
+  final String dayLabel;
+  final double weightKg;
+  final int systolic;
+  final int diastolic;
+  final int heartRate;
+}
+
+class HealthHistory {
+  const HealthHistory({required this.readings, required this.goalWeight});
+
+  /// Oldest → newest.
+  final List<VitalsReading> readings;
+  final double goalWeight;
+
+  VitalsReading get latest => readings.last;
+  double get weightDelta => readings.last.weightKg - readings.first.weightKg;
+}

--- a/frontend/flutter/lib/features/my_health/domain/repositories/my_health_repository.dart
+++ b/frontend/flutter/lib/features/my_health/domain/repositories/my_health_repository.dart
@@ -1,0 +1,5 @@
+import 'package:oncare/features/my_health/domain/entities/health_history.dart';
+
+abstract class MyHealthRepository {
+  Future<HealthHistory> fetchHistory();
+}

--- a/frontend/flutter/lib/features/my_health/presentation/controllers/my_health_controller.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/controllers/my_health_controller.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare/features/my_health/data/repositories/mock_my_health_repository.dart';
+import 'package:oncare/features/my_health/domain/entities/health_history.dart';
+import 'package:oncare/features/my_health/domain/repositories/my_health_repository.dart';
+
+final myHealthRepositoryProvider = Provider<MyHealthRepository>(
+  (ref) => const MockMyHealthRepository(),
+  name: 'myHealthRepository',
+);
+
+final healthHistoryProvider = FutureProvider<HealthHistory>((ref) {
+  return ref.watch(myHealthRepositoryProvider).fetchHistory();
+}, name: 'healthHistory');

--- a/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
@@ -1,16 +1,98 @@
+import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:oncare/core/errors/app_error.dart';
+import 'package:oncare/design_system/charts/app_line_chart.dart';
+import 'package:oncare/design_system/molecules/chart_card.dart';
+import 'package:oncare/design_system/molecules/metric_card.dart';
+import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/my_health/domain/entities/health_history.dart';
+import 'package:oncare/features/my_health/presentation/controllers/my_health_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/error_view.dart';
 
-class MyHealthPage extends StatelessWidget {
+class MyHealthPage extends ConsumerWidget {
   const MyHealthPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l = AppLocalizations.of(context);
+    final async = ref.watch(healthHistoryProvider);
     return Scaffold(
       appBar: AppBar(title: Text(l.pageMyHealthTitle)),
-      body: Center(child: Text(l.placeholderMyHealth)),
+      body: async.when(
+        data: (h) => _Body(history: h),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (Object e, _) => ErrorView(
+          error: e is AppError ? e : UnknownError(message: e.toString()),
+          onRetry: () => ref.invalidate(healthHistoryProvider),
+        ),
+      ),
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  const _Body({required this.history});
+  final HealthHistory history;
+
+  @override
+  Widget build(BuildContext context) {
+    final latest = history.latest;
+    final spots = <FlSpot>[
+      for (int i = 0; i < history.readings.length; i++)
+        FlSpot(i.toDouble(), history.readings[i].weightKg),
+    ];
+    final delta = history.weightDelta;
+    return ListView(
+      padding: const EdgeInsets.all(AppSpacing.lg),
+      children: <Widget>[
+        MetricCard(
+          title: '체중',
+          value: latest.weightKg.toStringAsFixed(1),
+          unit: 'kg',
+          delta:
+              '${delta >= 0 ? '+' : ''}${delta.toStringAsFixed(1)} '
+              '(목표 ${history.goalWeight.toStringAsFixed(0)}kg)',
+          deltaTone: delta <= 0
+              ? MetricDeltaTone.positive
+              : MetricDeltaTone.negative,
+          icon: Icons.monitor_weight_outlined,
+          accentColor: AppColors.domainHealth,
+        ),
+        const SizedBox(height: AppSpacing.md),
+        Row(
+          children: <Widget>[
+            Expanded(
+              child: MetricCard(
+                title: '혈압',
+                value: '${latest.systolic}/${latest.diastolic}',
+                unit: 'mmHg',
+                icon: Icons.favorite_outline,
+                accentColor: AppColors.domainHealth,
+              ),
+            ),
+            const SizedBox(width: AppSpacing.md),
+            Expanded(
+              child: MetricCard(
+                title: '심박수',
+                value: latest.heartRate.toString(),
+                unit: 'bpm',
+                icon: Icons.timeline,
+                accentColor: AppColors.domainHealth,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.md),
+        ChartCard(
+          title: '체중 추이 (7일)',
+          height: 180,
+          child: AppLineChart(color: AppColors.domainHealth, spots: spots),
+        ),
+      ],
     );
   }
 }

--- a/frontend/flutter/lib/features/notification/domain/entities/alert_item.dart
+++ b/frontend/flutter/lib/features/notification/domain/entities/alert_item.dart
@@ -1,0 +1,34 @@
+enum AlertCategory { reminder, healthCheck, achievement, system }
+
+class AlertItem {
+  const AlertItem({
+    required this.id,
+    required this.title,
+    required this.body,
+    required this.timeAgo,
+    required this.category,
+    this.read = false,
+  });
+
+  final String id;
+  final String title;
+  final String body;
+  final String timeAgo;
+  final AlertCategory category;
+  final bool read;
+
+  AlertItem copyWith({bool? read}) => AlertItem(
+    id: id,
+    title: title,
+    body: body,
+    timeAgo: timeAgo,
+    category: category,
+    read: read ?? this.read,
+  );
+}
+
+class NotificationState {
+  const NotificationState({required this.items});
+  final List<AlertItem> items;
+  int get unreadCount => items.where((AlertItem i) => !i.read).length;
+}

--- a/frontend/flutter/lib/features/notification/presentation/controllers/notification_controller.dart
+++ b/frontend/flutter/lib/features/notification/presentation/controllers/notification_controller.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare/features/notification/domain/entities/alert_item.dart';
+
+class NotificationController extends StateNotifier<NotificationState> {
+  NotificationController() : super(_seed());
+
+  static NotificationState _seed() {
+    return const NotificationState(
+      items: <AlertItem>[
+        AlertItem(
+          id: 'a1',
+          title: '식단 입력 알림',
+          body: '오늘 점심 입력이 비어있어요.',
+          timeAgo: '10분 전',
+          category: AlertCategory.reminder,
+        ),
+        AlertItem(
+          id: 'a2',
+          title: '운동 목표 달성',
+          body: '주간 운동 240분 달성!',
+          timeAgo: '1시간 전',
+          category: AlertCategory.achievement,
+        ),
+        AlertItem(
+          id: 'a3',
+          title: '체중 측정 권장',
+          body: '오늘 체중을 기록해 보세요.',
+          timeAgo: '3시간 전',
+          category: AlertCategory.healthCheck,
+          read: true,
+        ),
+        AlertItem(
+          id: 'a4',
+          title: '서비스 점검 안내',
+          body: '내일 02:00~03:00 점검 예정입니다.',
+          timeAgo: '어제',
+          category: AlertCategory.system,
+          read: true,
+        ),
+      ],
+    );
+  }
+
+  void markRead(String id) {
+    state = NotificationState(
+      items: state.items
+          .map((AlertItem i) => i.id == id ? i.copyWith(read: true) : i)
+          .toList(),
+    );
+  }
+
+  void markAllRead() {
+    state = NotificationState(
+      items: state.items.map((AlertItem i) => i.copyWith(read: true)).toList(),
+    );
+  }
+
+  /// Q9: in-app panel + simulated push. Inserts a new unread item
+  /// at the top, as if a real FCM notification had landed.
+  void simulatePush() {
+    final id = 'sim-${DateTime.now().millisecondsSinceEpoch}';
+    final injected = AlertItem(
+      id: id,
+      title: '시뮬레이션 알림',
+      body: '지금 막 가상 푸시가 도착했어요.',
+      timeAgo: '방금',
+      category: AlertCategory.reminder,
+    );
+    state = NotificationState(items: <AlertItem>[injected, ...state.items]);
+  }
+}
+
+final notificationControllerProvider =
+    StateNotifierProvider<NotificationController, NotificationState>(
+      (ref) => NotificationController(),
+      name: 'notifications',
+    );

--- a/frontend/flutter/lib/features/notification/presentation/pages/notification_page.dart
+++ b/frontend/flutter/lib/features/notification/presentation/pages/notification_page.dart
@@ -46,8 +46,7 @@ class NotificationPage extends ConsumerWidget {
           : ListView.separated(
               padding: const EdgeInsets.all(AppSpacing.lg),
               itemCount: state.items.length,
-              separatorBuilder: (_, _) =>
-                  const SizedBox(height: AppSpacing.sm),
+              separatorBuilder: (_, _) => const SizedBox(height: AppSpacing.sm),
               itemBuilder: (BuildContext ctx, int i) {
                 final item = state.items[i];
                 return _AlertTile(

--- a/frontend/flutter/lib/features/notification/presentation/pages/notification_page.dart
+++ b/frontend/flutter/lib/features/notification/presentation/pages/notification_page.dart
@@ -1,16 +1,115 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/design_system/atoms/app_badge.dart';
+import 'package:oncare/design_system/atoms/app_card.dart';
+import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/notification/domain/entities/alert_item.dart';
+import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/empty_state.dart';
 
-class NotificationPage extends StatelessWidget {
+({String label, AppBadgeTone tone}) _categoryDisplay(AlertCategory c) =>
+    switch (c) {
+      AlertCategory.reminder => (label: '리마인더', tone: AppBadgeTone.info),
+      AlertCategory.healthCheck => (label: '건강', tone: AppBadgeTone.warning),
+      AlertCategory.achievement => (label: '달성', tone: AppBadgeTone.success),
+      AlertCategory.system => (label: '시스템', tone: AppBadgeTone.neutral),
+    };
+
+class NotificationPage extends ConsumerWidget {
   const NotificationPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l = AppLocalizations.of(context);
+    final config = ref.watch(appConfigProvider);
+    final state = ref.watch(notificationControllerProvider);
+    final notifier = ref.read(notificationControllerProvider.notifier);
+
     return Scaffold(
-      appBar: AppBar(title: Text(l.pageNotificationTitle)),
-      body: Center(child: Text(l.placeholderNotification)),
+      appBar: AppBar(
+        title: Text(l.pageNotificationTitle),
+        actions: <Widget>[
+          TextButton(
+            onPressed: state.unreadCount == 0 ? null : notifier.markAllRead,
+            child: const Text('모두 읽음'),
+          ),
+        ],
+      ),
+      body: state.items.isEmpty
+          ? const EmptyState(
+              icon: Icons.notifications_off_outlined,
+              title: '알림이 없습니다',
+            )
+          : ListView.separated(
+              padding: const EdgeInsets.all(AppSpacing.lg),
+              itemCount: state.items.length,
+              separatorBuilder: (_, __) =>
+                  const SizedBox(height: AppSpacing.sm),
+              itemBuilder: (BuildContext ctx, int i) {
+                final item = state.items[i];
+                return _AlertTile(
+                  item: item,
+                  onTap: () => notifier.markRead(item.id),
+                );
+              },
+            ),
+      floatingActionButton: !config.isProd
+          ? FloatingActionButton.extended(
+              icon: const Icon(Icons.notification_add_outlined),
+              label: const Text('Simulate push'),
+              onPressed: notifier.simulatePush,
+            )
+          : null,
+    );
+  }
+}
+
+class _AlertTile extends StatelessWidget {
+  const _AlertTile({required this.item, required this.onTap});
+  final AlertItem item;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final display = _categoryDisplay(item.category);
+    return AppCard(
+      onTap: onTap,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Container(
+            width: 10,
+            height: 10,
+            margin: const EdgeInsets.only(top: 6, right: AppSpacing.md),
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: item.read ? Colors.transparent : theme.colorScheme.primary,
+            ),
+          ),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    AppBadge(label: display.label, tone: display.tone),
+                    const Spacer(),
+                    Text(item.timeAgo, style: theme.textTheme.bodySmall),
+                  ],
+                ),
+                const SizedBox(height: AppSpacing.xs),
+                Text(item.title, style: theme.textTheme.titleSmall),
+                const SizedBox(height: 2),
+                Text(item.body, style: theme.textTheme.bodyMedium),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/frontend/flutter/lib/features/notification/presentation/pages/notification_page.dart
+++ b/frontend/flutter/lib/features/notification/presentation/pages/notification_page.dart
@@ -46,7 +46,7 @@ class NotificationPage extends ConsumerWidget {
           : ListView.separated(
               padding: const EdgeInsets.all(AppSpacing.lg),
               itemCount: state.items.length,
-              separatorBuilder: (_, __) =>
+              separatorBuilder: (_, _) =>
                   const SizedBox(height: AppSpacing.sm),
               itemBuilder: (BuildContext ctx, int i) {
                 final item = state.items[i];

--- a/frontend/flutter/lib/features/place/data/repositories/mock_place_repository.dart
+++ b/frontend/flutter/lib/features/place/data/repositories/mock_place_repository.dart
@@ -1,0 +1,50 @@
+import 'package:oncare/features/place/domain/entities/place.dart';
+import 'package:oncare/features/place/domain/repositories/place_repository.dart';
+
+class MockPlaceRepository implements PlaceRepository {
+  const MockPlaceRepository();
+
+  @override
+  Future<List<Place>> nearbyPlaces() async {
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+    // Coordinates centred on 강남역 area for the demo.
+    return const <Place>[
+      Place(
+        id: 'p1',
+        name: '강남세브란스 가정의학과',
+        category: PlaceCategory.medical,
+        address: '서울특별시 강남구 테헤란로 123',
+        distanceMeters: 420,
+        lat: 37.4979,
+        lng: 127.0276,
+      ),
+      Place(
+        id: 'p2',
+        name: '온케어 피트니스',
+        category: PlaceCategory.fitness,
+        address: '서울특별시 강남구 역삼로 55',
+        distanceMeters: 680,
+        lat: 37.5005,
+        lng: 127.0319,
+      ),
+      Place(
+        id: 'p3',
+        name: '그린 샐러드 바',
+        category: PlaceCategory.healthyFood,
+        address: '서울특별시 강남구 강남대로 311',
+        distanceMeters: 250,
+        lat: 37.4970,
+        lng: 127.0270,
+      ),
+      Place(
+        id: 'p4',
+        name: '24시간 메디팜약국',
+        category: PlaceCategory.pharmacy,
+        address: '서울특별시 강남구 테헤란로 99',
+        distanceMeters: 800,
+        lat: 37.4995,
+        lng: 127.0263,
+      ),
+    ];
+  }
+}

--- a/frontend/flutter/lib/features/place/domain/entities/place.dart
+++ b/frontend/flutter/lib/features/place/domain/entities/place.dart
@@ -1,0 +1,21 @@
+enum PlaceCategory { medical, fitness, healthyFood, pharmacy }
+
+class Place {
+  const Place({
+    required this.id,
+    required this.name,
+    required this.category,
+    required this.address,
+    required this.distanceMeters,
+    required this.lat,
+    required this.lng,
+  });
+
+  final String id;
+  final String name;
+  final PlaceCategory category;
+  final String address;
+  final int distanceMeters;
+  final double lat;
+  final double lng;
+}

--- a/frontend/flutter/lib/features/place/domain/repositories/place_repository.dart
+++ b/frontend/flutter/lib/features/place/domain/repositories/place_repository.dart
@@ -1,0 +1,5 @@
+import 'package:oncare/features/place/domain/entities/place.dart';
+
+abstract class PlaceRepository {
+  Future<List<Place>> nearbyPlaces();
+}

--- a/frontend/flutter/lib/features/place/presentation/controllers/place_controller.dart
+++ b/frontend/flutter/lib/features/place/presentation/controllers/place_controller.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare/features/place/data/repositories/mock_place_repository.dart';
+import 'package:oncare/features/place/domain/entities/place.dart';
+import 'package:oncare/features/place/domain/repositories/place_repository.dart';
+
+final placeRepositoryProvider = Provider<PlaceRepository>(
+  (ref) => const MockPlaceRepository(),
+  name: 'placeRepository',
+);
+
+final nearbyPlacesProvider = FutureProvider<List<Place>>((ref) {
+  return ref.watch(placeRepositoryProvider).nearbyPlaces();
+}, name: 'nearbyPlaces');

--- a/frontend/flutter/lib/features/place/presentation/pages/place_page.dart
+++ b/frontend/flutter/lib/features/place/presentation/pages/place_page.dart
@@ -1,16 +1,150 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:oncare/core/errors/app_error.dart';
+import 'package:oncare/design_system/atoms/app_badge.dart';
+import 'package:oncare/design_system/atoms/app_card.dart';
+import 'package:oncare/design_system/molecules/section_header.dart';
+import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/design_system/tokens/radius.dart';
+import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/place/domain/entities/place.dart';
+import 'package:oncare/features/place/presentation/controllers/place_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/error_view.dart';
 
-class PlacePage extends StatelessWidget {
+({String label, AppBadgeTone tone}) _categoryDisplay(PlaceCategory c) =>
+    switch (c) {
+      PlaceCategory.medical => (label: '의료', tone: AppBadgeTone.info),
+      PlaceCategory.fitness => (label: '운동', tone: AppBadgeTone.success),
+      PlaceCategory.healthyFood => (label: '식단', tone: AppBadgeTone.warning),
+      PlaceCategory.pharmacy => (label: '약국', tone: AppBadgeTone.neutral),
+    };
+
+class PlacePage extends ConsumerWidget {
   const PlacePage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l = AppLocalizations.of(context);
+    final async = ref.watch(nearbyPlacesProvider);
     return Scaffold(
       appBar: AppBar(title: Text(l.pagePlaceTitle)),
-      body: Center(child: Text(l.placeholderPlace)),
+      body: async.when(
+        data: (places) => _Body(places: places),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (Object e, _) => ErrorView(
+          error: e is AppError ? e : UnknownError(message: e.toString()),
+          onRetry: () => ref.invalidate(nearbyPlacesProvider),
+        ),
+      ),
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  const _Body({required this.places});
+  final List<Place> places;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(AppSpacing.lg),
+      children: <Widget>[
+        const _MapPlaceholder(),
+        const SizedBox(height: AppSpacing.lg),
+        const SectionHeader('가까운 추천 장소'),
+        for (final p in places) ...<Widget>[
+          _PlaceTile(place: p),
+          const SizedBox(height: AppSpacing.sm),
+        ],
+      ],
+    );
+  }
+}
+
+class _MapPlaceholder extends StatelessWidget {
+  const _MapPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      height: 160,
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerHigh,
+        borderRadius: const BorderRadius.all(AppRadius.lg),
+        border: Border.all(color: scheme.outlineVariant),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          Icon(Icons.map_outlined, size: 36, color: scheme.onSurfaceVariant),
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            'Google Maps Flutter (API key needed)',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 2),
+          Text(
+            '실제 지도 위젯은 Stage 7 릴리즈 전에 활성화',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PlaceTile extends StatelessWidget {
+  const _PlaceTile({required this.place});
+  final Place place;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final display = _categoryDisplay(place.category);
+    return AppCard(
+      onTap: () {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('${place.name} → ${place.lat}, ${place.lng}')),
+        );
+      },
+      child: Row(
+        children: <Widget>[
+          Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              color: AppColors.domainAiCoach.withValues(alpha: 0.15),
+              borderRadius: const BorderRadius.all(AppRadius.md),
+            ),
+            child: const Icon(Icons.place_outlined),
+          ),
+          const SizedBox(width: AppSpacing.md),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    AppBadge(label: display.label, tone: display.tone),
+                    const Spacer(),
+                    Text(
+                      '${place.distanceMeters}m',
+                      style: theme.textTheme.bodySmall,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: AppSpacing.xs),
+                Text(place.name, style: theme.textTheme.titleSmall),
+                const SizedBox(height: 2),
+                Text(place.address, style: theme.textTheme.bodySmall),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/frontend/flutter/test/features/ai_coach/ai_coach_controller_test.dart
+++ b/frontend/flutter/test/features/ai_coach/ai_coach_controller_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/ai_coach/domain/entities/ai_coach_state.dart';
+import 'package:oncare/features/ai_coach/presentation/controllers/ai_coach_controller.dart';
+
+void main() {
+  test('aiCoachStateProvider returns greeting + suggestions', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final state = await container.read(aiCoachStateProvider.future);
+    expect(state.greeting, isNotEmpty);
+    expect(state.suggestions, isNotEmpty);
+    expect(
+      state.suggestions.map((AiSuggestion s) => s.tag).toSet().length,
+      greaterThan(1),
+    );
+  });
+}

--- a/frontend/flutter/test/features/auth/auth_controller_test.dart
+++ b/frontend/flutter/test/features/auth/auth_controller_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/auth/domain/entities/auth_state.dart';
+import 'package:oncare/features/auth/presentation/controllers/auth_controller.dart';
+
+void main() {
+  test('starts signed out', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final v = container.read(authControllerProvider);
+    expect(v.value?.isSignedIn, isFalse);
+  });
+
+  test('signIn(provider) ends up signed in with that provider', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    await container
+        .read(authControllerProvider.notifier)
+        .signIn(AuthProvider.kakao);
+    final v = container.read(authControllerProvider);
+    expect(v.value?.isSignedIn, isTrue);
+    expect(v.value?.user?.provider, AuthProvider.kakao);
+  });
+
+  test('signOut returns to signed-out state', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final ctl = container.read(authControllerProvider.notifier);
+    await ctl.signIn(AuthProvider.google);
+    await ctl.signOut();
+    expect(container.read(authControllerProvider).value?.isSignedIn, isFalse);
+  });
+}

--- a/frontend/flutter/test/features/dashboard/dashboard_controller_test.dart
+++ b/frontend/flutter/test/features/dashboard/dashboard_controller_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/dashboard/data/repositories/mock_dashboard_repository.dart';
+import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
+import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
+
+void main() {
+  test('dashboardSummaryProvider returns the mock summary', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final summary = await container.read(dashboardSummaryProvider.future);
+    expect(summary, isA<DashboardSummary>());
+    expect(summary.caloriesGoal, 2000);
+    expect(summary.weeklyWeight.length, 7);
+  });
+
+  test('MockDashboardRepository delivers a stable snapshot', () async {
+    const repo = MockDashboardRepository();
+    final s = await repo.fetchSummary();
+    expect(s.weeklyWeight.first, greaterThanOrEqualTo(s.weeklyWeight.last));
+  });
+}

--- a/frontend/flutter/test/features/diet/diet_controller_test.dart
+++ b/frontend/flutter/test/features/diet/diet_controller_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
+
+void main() {
+  test('dietTodayProvider returns a day with three meals', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final day = await container.read(dietTodayProvider.future);
+    expect(day, isA<DietDay>());
+    expect(day.entries.length, 3);
+    expect(
+      day.entries.map((DietEntry e) => e.mealType),
+      containsAll(<MealType>[
+        MealType.breakfast,
+        MealType.lunch,
+        MealType.dinner,
+      ]),
+    );
+    expect(
+      day.macros.carbsPct + day.macros.proteinPct + day.macros.fatPct,
+      100,
+    );
+  });
+}

--- a/frontend/flutter/test/features/exercise/exercise_controller_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_controller_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+
+void main() {
+  test('exerciseWeekProvider provides 7 days, sane average', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final week = await container.read(exerciseWeekProvider.future);
+    expect(week.dailyMinutes.length, 7);
+    expect(week.dayLabels.length, 7);
+    expect(week.totalMinutes, 240);
+    expect(week.averageMinutes, closeTo(34.28, 0.01));
+    expect(week.sessions, isNotEmpty);
+  });
+}

--- a/frontend/flutter/test/features/my_health/my_health_controller_test.dart
+++ b/frontend/flutter/test/features/my_health/my_health_controller_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/my_health/presentation/controllers/my_health_controller.dart';
+
+void main() {
+  test('healthHistoryProvider returns 7 readings, downward weight', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final h = await container.read(healthHistoryProvider.future);
+    expect(h.readings.length, 7);
+    expect(h.latest.weightKg, 68.2);
+    expect(h.weightDelta, lessThan(0));
+    expect(h.goalWeight, 65.0);
+  });
+}

--- a/frontend/flutter/test/features/notification/notification_controller_test.dart
+++ b/frontend/flutter/test/features/notification/notification_controller_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
+
+void main() {
+  test('seed state has unread items', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final state = container.read(notificationControllerProvider);
+    expect(state.items, isNotEmpty);
+    expect(state.unreadCount, greaterThan(0));
+  });
+
+  test('markRead toggles a single item', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(notificationControllerProvider.notifier);
+    final firstId = container
+        .read(notificationControllerProvider)
+        .items
+        .first
+        .id;
+
+    notifier.markRead(firstId);
+
+    final updated = container
+        .read(notificationControllerProvider)
+        .items
+        .firstWhere((i) => i.id == firstId);
+    expect(updated.read, isTrue);
+  });
+
+  test('markAllRead drops unread count to zero', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(notificationControllerProvider.notifier).markAllRead();
+    expect(container.read(notificationControllerProvider).unreadCount, 0);
+  });
+
+  test('simulatePush prepends an unread item', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final before = container.read(notificationControllerProvider);
+    container.read(notificationControllerProvider.notifier).simulatePush();
+    final after = container.read(notificationControllerProvider);
+    expect(after.items.length, before.items.length + 1);
+    expect(after.items.first.read, isFalse);
+    expect(after.items.first.id.startsWith('sim-'), isTrue);
+  });
+}

--- a/frontend/flutter/test/features/place/place_controller_test.dart
+++ b/frontend/flutter/test/features/place/place_controller_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/place/domain/entities/place.dart';
+import 'package:oncare/features/place/presentation/controllers/place_controller.dart';
+
+void main() {
+  test(
+    'nearbyPlacesProvider returns mock places with all categories',
+    () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final places = await container.read(nearbyPlacesProvider.future);
+      expect(places, isNotEmpty);
+      final cats = places.map((Place p) => p.category).toSet();
+      expect(cats, contains(PlaceCategory.medical));
+      expect(cats, contains(PlaceCategory.fitness));
+      expect(cats, contains(PlaceCategory.healthyFood));
+      expect(cats, contains(PlaceCategory.pharmacy));
+    },
+  );
+}

--- a/frontend/flutter/test/widget_test.dart
+++ b/frontend/flutter/test/widget_test.dart
@@ -55,10 +55,14 @@ void main() {
 
   testWidgets('Korean locale localises the bottom-nav labels', (tester) async {
     await pumpApp(tester, locale: const Locale('ko'));
+    // Dashboard async data is fetched after first frame — wait it out.
+    await tester.pumpAndSettle();
     expect(find.widgetWithText(AppBar, '대시보드'), findsOneWidget);
-    expect(find.text('식단'), findsOneWidget);
-    expect(find.text('운동'), findsOneWidget);
-    expect(find.text('내 건강'), findsOneWidget);
+    // Dashboard content may include the same Korean tokens as the
+    // bottom-nav labels (e.g. 운동 / 식단 metric cards), so allow ≥1.
+    expect(find.text('식단'), findsAtLeastNWidgets(1));
+    expect(find.text('운동'), findsAtLeastNWidgets(1));
+    expect(find.text('내 건강'), findsAtLeastNWidgets(1));
   });
 
   test('ARB resources expose nav strings for ko + en', () {


### PR DESCRIPTION
## Summary

Flutter **8개 피처 슬라이스 MVP** — 디자인 시스템 위에 mock 데이터로 동작하는 첫 번째 동작 가능한 화면들을 모두 붙였습니다. `oncare-flutter` stage 4 phase 4.1–4.8 + style fixup + end-of-stage, 총 10개 커밋을 동일 메시지·동일 트리로 재현.

- **4.1 dashboard** — mock repository 기반 summary
- **4.2 diet** — 3 끼 mock 하루치 식단 기록
- **4.3 exercise** — 주간 운동 MVP
- **4.4 my_health** — vitals + mock 7일 히스토리
- **4.5 ai_coach** — mock 제안 카드
- **4.6 notification (Q9)** — in-app 패널 + simulated push
- **4.7 place (Q8)** — 주변 장소 MVP w/ Maps placeholder
- **4.8 auth (Q4)** — mock 소셜 로그인 (Apple / Google / Kakao / Naver)
- end of stage 4 — feature MVP 완성, 다음 stage 5 (통합·폴리시) 로 진행

10 commits, 50 files, +1823 / -62.

## Test plan

- [x] `cd frontend/flutter && flutter pub get`
- [x] `dart run build_runner build --delete-conflicting-outputs` (필요 시)
- [x] `flutter analyze` clean
- [x] `flutter test` 통과
- [x] `dart format --set-exit-if-changed .` 차이 없음
- [x] (선택) `flutter run -d chrome --dart-define=ENV=dev` → BottomNav 8개 화면 시각 확인

## Notes
- stage 3 (#4) 머지 이후 main 위에서 작업.

---

Closes #44