### PR TITLE
feat(flutter): integration & polish — nav/anim/a11y/responsive/i18n (stage 5)

### DIFF
--- a/frontend/flutter/README.md
+++ b/frontend/flutter/README.md
@@ -3,7 +3,7 @@
 [Oncare Prototype (React/TS)](https://github.com/subin21cc/Oncareprototype) 를 Flutter로 재구성하는 프로젝트입니다.
 **Android / iOS / Web** 3개 타깃을 단일 코드베이스로 빌드하며, 웹은 GitHub Pages에 CI 배포됩니다.
 
-> 현재 상태: **Stage 4 — Features MVP 완료** → Stage 5 (Integration & Polish) 진입 예정
+> 현재 상태: **Stage 5 — Integration & Polish 완료** → Stage 6 (Quality) 진입 예정
 
 ## 문서
 
@@ -63,6 +63,6 @@ flutter build ios --release      # Xcode에서 archive
 - [x] **Stage 2 — Core Infrastructure** (router, theme, dio, drift, errors, l10n)
 - [x] **Stage 3 — Design System** (tokens / atoms / molecules / charts / responsive / UI 카탈로그)
 - [x] **Stage 4 — Features MVP** (Dashboard / Diet / Exercise / MyHealth / AICoach / Notification / Place / Auth — 모두 mock 데이터)
-- [ ] Stage 5 — Integration & Polish
+- [x] **Stage 5 — Integration & Polish** (nav logger, dashboard animation, MetricCard a11y, dashboard responsive layout, dashboard i18n)
 - [ ] Stage 6 — Quality
 - [ ] Stage 7 — Release

--- a/frontend/flutter/lib/app/router/app_router.dart
+++ b/frontend/flutter/lib/app/router/app_router.dart
@@ -1,9 +1,12 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare/app/router/main_shell.dart';
+import 'package:oncare/app/router/nav_logger_observer.dart';
 import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/core/logging/app_logger.dart';
 import 'package:oncare/design_system/catalog/ui_catalog_page.dart';
 import 'package:oncare/features/ai_coach/presentation/pages/ai_coach_page.dart';
 import 'package:oncare/features/auth/presentation/pages/sign_in_page.dart';
@@ -17,10 +20,16 @@ import 'package:oncare/features/place/presentation/pages/place_page.dart';
 /// Single source of truth for the app's routing tree. The `config`
 /// is read once at build time — dev-only routes (UI catalog) are
 /// excluded from prod builds.
-GoRouter buildAppRouter({required AppConfig config}) {
+GoRouter buildAppRouter({
+  required AppConfig config,
+  NavigatorObserver? observer,
+}) {
   return GoRouter(
     initialLocation: AppRoutes.dashboard,
     debugLogDiagnostics: !config.isProd,
+    observers: observer == null
+        ? const <NavigatorObserver>[]
+        : <NavigatorObserver>[observer],
     routes: <RouteBase>[
       StatefulShellRoute.indexedStack(
         builder: (context, state, navigationShell) =>
@@ -88,5 +97,8 @@ GoRouter buildAppRouter({required AppConfig config}) {
 /// Riverpod-managed router. Rebuilds if AppConfig is ever swapped.
 final appRouterProvider = Provider<GoRouter>((ref) {
   final config = ref.watch(appConfigProvider);
-  return buildAppRouter(config: config);
+  final observer = config.isProd
+      ? null
+      : NavLoggerObserver(ref.watch(appLoggerProvider));
+  return buildAppRouter(config: config, observer: observer);
 });

--- a/frontend/flutter/lib/app/router/nav_logger_observer.dart
+++ b/frontend/flutter/lib/app/router/nav_logger_observer.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/widgets.dart';
+import 'package:logger/logger.dart';
+
+/// Logs every push/pop/replace done by go_router. Attached in
+/// non-prod builds only.
+class NavLoggerObserver extends NavigatorObserver {
+  NavLoggerObserver(this._logger);
+  final Logger _logger;
+
+  String _name(Route<dynamic>? route) =>
+      route?.settings.name ?? route?.runtimeType.toString() ?? 'unknown';
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    _logger.d('[nav>] push ${_name(route)} (from ${_name(previousRoute)})');
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    _logger.d('[nav<] pop ${_name(route)} (to ${_name(previousRoute)})');
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    _logger.d('[nav~] replace ${_name(oldRoute)} → ${_name(newRoute)}');
+  }
+}

--- a/frontend/flutter/lib/design_system/molecules/metric_card.dart
+++ b/frontend/flutter/lib/design_system/molecules/metric_card.dart
@@ -41,50 +41,62 @@ class MetricCard extends StatelessWidget {
       MetricDeltaTone.neutral => theme.colorScheme.onSurfaceVariant,
     };
 
-    return AppCard(
-      onTap: onTap,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Row(
-            children: <Widget>[
-              if (icon != null) ...<Widget>[
-                Container(
-                  padding: const EdgeInsets.all(8),
-                  decoration: BoxDecoration(
-                    color: accent.withValues(alpha: 0.15),
-                    borderRadius: const BorderRadius.all(AppRadius.sm),
+    final semanticLabel = <String?>[
+      title,
+      value,
+      unit,
+      delta,
+    ].whereType<String>().where((String s) => s.isNotEmpty).join(' ');
+
+    return Semantics(
+      container: true,
+      label: semanticLabel,
+      button: onTap != null,
+      child: AppCard(
+        onTap: onTap,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                if (icon != null) ...<Widget>[
+                  Container(
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: accent.withValues(alpha: 0.15),
+                      borderRadius: const BorderRadius.all(AppRadius.sm),
+                    ),
+                    child: Icon(icon, color: accent, size: 18),
                   ),
-                  child: Icon(icon, color: accent, size: 18),
-                ),
-                const SizedBox(width: AppSpacing.sm),
+                  const SizedBox(width: AppSpacing.sm),
+                ],
+                Expanded(child: Text(title, style: theme.textTheme.bodyMedium)),
               ],
-              Expanded(child: Text(title, style: theme.textTheme.bodyMedium)),
-            ],
-          ),
-          const SizedBox(height: AppSpacing.md),
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.baseline,
-            textBaseline: TextBaseline.alphabetic,
-            children: <Widget>[
-              Text(value, style: theme.textTheme.displaySmall),
-              if (unit != null) ...<Widget>[
-                const SizedBox(width: 4),
-                Text(unit!, style: theme.textTheme.bodyMedium),
-              ],
-            ],
-          ),
-          if (delta != null) ...<Widget>[
-            const SizedBox(height: AppSpacing.xs),
-            Text(
-              delta!,
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: deltaColor,
-                fontWeight: FontWeight.w600,
-              ),
             ),
+            const SizedBox(height: AppSpacing.md),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.baseline,
+              textBaseline: TextBaseline.alphabetic,
+              children: <Widget>[
+                Text(value, style: theme.textTheme.displaySmall),
+                if (unit != null) ...<Widget>[
+                  const SizedBox(width: 4),
+                  Text(unit!, style: theme.textTheme.bodyMedium),
+                ],
+              ],
+            ),
+            if (delta != null) ...<Widget>[
+              const SizedBox(height: AppSpacing.xs),
+              Text(
+                delta!,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: deltaColor,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
           ],
-        ],
+        ),
       ),
     );
   }

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -1,5 +1,6 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 
 import 'package:oncare/design_system/charts/app_line_chart.dart';
 import 'package:oncare/design_system/molecules/chart_card.dart';
@@ -26,58 +27,67 @@ class DashboardContent extends StatelessWidget {
     final lastWeight = summary.weeklyWeight.last;
     final weightDelta = lastWeight - firstWeight;
 
+    final tiles = <Widget>[
+      Row(
+        children: <Widget>[
+          Expanded(
+            child: MetricCard(
+              title: '칼로리',
+              value: summary.caloriesToday.toString(),
+              unit: 'kcal',
+              delta: '$caloriesPct% of ${summary.caloriesGoal}',
+              icon: Icons.restaurant,
+              accentColor: AppColors.domainDiet,
+            ),
+          ),
+          const SizedBox(width: AppSpacing.md),
+          Expanded(
+            child: MetricCard(
+              title: '운동',
+              value: summary.exerciseMinutesToday.toString(),
+              unit: '분',
+              icon: Icons.fitness_center,
+              accentColor: AppColors.domainExercise,
+            ),
+          ),
+        ],
+      ),
+      MetricCard(
+        title: '체중',
+        value: summary.weightKg.toStringAsFixed(1),
+        unit: 'kg',
+        delta:
+            '${weightDelta >= 0 ? '+' : ''}${weightDelta.toStringAsFixed(1)} '
+            'vs 지난주',
+        deltaTone: weightDelta <= 0
+            ? MetricDeltaTone.positive
+            : MetricDeltaTone.negative,
+        icon: Icons.favorite_outline,
+        accentColor: AppColors.domainHealth,
+      ),
+      ChartCard(
+        title: '주간 체중',
+        height: 160,
+        child: AppLineChart(color: AppColors.domainHealth, spots: weightSpots),
+      ),
+    ];
+
     return ListView(
       padding: const EdgeInsets.all(AppSpacing.lg),
       children: <Widget>[
         const SectionHeader('오늘의 요약'),
-        Row(
-          children: <Widget>[
-            Expanded(
-              child: MetricCard(
-                title: '칼로리',
-                value: summary.caloriesToday.toString(),
-                unit: 'kcal',
-                delta: '$caloriesPct% of ${summary.caloriesGoal}',
-                icon: Icons.restaurant,
-                accentColor: AppColors.domainDiet,
-              ),
-            ),
-            const SizedBox(width: AppSpacing.md),
-            Expanded(
-              child: MetricCard(
-                title: '운동',
-                value: summary.exerciseMinutesToday.toString(),
-                unit: '분',
-                icon: Icons.fitness_center,
-                accentColor: AppColors.domainExercise,
-              ),
-            ),
-          ],
-        ),
+        for (int i = 0; i < tiles.length; i++) ...<Widget>[
+          tiles[i]
+              .animate()
+              .fadeIn(
+                duration: const Duration(milliseconds: 320),
+                delay: Duration(milliseconds: 60 * i),
+              )
+              .slideY(begin: 0.06, end: 0, curve: Curves.easeOutCubic),
+          if (i < tiles.length - 1) const SizedBox(height: AppSpacing.md),
+        ],
         const SizedBox(height: AppSpacing.md),
-        MetricCard(
-          title: '체중',
-          value: summary.weightKg.toStringAsFixed(1),
-          unit: 'kg',
-          delta:
-              '${weightDelta >= 0 ? '+' : ''}${weightDelta.toStringAsFixed(1)} '
-              'vs 지난주',
-          deltaTone: weightDelta <= 0
-              ? MetricDeltaTone.positive
-              : MetricDeltaTone.negative,
-          icon: Icons.favorite_outline,
-          accentColor: AppColors.domainHealth,
-        ),
-        const SizedBox(height: AppSpacing.xl),
         const SectionHeader('체중 추이 (7일)'),
-        ChartCard(
-          title: '주간 체중',
-          height: 160,
-          child: AppLineChart(
-            color: AppColors.domainHealth,
-            spots: weightSpots,
-          ),
-        ),
       ],
     );
   }

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -6,6 +6,7 @@ import 'package:oncare/design_system/charts/app_line_chart.dart';
 import 'package:oncare/design_system/molecules/chart_card.dart';
 import 'package:oncare/design_system/molecules/metric_card.dart';
 import 'package:oncare/design_system/molecules/section_header.dart';
+import 'package:oncare/design_system/responsive/responsive_builder.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
 import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
@@ -27,51 +28,72 @@ class DashboardContent extends StatelessWidget {
     final lastWeight = summary.weeklyWeight.last;
     final weightDelta = lastWeight - firstWeight;
 
-    final tiles = <Widget>[
+    final caloriesCard = MetricCard(
+      title: '칼로리',
+      value: summary.caloriesToday.toString(),
+      unit: 'kcal',
+      delta: '$caloriesPct% of ${summary.caloriesGoal}',
+      icon: Icons.restaurant,
+      accentColor: AppColors.domainDiet,
+    );
+    final exerciseCard = MetricCard(
+      title: '운동',
+      value: summary.exerciseMinutesToday.toString(),
+      unit: '분',
+      icon: Icons.fitness_center,
+      accentColor: AppColors.domainExercise,
+    );
+    final weightCard = MetricCard(
+      title: '체중',
+      value: summary.weightKg.toStringAsFixed(1),
+      unit: 'kg',
+      delta:
+          '${weightDelta >= 0 ? '+' : ''}${weightDelta.toStringAsFixed(1)} '
+          'vs 지난주',
+      deltaTone: weightDelta <= 0
+          ? MetricDeltaTone.positive
+          : MetricDeltaTone.negative,
+      icon: Icons.favorite_outline,
+      accentColor: AppColors.domainHealth,
+    );
+    final chartCard = ChartCard(
+      title: '주간 체중',
+      height: 160,
+      child: AppLineChart(color: AppColors.domainHealth, spots: weightSpots),
+    );
+
+    final mobileTiles = <Widget>[
       Row(
         children: <Widget>[
-          Expanded(
-            child: MetricCard(
-              title: '칼로리',
-              value: summary.caloriesToday.toString(),
-              unit: 'kcal',
-              delta: '$caloriesPct% of ${summary.caloriesGoal}',
-              icon: Icons.restaurant,
-              accentColor: AppColors.domainDiet,
-            ),
-          ),
+          Expanded(child: caloriesCard),
           const SizedBox(width: AppSpacing.md),
-          Expanded(
-            child: MetricCard(
-              title: '운동',
-              value: summary.exerciseMinutesToday.toString(),
-              unit: '분',
-              icon: Icons.fitness_center,
-              accentColor: AppColors.domainExercise,
-            ),
-          ),
+          Expanded(child: exerciseCard),
         ],
       ),
-      MetricCard(
-        title: '체중',
-        value: summary.weightKg.toStringAsFixed(1),
-        unit: 'kg',
-        delta:
-            '${weightDelta >= 0 ? '+' : ''}${weightDelta.toStringAsFixed(1)} '
-            'vs 지난주',
-        deltaTone: weightDelta <= 0
-            ? MetricDeltaTone.positive
-            : MetricDeltaTone.negative,
-        icon: Icons.favorite_outline,
-        accentColor: AppColors.domainHealth,
-      ),
-      ChartCard(
-        title: '주간 체중',
-        height: 160,
-        child: AppLineChart(color: AppColors.domainHealth, spots: weightSpots),
-      ),
+      weightCard,
+      chartCard,
     ];
 
+    return ResponsiveBuilder(
+      mobile: (_) => _MobileLayout(tiles: mobileTiles),
+      tablet: (_) => _WideLayout(
+        leftColumn: <Widget>[caloriesCard, exerciseCard, weightCard],
+        rightColumn: <Widget>[chartCard],
+      ),
+      desktop: (_) => _WideLayout(
+        leftColumn: <Widget>[caloriesCard, exerciseCard, weightCard],
+        rightColumn: <Widget>[chartCard],
+      ),
+    );
+  }
+}
+
+class _MobileLayout extends StatelessWidget {
+  const _MobileLayout({required this.tiles});
+  final List<Widget> tiles;
+
+  @override
+  Widget build(BuildContext context) {
     return ListView(
       padding: const EdgeInsets.all(AppSpacing.lg),
       children: <Widget>[
@@ -86,9 +108,47 @@ class DashboardContent extends StatelessWidget {
               .slideY(begin: 0.06, end: 0, curve: Curves.easeOutCubic),
           if (i < tiles.length - 1) const SizedBox(height: AppSpacing.md),
         ],
-        const SizedBox(height: AppSpacing.md),
-        const SectionHeader('체중 추이 (7일)'),
       ],
+    );
+  }
+}
+
+class _WideLayout extends StatelessWidget {
+  const _WideLayout({required this.leftColumn, required this.rightColumn});
+
+  final List<Widget> leftColumn;
+  final List<Widget> rightColumn;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget column(List<Widget> items) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          for (int i = 0; i < items.length; i++) ...<Widget>[
+            items[i],
+            if (i < items.length - 1) const SizedBox(height: AppSpacing.md),
+          ],
+        ],
+      );
+    }
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(AppSpacing.lg),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          const SectionHeader('오늘의 요약'),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Expanded(child: column(leftColumn)),
+              const SizedBox(width: AppSpacing.lg),
+              Expanded(child: column(rightColumn)),
+            ],
+          ),
+        ],
+      ),
     );
   }
 }

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -10,6 +10,7 @@ import 'package:oncare/design_system/responsive/responsive_builder.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
 import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
 
 class DashboardContent extends StatelessWidget {
   const DashboardContent({required this.summary, super.key});
@@ -28,28 +29,31 @@ class DashboardContent extends StatelessWidget {
     final lastWeight = summary.weeklyWeight.last;
     final weightDelta = lastWeight - firstWeight;
 
+    final l = AppLocalizations.of(context);
+
     final caloriesCard = MetricCard(
-      title: '칼로리',
+      title: l.dashboardMetricCalories,
       value: summary.caloriesToday.toString(),
-      unit: 'kcal',
-      delta: '$caloriesPct% of ${summary.caloriesGoal}',
+      unit: l.unitKcal,
+      delta: l.dashboardCaloriesProgress(caloriesPct, summary.caloriesGoal),
       icon: Icons.restaurant,
       accentColor: AppColors.domainDiet,
     );
     final exerciseCard = MetricCard(
-      title: '운동',
+      title: l.dashboardMetricExercise,
       value: summary.exerciseMinutesToday.toString(),
-      unit: '분',
+      unit: l.unitMinutes,
       icon: Icons.fitness_center,
       accentColor: AppColors.domainExercise,
     );
     final weightCard = MetricCard(
-      title: '체중',
+      title: l.dashboardMetricWeight,
       value: summary.weightKg.toStringAsFixed(1),
-      unit: 'kg',
-      delta:
-          '${weightDelta >= 0 ? '+' : ''}${weightDelta.toStringAsFixed(1)} '
-          'vs 지난주',
+      unit: l.unitKg,
+      delta: l.dashboardWeightDelta(
+        weightDelta >= 0 ? '+' : '',
+        weightDelta.toStringAsFixed(1),
+      ),
       deltaTone: weightDelta <= 0
           ? MetricDeltaTone.positive
           : MetricDeltaTone.negative,
@@ -57,7 +61,7 @@ class DashboardContent extends StatelessWidget {
       accentColor: AppColors.domainHealth,
     );
     final chartCard = ChartCard(
-      title: '주간 체중',
+      title: l.dashboardChartWeightWeek,
       height: 160,
       child: AppLineChart(color: AppColors.domainHealth, spots: weightSpots),
     );
@@ -94,10 +98,11 @@ class _MobileLayout extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
     return ListView(
       padding: const EdgeInsets.all(AppSpacing.lg),
       children: <Widget>[
-        const SectionHeader('오늘의 요약'),
+        SectionHeader(l.dashboardSectionToday),
         for (int i = 0; i < tiles.length; i++) ...<Widget>[
           tiles[i]
               .animate()
@@ -121,6 +126,7 @@ class _WideLayout extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
     Widget column(List<Widget> items) {
       return Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -138,7 +144,7 @@ class _WideLayout extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
-          const SectionHeader('오늘의 요약'),
+          SectionHeader(l.dashboardSectionToday),
           Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -283,6 +283,66 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Something went wrong'**
   String get errorUnknown;
+
+  /// No description provided for @dashboardSectionToday.
+  ///
+  /// In en, this message translates to:
+  /// **'Today'**
+  String get dashboardSectionToday;
+
+  /// No description provided for @dashboardMetricCalories.
+  ///
+  /// In en, this message translates to:
+  /// **'Calories'**
+  String get dashboardMetricCalories;
+
+  /// No description provided for @dashboardMetricExercise.
+  ///
+  /// In en, this message translates to:
+  /// **'Exercise'**
+  String get dashboardMetricExercise;
+
+  /// No description provided for @dashboardMetricWeight.
+  ///
+  /// In en, this message translates to:
+  /// **'Weight'**
+  String get dashboardMetricWeight;
+
+  /// No description provided for @dashboardChartWeightWeek.
+  ///
+  /// In en, this message translates to:
+  /// **'Weekly weight'**
+  String get dashboardChartWeightWeek;
+
+  /// No description provided for @dashboardCaloriesProgress.
+  ///
+  /// In en, this message translates to:
+  /// **'{pct}% of {goal}'**
+  String dashboardCaloriesProgress(int pct, int goal);
+
+  /// No description provided for @dashboardWeightDelta.
+  ///
+  /// In en, this message translates to:
+  /// **'{sign}{delta} vs last week'**
+  String dashboardWeightDelta(String sign, String delta);
+
+  /// No description provided for @unitKcal.
+  ///
+  /// In en, this message translates to:
+  /// **'kcal'**
+  String get unitKcal;
+
+  /// No description provided for @unitMinutes.
+  ///
+  /// In en, this message translates to:
+  /// **'min'**
+  String get unitMinutes;
+
+  /// No description provided for @unitKg.
+  ///
+  /// In en, this message translates to:
+  /// **'kg'**
+  String get unitKg;
 }
 
 class _AppLocalizationsDelegate

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -101,4 +101,38 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get errorUnknown => 'Something went wrong';
+
+  @override
+  String get dashboardSectionToday => 'Today';
+
+  @override
+  String get dashboardMetricCalories => 'Calories';
+
+  @override
+  String get dashboardMetricExercise => 'Exercise';
+
+  @override
+  String get dashboardMetricWeight => 'Weight';
+
+  @override
+  String get dashboardChartWeightWeek => 'Weekly weight';
+
+  @override
+  String dashboardCaloriesProgress(int pct, int goal) {
+    return '$pct% of $goal';
+  }
+
+  @override
+  String dashboardWeightDelta(String sign, String delta) {
+    return '$sign$delta vs last week';
+  }
+
+  @override
+  String get unitKcal => 'kcal';
+
+  @override
+  String get unitMinutes => 'min';
+
+  @override
+  String get unitKg => 'kg';
 }

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -100,4 +100,38 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get errorUnknown => '알 수 없는 오류';
+
+  @override
+  String get dashboardSectionToday => '오늘의 요약';
+
+  @override
+  String get dashboardMetricCalories => '칼로리';
+
+  @override
+  String get dashboardMetricExercise => '운동';
+
+  @override
+  String get dashboardMetricWeight => '체중';
+
+  @override
+  String get dashboardChartWeightWeek => '주간 체중';
+
+  @override
+  String dashboardCaloriesProgress(int pct, int goal) {
+    return '$pct% / $goal';
+  }
+
+  @override
+  String dashboardWeightDelta(String sign, String delta) {
+    return '$sign$delta (지난주 대비)';
+  }
+
+  @override
+  String get unitKcal => 'kcal';
+
+  @override
+  String get unitMinutes => '분';
+
+  @override
+  String get unitKg => 'kg';
 }

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -38,5 +38,29 @@
   "errorNotFound": "Not found",
   "errorServer": "Server error",
   "errorCancelled": "Cancelled",
-  "errorUnknown": "Something went wrong"
+  "errorUnknown": "Something went wrong",
+
+  "dashboardSectionToday": "Today",
+  "dashboardMetricCalories": "Calories",
+  "dashboardMetricExercise": "Exercise",
+  "dashboardMetricWeight": "Weight",
+  "dashboardChartWeightWeek": "Weekly weight",
+  "dashboardCaloriesProgress": "{pct}% of {goal}",
+  "@dashboardCaloriesProgress": {
+    "placeholders": {
+      "pct": {"type": "int"},
+      "goal": {"type": "int"}
+    }
+  },
+  "dashboardWeightDelta": "{sign}{delta} vs last week",
+  "@dashboardWeightDelta": {
+    "placeholders": {
+      "sign": {"type": "String"},
+      "delta": {"type": "String"}
+    }
+  },
+
+  "unitKcal": "kcal",
+  "unitMinutes": "min",
+  "unitKg": "kg"
 }

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -35,5 +35,17 @@
   "errorNotFound": "찾을 수 없습니다",
   "errorServer": "서버 오류",
   "errorCancelled": "취소됨",
-  "errorUnknown": "알 수 없는 오류"
+  "errorUnknown": "알 수 없는 오류",
+
+  "dashboardSectionToday": "오늘의 요약",
+  "dashboardMetricCalories": "칼로리",
+  "dashboardMetricExercise": "운동",
+  "dashboardMetricWeight": "체중",
+  "dashboardChartWeightWeek": "주간 체중",
+  "dashboardCaloriesProgress": "{pct}% / {goal}",
+  "dashboardWeightDelta": "{sign}{delta} (지난주 대비)",
+
+  "unitKcal": "kcal",
+  "unitMinutes": "분",
+  "unitKg": "kg"
 }

--- a/frontend/flutter/test/widget_test.dart
+++ b/frontend/flutter/test/widget_test.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
 
 import 'package:oncare/app/app.dart';
 import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/core/logging/app_logger.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/services/locale_provider.dart';
 
@@ -18,6 +20,7 @@ void main() {
       ProviderScope(
         overrides: <Override>[
           appConfigProvider.overrideWithValue(config),
+          appLoggerProvider.overrideWithValue(Logger(level: Level.off)),
           if (locale != null) localeProvider.overrideWith((ref) => locale),
         ],
         child: const OncareApp(),

--- a/frontend/flutter/test/widget_test.dart
+++ b/frontend/flutter/test/widget_test.dart
@@ -33,9 +33,11 @@ void main() {
     await pumpApp(tester, locale: const Locale('en'));
     expect(find.widgetWithText(AppBar, 'Dashboard'), findsOneWidget);
     expect(find.byType(NavigationBar), findsOneWidget);
-    expect(find.text('Diet'), findsOneWidget);
-    expect(find.text('Exercise'), findsOneWidget);
-    expect(find.text('My Health'), findsOneWidget);
+    // Dashboard content may share tokens with nav labels (e.g.
+    // 'Exercise' metric card + 'Exercise' bottom-nav destination).
+    expect(find.text('Diet'), findsAtLeastNWidgets(1));
+    expect(find.text('Exercise'), findsAtLeastNWidgets(1));
+    expect(find.text('My Health'), findsAtLeastNWidgets(1));
   });
 
   testWidgets('Tapping a bottom-nav destination switches branch', (


### PR DESCRIPTION
## Summary

Flutter **통합·폴리시 패스** — MVP 화면들을 다듬는 작업으로, NavigatorObserver 로깅·애니메이션·접근성·태블릿/데스크톱 반응형·i18n을 보강했습니다. `oncare-flutter` stage 5 phase 5.1–5.5 + test fixup + end-of-stage, 7개 커밋을 동일 메시지·동일 트리로 재현.

- **5.1 nav** — `NavigatorObserver` (Logger 사용) 라우터에 부착
- **5.2 dashboard anim** — summary 카드 staggered fade + slide 인트로
- **5.3 a11y** — `MetricCard` 단일 `Semantics` 레이블 노출 (스크린리더 noise 제거)
- **5.4 responsive** — 태블릿/데스크톱에서 대시보드 2열 레이아웃
- **5.5 i18n** — 대시보드 카피 ARB 외부화 (ko / en)
- test(widget) — 영문 대시보드 테스트가 `findsAtLeastNWidgets` 로 동작 (i18n 도입 후 매칭 완화)
- end of stage 5 — 통합·폴리시 완료, 다음 stage 6 (퀄리티 게이트) 로 진행

7 commits, 11 files, +392 / -96.

## Test plan

- [x] `cd frontend/flutter && flutter pub get` (ARB → gen 트리거)
- [x] `flutter analyze` clean
- [x] `flutter test` 통과 (영/한 i18n 케이스 포함)
- [x] `dart format --set-exit-if-changed .` 차이 없음
- [x] (선택) `flutter run -d chrome` → 대시보드 카드 인트로 애니메이션 + 데스크톱 폭에서 2열 레이아웃 확인

## Notes
- stage 4 (#5) 머지 이후 main 위에서 작업.