### PR TITLE
feat(flutter): local backend via drift + LocalApiInterceptor — v0.3.0+3 + web fixes (stage 9)

### DIFF
--- a/frontend/flutter/.github/workflows/deploy-web.yml
+++ b/frontend/flutter/.github/workflows/deploy-web.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Pub get
         run: flutter pub get
 
+      - name: Download drift WASM (sqlite3.wasm + drift_worker.js)
+        run: bash tool/fetch_drift_wasm.sh
+
       - name: Build web (release, base-href /oncare-flutter/)
         env:
           # Default API_BASE_URL for the public preview build.

--- a/frontend/flutter/.gitignore
+++ b/frontend/flutter/.gitignore
@@ -1,3 +1,9 @@
+# drift web runtime — downloaded by CI (or tool/fetch_drift_wasm.sh
+# locally) before `flutter build web`. Not committed because the
+# version must match pubspec.lock's drift.
+/web/sqlite3.wasm
+/web/drift_worker.js
+
 # Miscellaneous
 *.class
 *.log

--- a/frontend/flutter/CHANGELOG.md
+++ b/frontend/flutter/CHANGELOG.md
@@ -6,6 +6,65 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.3.0+3] — 2026-05-20
+
+Stage 9 — Local backend via drift + LocalApiInterceptor. The
+production `USE_MOCK_API=true` build no longer relies on per-feature
+in-memory fakes; every feature talks to dio, and dio talks to a
+drift-backed dispatcher. Switching to FastAPI is a single
+`--dart-define=USE_MOCK_API=false`.
+
+### Added
+- **drift schema v2**: 6 tables — `AppKeyValues`, `DietEntries`,
+  `ExerciseSessions`, `Vitals`, `ScheduleEvents`, `NotificationItems`,
+  with `onUpgrade` migration from v1.
+- **Seed bootstrap**: `core/storage/seed_data.dart` writes the React
+  prototype's mock data into the new tables on first run, gated by a
+  `seeded_v1` key. Adds a 95 mg/dL blood-sugar reading so MyHealth
+  matches the React mock out of the box.
+- **LocalApiInterceptor**: `core/network/interceptors/local_api_interceptor.dart`
+  — `_routes` map dispatches `METHOD path` strings to drift-backed
+  handlers. Falls through (`null`) on unknown paths so production
+  FastAPI calls still reach the wire.
+- **Endpoints**:
+  - `GET /diet/days/today` — aggregates today's `DietEntries`.
+  - `POST /vitals/{kind}` + `GET /vitals/{kind}/latest` — three fixed
+    kinds (weight | blood-pressure | blood-sugar).
+  - `GET /exercise/weeks/current` — daily-minutes aggregation Mon..Sun
+    with streak.
+  - `GET /schedule/events?date=` — calendar event listing.
+  - `GET /notifications` — newest-first with Korean `time_ago`.
+  - `GET /dashboard/summary` — full cross-table aggregation (diet +
+    exercise + vital + schedule + heuristic week-score).
+  - `GET /ai-coach/feedback`, `GET /users/me`, `GET /users/me/health`,
+    `GET /places/nearby` — static demo payloads.
+  - `GET /healthz` reports `{"status":"ok","backend":"drift-local"}`.
+- **New repositories**: `DioDietRepository`, `DioVitalsRepository`,
+  `DioExerciseRepository`, `DioScheduleRepository`,
+  `DioNotificationRepository`, `DioDashboardRepository`,
+  `DioAiCoachRepository`, `DioMyHealthRepository`, `DioPlaceRepository`.
+  Each feature controller now defaults to the Dio implementation.
+- **New schedule feature**: `lib/features/schedule/` — entity, repo
+  interface, mock + Dio repos, controller (FutureProvider.family).
+- **Tests**: 7 new LocalApiInterceptor integration files
+  (`local_api_interceptor_{diet,vitals,exercise,schedule,notifications,dashboard,aux}_test.dart`)
+  + `local_api_smoke_test.dart` covering the dio → interceptor →
+  fromJson stack. Existing controller tests now override repos with
+  in-memory mocks. **85 tests pass**, analyze clean.
+
+### Changed
+- **QuickInputDialog**: now persists weight / BP / blood-sugar through
+  `VitalsRepository` and invalidates `latestVitalProvider` on success.
+- **DashboardSummary / DietDay / ExerciseWeek / Place / MyHealthState /
+  AiCoachState / ScheduleEvent**: all gained `fromJson` factories on
+  the snake_case wire shape.
+
+### Documentation
+- `docs/PLAN.md` §9.5–9.7 — Stage 9 decision log (D1..D6), endpoint
+  matrix, FastAPI swap procedure.
+- `docs/API_CATALOG.md` and `docs/DUMMY_BACKEND.md` (Phase 8) still
+  describe the long-form spec.
+
 ## [0.2.0+2] — 2026-05-20
 
 UX Alignment with the React original (Stage 8). The app now matches

--- a/frontend/flutter/README.md
+++ b/frontend/flutter/README.md
@@ -12,6 +12,8 @@
 - [docs/DESIGN_TOKENS.md](./docs/DESIGN_TOKENS.md) — 디자인 토큰 초안 (Figma 접근 후 보강)
 - [docs/CONTRIBUTING_NOTES.md](./docs/CONTRIBUTING_NOTES.md) — 커밋 컨벤션, AI co-author trailer 미사용 정책, Phase/Stage 커밋·푸시 케이던스
 - [docs/RELEASE.md](./docs/RELEASE.md) — Web/Android/iOS 수동 릴리즈 절차, SemVer 정책
+- [docs/API_CATALOG.md](./docs/API_CATALOG.md) — FastAPI 백엔드 endpoint 목록 (front 데이터 흐름 기준)
+- [docs/DUMMY_BACKEND.md](./docs/DUMMY_BACKEND.md) — 실 백엔드 전까지 dummy backend 옵션 비교 + 권장(drift backed)
 - [CHANGELOG.md](./CHANGELOG.md) — 버전별 변경 이력
 
 ## 빌드 / 실행

--- a/frontend/flutter/docs/API_CATALOG.md
+++ b/frontend/flutter/docs/API_CATALOG.md
@@ -1,0 +1,284 @@
+# Backend API Catalog — Oncare Flutter ⇆ FastAPI
+
+> 이 문서는 현재 Flutter front-end의 도메인 모델/리포지토리를 기준으로
+> 백엔드(FastAPI)가 노출해야 할 REST endpoint를 정리합니다. 모든 경로는
+> `${API_BASE_URL}/api/v1/...` 기준이며, 인증은 `Authorization: Bearer
+> <access_token>` 헤더를 사용합니다.
+
+| 베이스 | `${API_BASE_URL}/api/v1` |
+| --- | --- |
+| 인증 | `Authorization: Bearer <jwt>` (POST /auth/social 이후 발급) |
+| 응답 | `application/json`, snake_case 권장 (Flutter 측에서 camelCase로 매핑) |
+| 시간 | ISO 8601 (`2026-05-20T08:00:00+09:00`) |
+| 오류 | `{code, message, details?}` + HTTP status (`core/errors/app_error.dart` 매핑) |
+
+---
+
+## 1. Auth (Q4: Apple / Google / Kakao / Naver)
+
+| Method | Path | Body | 응답 | Flutter 사용처 |
+| --- | --- | --- | --- | --- |
+| POST | `/auth/social` | `{provider, id_token, nonce?}` | `{access_token, refresh_token, user: UserProfile}` | `MockAuthRepository.signIn` |
+| POST | `/auth/refresh` | `{refresh_token}` | `{access_token, refresh_token}` | dio interceptor (Stage 4 후속) |
+| POST | `/auth/logout` | — | `204` | `signOut` |
+
+`provider` enum: `apple | google | kakao | naver` (소문자, `AuthProvider.name`).
+
+---
+
+## 2. Users / Me
+
+| Method | Path | 응답 | Flutter 사용처 |
+| --- | --- | --- | --- |
+| GET | `/users/me` | `UserProfile { id, name, email, avatar_url? }` | `AuthUser`, MyHealth `ProfileCard` |
+| PATCH | `/users/me` | `UserProfile` | (설정 페이지, 후속) |
+| GET | `/users/me/health` | `MyHealthState` payload | `MockMyHealthRepository.fetchState` |
+| GET | `/users/me/points` | `{ points, rank, leaderboard?[] }` | MyHealth `PointsCard` |
+
+`MyHealthState` payload (한 endpoint로 조합해 반환):
+
+```json
+{
+  "profile": { "name": "김민수", "email": "minsu@oncare.com" },
+  "risk":    { "title": "...", "body": "...", "level": "medium" },
+  "indicators": [
+    { "kind": "weight", "label": "체중", "latest_value": "68.2",
+      "unit": "kg", "delta_text": "-1.2kg (지난주 대비)",
+      "improving": true, "last_7_days": [0.95, 0.92, ...] }
+  ],
+  "activity_points": 1240,
+  "activity_rank": 14,
+  "settings": [{ "label": "개인 정보", "icon": "👤" }, ...]
+}
+```
+
+---
+
+## 3. Dashboard
+
+| Method | Path | Query | 응답 | Flutter 사용처 |
+| --- | --- | --- | --- | --- |
+| GET | `/dashboard/summary` | `?date=YYYY-MM-DD` (선택) | `DashboardSummary` | `MockDashboardRepository.fetchSummary` |
+
+`DashboardSummary` payload:
+
+```json
+{
+  "indicators": [
+    { "label": "칼로리", "current": 1170, "max": 2000,
+      "unit": "kcal", "over_budget": false }
+  ],
+  "diet_entries": 2,
+  "exercise_minutes": 45,
+  "today_schedule": [
+    { "time": "10:00", "title": "병원 정기검진", "emoji": "🏥" }
+  ],
+  "week_score": 85,
+  "week_score_delta": 12,
+  "sodium_warning": "오늘의 나트륨 섭취량이 높아요..."
+}
+```
+
+서버에서는 사실 여러 source(vitals + diet + exercise + schedule)를
+조합하므로, **server-side aggregation endpoint**로 두는 게 가장 깔끔.
+
+---
+
+## 4. Diet
+
+| Method | Path | Body / Query | 응답 | Flutter 사용처 |
+| --- | --- | --- | --- | --- |
+| GET | `/diet/days/today` | — | `DietDay` | `MockDietRepository.fetchToday` |
+| GET | `/diet/days/{date}` | `date=YYYY-MM-DD` | `DietDay` | (캘린더 진입 시) |
+| POST | `/diet/entries` | `DietEntry` (without id) | 생성된 `DietEntry` | FAB "식단 추가" |
+| PATCH | `/diet/entries/{id}` | partial `DietEntry` | 갱신된 entry | 식사 수정 |
+| DELETE | `/diet/entries/{id}` | — | `204` | 식사 삭제 |
+| POST | `/diet/photo-scan` | `multipart/form-data: file` | `{candidates: FoodItem[]}` | (Stage 4 후속 — 카메라) |
+
+`DietEntry`:
+```json
+{
+  "id": "...",
+  "meal_type": "breakfast",  // breakfast|lunch|dinner|snack
+  "time_label": "08:20",
+  "foods": [{ "name": "오트밀", "calories": 220 }],
+  "total_calories": 315,
+  "sodium_mg": 380,
+  "sugar_g": 18
+}
+```
+
+`DietDay`: `entries[] + totals + macros + ai_coach_message`.
+
+---
+
+## 5. Exercise
+
+| Method | Path | Body / Query | 응답 | Flutter 사용처 |
+| --- | --- | --- | --- | --- |
+| GET | `/exercise/weeks/current` | — | `ExerciseWeek` | `MockExerciseRepository.fetchThisWeek` |
+| GET | `/exercise/weeks/{week_start}` | `?week_start=YYYY-MM-DD` (월요일) | `ExerciseWeek` | (주간 이동) |
+| POST | `/exercise/sessions` | `ExerciseSession` | 생성된 session | "운동 추가" |
+| PATCH | `/exercise/sessions/{id}` | partial | 갱신 | |
+| DELETE | `/exercise/sessions/{id}` | — | `204` | |
+
+`ExerciseSession`:
+```json
+{
+  "id": "...",
+  "day_label": "월", "started_at": "2026-05-12T08:00:00+09:00",
+  "type": "cardio",          // cardio|strength|yoga|walking
+  "minutes": 30,
+  "calories": 250
+}
+```
+
+`ExerciseWeek`: `sessions[] + daily_minutes + day_labels + totals + streak_days + ai_coach_message`.
+
+---
+
+## 6. Vitals (Quick Input)
+
+| Method | Path | Body | 응답 | Flutter 사용처 |
+| --- | --- | --- | --- | --- |
+| POST | `/vitals/weight` | `{kg: number, recorded_at: iso}` | `{id, ...}` | Dashboard quick-input |
+| POST | `/vitals/blood-pressure` | `{systolic, diastolic, recorded_at}` | `{id, ...}` | Dashboard quick-input |
+| POST | `/vitals/blood-sugar` | `{mg_per_dl, recorded_at}` | `{id, ...}` | Dashboard quick-input |
+| GET | `/vitals/{kind}/history` | `?from=&to=` | `[{value, recorded_at}, ...]` | MyHealth sparkline |
+| GET | `/vitals/{kind}/latest` | — | `{value, recorded_at}` | MyHealth IndicatorTile |
+
+`kind`: `weight | blood-pressure | blood-sugar`.
+
+---
+
+## 7. Schedule / Events
+
+| Method | Path | Body / Query | 응답 | Flutter 사용처 |
+| --- | --- | --- | --- | --- |
+| GET | `/schedule/events` | `?from=YYYY-MM-DD&to=YYYY-MM-DD` | `ScheduleEvent[]` | Calendar 모달 |
+| GET | `/schedule/events` | `?date=YYYY-MM-DD` | 해당 일자 events | "오늘의 일정" |
+| POST | `/schedule/events` | `ScheduleEvent` (without id) | 생성된 event | "일정 추가" |
+| PATCH | `/schedule/events/{id}` | partial | 갱신 | "수정" |
+| DELETE | `/schedule/events/{id}` | — | `204` | "삭제" |
+
+`ScheduleEvent`:
+```json
+{
+  "id": "...",
+  "title": "병원 정기검진",
+  "date": "2026-05-14",
+  "time": "10:00",
+  "category": "hospital",   // hospital|exercise|meal|medication|other
+  "emoji": "🏥",
+  "color_hint": "#FEE2E2"
+}
+```
+
+---
+
+## 8. Notifications
+
+| Method | Path | Query / Body | 응답 | Flutter 사용처 |
+| --- | --- | --- | --- | --- |
+| GET | `/notifications` | `?unread_only=true` | `AlertItem[]` | Notification 패널 |
+| GET | `/notifications/unread-count` | — | `{count: int}` | Header bell dot |
+| PATCH | `/notifications/{id}` | `{read: true}` | 갱신된 item | tile tap |
+| POST | `/notifications/read-all` | — | `204` | "모두 읽음" |
+| POST | `/notifications/devices` | `{platform, token}` | `204` | FCM 등록 (Stage 후속) |
+
+`AlertItem`:
+```json
+{
+  "id": "...", "title": "...", "body": "...",
+  "time_ago": "10분 전", "created_at": "2026-05-20T07:50:00+09:00",
+  "category": "reminder",   // reminder|health_check|achievement|system
+  "read": false
+}
+```
+
+> Q9 결정상 실제 push 발송은 시뮬레이션 → 백엔드는 데이터 저장 + 클라이언트가
+> 폴링/WebSocket. 실 push 시 FCM 토큰 endpoint 추가.
+
+---
+
+## 9. AI Coach (Q7: mock)
+
+| Method | Path | Body | 응답 | Flutter 사용처 |
+| --- | --- | --- | --- | --- |
+| GET | `/ai-coach/feedback` | — | `AiCoachState` | `MockAiCoachRepository.fetchState`, AiCoachCard, AiCoachPanel |
+| POST | `/ai-coach/chat` | `{message: string, context?: dict}` | `{reply: string, suggestions?: AiSuggestion[]}` | (추후 채팅 UI) |
+
+`AiCoachState`:
+```json
+{
+  "greeting": "안녕하세요, 오늘 컨디션은 어떠세요?",
+  "suggestions": [
+    { "tag": "diet", "title": "...", "body": "..." }
+  ]
+}
+```
+
+`tag`: `diet|exercise|sleep|hydration`.
+
+> Q7: 일단은 정적 mock 응답. 실제 LLM/추천 엔진 통합은 별도 후속.
+
+---
+
+## 10. Places (Q8: Google Maps 통합 예정)
+
+| Method | Path | Query | 응답 | Flutter 사용처 |
+| --- | --- | --- | --- | --- |
+| GET | `/places/nearby` | `?lat=&lng=&category=&radius_m=1000` | `Place[]` | Place 페이지 |
+| GET | `/places/{id}` | — | `Place` (상세) | (place 상세, 후속) |
+
+`Place`:
+```json
+{
+  "id": "...", "name": "강남세브란스 가정의학과",
+  "category": "medical",       // medical|fitness|healthy_food|pharmacy
+  "address": "...",
+  "distance_meters": 420,
+  "lat": 37.4979, "lng": 127.0276
+}
+```
+
+---
+
+## 11. Health Check
+
+| Method | Path | 응답 |
+| --- | --- | --- |
+| GET | `/healthz` | `{status: "ok", version: "..."}` |
+| GET | `/version` | `{api_version, commit_sha}` |
+
+`MockApiInterceptor`의 `GET /ping → {message: "pong (mock)"}`도 dev/test
+용으로 살려두면 좋습니다.
+
+---
+
+## 12. 우선순위 (FastAPI 구현 단계 제안)
+
+| 단계 | 엔드포인트 | 이유 |
+| --- | --- | --- |
+| **MVP-1** | `GET /healthz`, `GET /dashboard/summary`, `GET /diet/days/today`, `GET /exercise/weeks/current`, `GET /users/me/health` | 첫 빌드에서 4탭 모두 데이터를 그리는 데 필요 |
+| **MVP-2** | Vitals POST, Notifications GET/PATCH, Schedule GET/POST | 인터랙티브 카드들이 실제 데이터를 만들 수 있게 |
+| **MVP-3** | Auth (social/refresh/logout), Users PATCH, AI Coach | 실 사용자 분리 + 보안 |
+| **MVP-4** | Diet/Exercise CRUD 전체, Places, photo-scan | 본격 기록 + 통계 |
+
+---
+
+## 13. 명명/스키마 노트 (FastAPI 측)
+
+- **snake_case** 필드 (Pydantic의 `alias_generator` 또는 응답 serializer로
+  통일). Flutter 측은 `freezed` + `@JsonKey(name: '...')` 또는 매뉴얼 매핑.
+- **DateTime**: 모두 ISO 8601 + timezone. Asia/Seoul 기준 UTC offset.
+- **ID**: UUID v4 권장 (`str(uuid4())`).
+- **Pagination**: `?cursor=&limit=` 또는 `?page=&size=` 중 일관되게 — 권장
+  `cursor` (notifications/schedule 역방향 스크롤 친화적).
+- **Errors**:
+  ```json
+  { "code": "validation_error",
+    "message": "weight must be > 0",
+    "details": { "field": "kg" } }
+  ```
+  HTTP code: 400/401/403/404/409/422/500. `AppError.fromDio`가 이걸 맵핑.

--- a/frontend/flutter/docs/DUMMY_BACKEND.md
+++ b/frontend/flutter/docs/DUMMY_BACKEND.md
@@ -1,0 +1,146 @@
+# Dummy Backend Strategy — 실 FastAPI 서버 전까지
+
+> 본 문서는 "실제 백엔드 없이도 Flutter app이 풀 기능을 시연할 수 있는"
+> dummy backend 옵션을 비교합니다. 권장은 §3.
+
+---
+
+## 1. 옵션 비교
+
+| 옵션 | 영속성 | 플랫폼 | 추가 의존성 | 코드 변경 | Production 전환 |
+| --- | --- | --- | --- | --- | --- |
+| A. 현재 `MockApiInterceptor` (in-memory) | ❌ 앱 재시작 시 초기화 | 모두 | 없음 (기존) | 거의 없음 | interceptor 제거 |
+| B. **브라우저 `localStorage`** | ✅ (브라우저 한정) | **Web만** | 없음 (dart:html / package:web) | interceptor 추가 | interceptor 제거 |
+| C. **drift (SQLite) backed interceptor** ⭐ | ✅ 영구 | **Android / iOS / Web** | 없음 (이미 설치됨, drift_flutter) | schema 정의 + interceptor 확장 | interceptor 제거, schema는 그대로 |
+| D. 외부 mock 서버 (Mockoon / JSON Server / Hoverfly) | ✅ 파일/메모리 | 모두 (서버 켜진 동안) | 사용자가 별도 실행 | dart-define으로 base URL만 변경 | base URL 교체 |
+| E. OpenAPI-prism / WireMock | ✅ | 모두 | 사용자가 별도 실행 | API_CATALOG.md → openapi.yaml 작성 | spec 기반 자동 |
+
+### 1.1 옵션 B (localStorage) 자세히
+
+- **장점**: 가장 단순. `window.localStorage` 호출만으로 끝.
+- **단점**:
+  - **Web 전용**. 모바일 빌드에서 컴파일 자체가 안 됨 (`dart:html` /
+    `package:web`은 web만).
+  - 검색·정렬·필터링이 모두 클라이언트 측 JS — `WHERE meal_type='lunch'`
+    같은 쿼리도 매번 전 객체를 JSON 디코드해 직접 filter.
+  - 5–10MB 한도 (브라우저별). 7일 vital + 1개월 일정 정도면 충분하나,
+    사진 등은 못 담음.
+  - **Flutter 모바일에서 같은 인터셉터를 켤 수 없음** → 코드가 web/mobile
+    분기됨.
+
+만약 굳이 localStorage를 쓴다면, web 전용 `WebLocalStorageInterceptor`를
+conditional import로 분리하고 모바일은 옵션 C로 fallback — 즉 결국 옵션 C가
+필요합니다. → **단독 사용은 비권장**.
+
+### 1.2 옵션 C (drift) 자세히
+
+이미 `lib/core/storage/app_database.dart`로 drift가 설치되어 있고, drift_flutter
+가 Android/iOS는 NativeDatabase(sqlite3), Web은 sqlite3 WASM + IndexedDB로
+자동 backed 됩니다. 즉:
+
+- **한 코드로 3 플랫폼 모두 영속 백엔드**가 됩니다.
+- SQL 쿼리 + transaction이 가능 → "오늘 식단의 합산 칼로리" 등이 자연스럽.
+- 마이그레이션 패턴이 그대로 — Stage 후속에 새 테이블 추가 쉽다.
+- 실 FastAPI로 전환 시 **interceptor만 끄면 됩니다** (이미 USE_MOCK_API
+  플래그 보유).
+
+단점:
+
+- 첫 셋업에 schema 정의가 필요 (DietEntries / ExerciseSessions / Vitals /
+  ScheduleEvents / Notifications / …).
+- drift codegen (`dart run build_runner build`)이 필요.
+
+### 1.3 옵션 D (Mockoon 등 외부 서버) 자세히
+
+- **장점**: 실제 네트워크 통신을 그대로 검증, HTTP 코드/지연/오류 시뮬레이션
+  쉬움. CORS·인증 등 production 상황 미리 점검.
+- **단점**: 사용자가 따로 켜야 함. CORS 설정 필요 for web. CI에서 e2e
+  돌리려면 컨테이너 실행 추가.
+
+이미 FastAPI를 곧 만들 계획이므로, **Mockoon은 굳이 거치지 않고 바로 FastAPI
+서버를 가볍게 띄우는 게 더 유익**합니다 (옵션 E와 결합).
+
+---
+
+## 2. 권장 — 옵션 C (drift backed `LocalApiInterceptor`)
+
+### 2.1 동작 흐름
+
+```
+DioClient
+  └ MockApiInterceptor (현재)  ──→  LocalApiInterceptor (신규)
+                                         │
+                                         ├─ /diet/days/today → drift query
+                                         ├─ /diet/entries POST → drift insert
+                                         ├─ /vitals/weight POST → drift insert
+                                         ├─ /notifications GET → drift query
+                                         └─ ... (API_CATALOG.md 전부)
+```
+
+요청 path를 보고 SQL을 실행한 결과를 `Response`로 즉시 resolve. dio는 실제
+네트워크를 타지 않습니다.
+
+### 2.2 schema 확장 계획 (drift 테이블)
+
+- `DietEntries(id, date, meal_type, time_label, foods_json, total_calories,
+  sodium_mg, sugar_g)`
+- `ExerciseSessions(id, date, day_label, type, minutes, calories)`
+- `Vitals(id, kind, value_json, recorded_at)`
+- `ScheduleEvents(id, date, time, title, category, emoji)`
+- `Notifications(id, created_at, title, body, category, read)`
+- `KvSeed(key, value_json)` — 첫 실행에 React 원본의 mock 데이터를 seed
+  (이미 `AppKeyValues` 테이블이 비슷한 역할).
+
+### 2.3 단계적 도입
+
+1. **Phase A**: schema 추가 + codegen. seed 데이터 삽입 (앱 첫 실행 시).
+2. **Phase B**: `MockApiInterceptor`를 점진적으로 `LocalApiInterceptor`로
+   대체. 한 path씩 교체.
+3. **Phase C**: 모든 endpoint가 drift로 흘러가면 `USE_MOCK_API=true`가
+   사실상 "local backend" 모드.
+4. **Phase D (FastAPI 도착)**: `USE_MOCK_API=false`로 바꾸면 동일 path 시그
+   니처의 실 백엔드로 자동 전환.
+
+### 2.4 보너스 — DevTools / 로그
+
+`ApiLoggingInterceptor`가 이미 dev에서 한 줄로 매 요청을 찍기 때문에 drift
+backed mock도 그대로 확인 가능. drift는 별도로 `LogInterceptor`를 attach해
+SQL을 찍을 수 있어 디버깅이 편합니다.
+
+---
+
+## 3. FastAPI 본격 도입 시 시나리오
+
+본격 FastAPI 서버 도입 후의 흐름은 다음과 같습니다.
+
+1. `docs/API_CATALOG.md`의 endpoint를 FastAPI에서 그대로 구현
+   (`fastapi.APIRouter` + Pydantic 모델). snake_case로.
+2. CI/CD: docker compose로 FastAPI + Postgres + Redis 띄우고 staging에 배포.
+3. Flutter:
+   ```bash
+   flutter run -d chrome \
+     --dart-define=ENV=staging \
+     --dart-define=API_BASE_URL=https://staging.api.oncare.example.com \
+     --dart-define=USE_MOCK_API=false
+   ```
+4. 로컬 개발은 그대로 `USE_MOCK_API=true` → drift backed mock으로 동작.
+5. 인증 토큰은 `AuthInterceptor`(이미 stub)가 `SecureTokenStore`에서 읽어
+   `Authorization: Bearer …` 헤더로 첨부.
+
+CORS는 FastAPI 측에서 `https://barmi.github.io`와 dev origin을 허용하면
+됩니다.
+
+---
+
+## 4. 결정 필요 사항
+
+| # | 결정 항목 | 옵션 | 권장 |
+| --- | --- | --- | --- |
+| D1 | dummy backend 방식 | A/B/C/D/E | **C (drift backed)** |
+| D2 | snake_case ↔ camelCase 변환 위치 | 서버 (Pydantic alias) / 클라이언트 (freezed @JsonKey) | 서버에서 alias로 양쪽 변환 |
+| D3 | 응답 envelope 사용? | `{data, meta}` / 그냥 객체 직접 | 직접 객체 (간결) + paginated list만 `{items, next_cursor}` |
+| D4 | API 버전 prefix | `/api/v1` / 없음 | `/api/v1` (forward-compat) |
+| D5 | Pagination | cursor / offset | cursor |
+| D6 | OpenAPI 스펙 자동 생성 활용 | FastAPI 기본 `/openapi.json` → Flutter codegen | yes (`openapi-generator-cli`로 retrofit 클라이언트 자동 생성 검토) |
+
+위 결정만 받으면 옵션 C 구현부터 들어갈 수 있습니다.

--- a/frontend/flutter/docs/PLAN.md
+++ b/frontend/flutter/docs/PLAN.md
@@ -365,3 +365,34 @@ features/dashboard/
 - 각 **Phase** 종료 시 → `git commit` (push 없음).
 - 각 **Stage** 종료 시 → `git commit && git push origin main`.
 - 자세한 규약: [CONTRIBUTING_NOTES.md](./CONTRIBUTING_NOTES.md).
+
+### 9.5 2026-05-20 — Stage 9 (Local backend) 결정 사항
+
+Stage 9 시작 전 사용자가 결정한 6개 항목 (D1..D6).
+
+| # | 항목 | 결정 | 구현 |
+| --- | --- | --- | --- |
+| D1 | 더미 백엔드 방식 | **drift 기반 LocalApiInterceptor (옵션 C)** | `core/network/interceptors/local_api_interceptor.dart` — `_routes` 맵 + per-handler 메서드. `USE_MOCK_API=true` 일 때 wire. |
+| D2 | 케이스 매핑 | **snake_case (FastAPI Pydantic alias 컨벤션)** ↔ **camelCase (Dart)** | `core/network/case_mapper.dart` — `toCamelCaseJson` / `toSnakeCaseJson` 재귀 변환. fromJson 팩토리들이 snake_case 키를 읽음. |
+| D3 | drift 스키마 v2 | **6개 테이블** (AppKeyValues / DietEntries / ExerciseSessions / Vitals / ScheduleEvents / NotificationItems) | `core/storage/app_database.dart` schemaVersion=2 + onUpgrade 마이그레이션. |
+| D4 | seed 정책 | **첫 실행 1회만** (`seeded_v1` 플래그) | `core/storage/seed_data.dart` `seedIfEmpty(db)`. React mock 데이터를 그대로 주입. |
+| D5 | swap 전략 | **interceptor 우선 dispatch → 미매핑 path는 fall-through** | `LocalApiInterceptor.onRequest()` 가 `null` 반환 시 다음 인터셉터로. `USE_MOCK_API=false` 빌드면 FastAPI에 그대로 도달. |
+| D6 | 테스트 | **각 endpoint LocalApi 단위 + 기존 controller mock-repo 전환** | `test/core/network/local_api_interceptor_*_test.dart` (7 파일) + 각 feature controller test override. |
+
+### 9.6 Stage 9 — 엔드포인트 매트릭스
+
+| Phase | 엔드포인트 | drift 의존 테이블 | 비고 |
+| --- | --- | --- | --- |
+| 9.4 | `GET /diet/days/today` | DietEntries | 칼로리/나트륨/당류 누계 |
+| 9.5 | `POST /vitals/{kind}`, `GET /vitals/{kind}/latest` | Vitals | weight / blood-pressure / blood-sugar 3종 |
+| 9.6 | `GET /exercise/weeks/current` | ExerciseSessions | 월~일 daily_minutes 집계 + streak |
+| 9.7 | `GET /schedule/events?date=`, `GET /notifications` | ScheduleEvents, NotificationItems | time_ago Korean formatter |
+| 9.8 | `GET /dashboard/summary` | Diet + Exercise + Vitals + Schedule | week_score 휴리스틱 (50 + cal*25 + ex*25) |
+| 9.9 | `GET /ai-coach/feedback`, `GET /users/me`, `GET /users/me/health`, `GET /places/nearby` | (정적) | drift 사용 안 함 — 정적 demo payload |
+| — | `GET /ping`, `GET /healthz`, `GET /version` | — | 기존 헬스체크 (Stage 9.3에서 도입) |
+
+### 9.7 FastAPI 전환 시 (D5 swap)
+
+- 빌드 명령에 `--dart-define=USE_MOCK_API=false --dart-define=API_BASE_URL=https://api.oncare.dev` 추가 → `LocalApiInterceptor`가 wire되지 않고 모든 호출이 FastAPI로 라우팅.
+- 응답 contract는 그대로 (snake_case + 동일 JSON shape). fromJson 팩토리는 재사용.
+- 검증: integration test (smoke) → `assets/api/contract_*.json` 으로 fixture를 두고 LocalApi 응답과 동일한 shape인지 확인.

--- a/frontend/flutter/lib/app/bootstrap.dart
+++ b/frontend/flutter/lib/app/bootstrap.dart
@@ -7,7 +7,9 @@ import 'package:oncare/app/app.dart';
 import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/core/logging/app_logger.dart';
 import 'package:oncare/core/logging/logging_provider_observer.dart';
+import 'package:oncare/core/storage/app_database.dart';
 import 'package:oncare/core/storage/prefs_store.dart';
+import 'package:oncare/core/storage/seed_data.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// Single entry point used by `main.dart`. Initializes binding,
@@ -25,6 +27,12 @@ Future<void> bootstrap() async {
   );
 
   final prefs = await SharedPreferences.getInstance();
+
+  // Local backend (drift-backed mock). Seed once on first run so the
+  // app boots with the React prototype's mock data even before the
+  // real FastAPI server exists. See docs/DUMMY_BACKEND.md.
+  final db = AppDatabase();
+  await seedIfEmpty(db);
 
   FlutterError.onError = (FlutterErrorDetails details) {
     FlutterError.presentError(details);
@@ -49,6 +57,7 @@ Future<void> bootstrap() async {
             appConfigProvider.overrideWithValue(config),
             appLoggerProvider.overrideWithValue(logger),
             sharedPreferencesProvider.overrideWithValue(prefs),
+            appDatabaseProvider.overrideWithValue(db),
           ],
           child: const OncareApp(),
         ),

--- a/frontend/flutter/lib/app/bootstrap.dart
+++ b/frontend/flutter/lib/app/bootstrap.dart
@@ -31,8 +31,25 @@ Future<void> bootstrap() async {
   // Local backend (drift-backed mock). Seed once on first run so the
   // app boots with the React prototype's mock data even before the
   // real FastAPI server exists. See docs/DUMMY_BACKEND.md.
+  //
+  // The drift open is lazy — the first query (the `seedIfEmpty`
+  // below) is what can throw. On the web build, drift needs
+  // `sqlite3.wasm` + `drift_worker.js` at the same origin; the
+  // deploy workflow downloads them into `web/` from the drift
+  // release matching `pubspec.lock`. If the fetch still fails (or
+  // the browser lacks the storage APIs drift needs), we log and
+  // continue — the UI renders, individual feature pages will show
+  // their own error states when they hit the empty DB.
   final db = AppDatabase();
-  await seedIfEmpty(db);
+  try {
+    await seedIfEmpty(db);
+  } catch (e, st) {
+    logger.e(
+      'Drift seed failed — app will boot with no local data',
+      error: e,
+      stackTrace: st,
+    );
+  }
 
   FlutterError.onError = (FlutterErrorDetails details) {
     FlutterError.presentError(details);

--- a/frontend/flutter/lib/core/network/case_mapper.dart
+++ b/frontend/flutter/lib/core/network/case_mapper.dart
@@ -1,0 +1,54 @@
+/// snake_case ↔ camelCase helpers. The FastAPI server emits snake_case
+/// JSON (Pydantic alias convention); Flutter prefers camelCase.
+/// Used by `LocalApiInterceptor` so the dummy backend can pretend it
+/// is the real server.
+Object? toCamelCaseJson(Object? value) {
+  if (value is Map<String, Object?>) {
+    return <String, Object?>{
+      for (final entry in value.entries)
+        _snakeToCamel(entry.key): toCamelCaseJson(entry.value),
+    };
+  }
+  if (value is List<Object?>) {
+    return <Object?>[for (final v in value) toCamelCaseJson(v)];
+  }
+  return value;
+}
+
+Object? toSnakeCaseJson(Object? value) {
+  if (value is Map<String, Object?>) {
+    return <String, Object?>{
+      for (final entry in value.entries)
+        _camelToSnake(entry.key): toSnakeCaseJson(entry.value),
+    };
+  }
+  if (value is List<Object?>) {
+    return <Object?>[for (final v in value) toSnakeCaseJson(v)];
+  }
+  return value;
+}
+
+String _snakeToCamel(String s) {
+  final parts = s.split('_');
+  if (parts.length == 1) return s;
+  final head = parts.first;
+  final tail = parts.skip(1).map((String w) {
+    if (w.isEmpty) return '';
+    return w[0].toUpperCase() + w.substring(1);
+  });
+  return head + tail.join();
+}
+
+String _camelToSnake(String s) {
+  final buf = StringBuffer();
+  for (int i = 0; i < s.length; i++) {
+    final ch = s[i];
+    if (i > 0 && ch == ch.toUpperCase() && ch != ch.toLowerCase()) {
+      buf.write('_');
+      buf.write(ch.toLowerCase());
+    } else {
+      buf.write(ch);
+    }
+  }
+  return buf.toString();
+}

--- a/frontend/flutter/lib/core/network/dio_client.dart
+++ b/frontend/flutter/lib/core/network/dio_client.dart
@@ -23,6 +23,11 @@ final dioProvider = Provider<Dio>((ref) {
       receiveTimeout: const Duration(seconds: 15),
       sendTimeout: const Duration(seconds: 10),
       contentType: Headers.jsonContentType,
+      // 4xx/5xx are normal API errors and should surface as DioException
+      // so callers can react via try/catch, not slip past `res.data!`
+      // straight into a misleading "Null check" failure in a fromJson
+      // factory.
+      validateStatus: (int? status) => status != null && status < 400,
     ),
   );
 

--- a/frontend/flutter/lib/core/network/dio_client.dart
+++ b/frontend/flutter/lib/core/network/dio_client.dart
@@ -5,7 +5,9 @@ import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/core/logging/app_logger.dart';
 import 'package:oncare/core/network/interceptors/api_logging_interceptor.dart';
 import 'package:oncare/core/network/interceptors/auth_interceptor.dart';
+import 'package:oncare/core/network/interceptors/local_api_interceptor.dart';
 import 'package:oncare/core/network/interceptors/mock_api_interceptor.dart';
+import 'package:oncare/core/storage/app_database.dart';
 
 /// App-wide `Dio` instance, wired with logging/auth/mock interceptors
 /// based on the current [AppConfig]. Feature data sources should read
@@ -24,10 +26,12 @@ final dioProvider = Provider<Dio>((ref) {
     ),
   );
 
-  // Order matters: mock should fire first so it can short-circuit
-  // before any auth/logging interceptor is exercised.
+  // Order matters: LocalApi (drift-backed) and the legacy in-memory
+  // MockApi both short-circuit before auth/logging fire.
   if (config.useMockApi) {
-    dio.interceptors.add(MockApiInterceptor(logger));
+    dio.interceptors
+      ..add(LocalApiInterceptor(ref.watch(appDatabaseProvider), logger))
+      ..add(MockApiInterceptor(logger));
   }
   dio.interceptors.add(AuthInterceptor(ref));
   if (!config.isProd) {

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -33,6 +33,8 @@ class LocalApiInterceptor extends Interceptor {
     'GET /version': _version,
     'GET /diet/days/today': _dietToday,
     'GET /exercise/weeks/current': _exerciseCurrentWeek,
+    'GET /schedule/events': _scheduleEvents,
+    'GET /notifications': _notifications,
     // Vitals — three fixed kinds (weight | blood-pressure | blood-sugar).
     'POST /vitals/weight': _vitalsSubmit,
     'POST /vitals/blood-pressure': _vitalsSubmit,
@@ -218,6 +220,64 @@ class LocalApiInterceptor extends Interceptor {
           ? '주간 운동 목표 80%를 달성했어요! 일요일에 가볍게 걷기를 더해 100%를 채워봐요.'
           : '이번 주는 운동량이 조금 부족해요. 가벼운 산책부터 다시 시작해 봐요.',
     });
+  }
+
+  // ---- Schedule ----
+
+  Future<Response<Object?>> _scheduleEvents(RequestOptions options) async {
+    // `?date=YYYY-MM-DD`. Defaults to today.
+    final date =
+        (options.queryParameters['date'] as String?) ?? _todayDateString();
+    final rows = await (_db.select(
+      _db.scheduleEvents,
+    )..where((t) => t.date.equals(date))).get();
+
+    final list = <Map<String, Object?>>[
+      for (final r in rows)
+        <String, Object?>{
+          'id': r.id,
+          'date': r.date,
+          'time': r.time,
+          'title': r.title,
+          'category': r.category,
+          'emoji': r.emoji,
+          'color_hex': r.colorHex,
+        },
+    ];
+    return _ok(options, list);
+  }
+
+  // ---- Notifications ----
+
+  Future<Response<Object?>> _notifications(RequestOptions options) async {
+    final query = _db.select(_db.notificationItems)
+      ..orderBy(<OrderClauseGenerator<$NotificationItemsTable>>[
+        (t) => OrderingTerm(expression: t.createdAt, mode: OrderingMode.desc),
+      ]);
+    final rows = await query.get();
+
+    final now = DateTime.now();
+    final list = <Map<String, Object?>>[
+      for (final r in rows)
+        <String, Object?>{
+          'id': r.id,
+          'title': r.title,
+          'body': r.body,
+          'category': r.category,
+          'read': r.read,
+          'created_at': r.createdAt.toIso8601String(),
+          'time_ago': _timeAgoKorean(now.difference(r.createdAt)),
+        },
+    ];
+    return _ok(options, list);
+  }
+
+  String _timeAgoKorean(Duration d) {
+    if (d.inMinutes < 1) return '방금';
+    if (d.inMinutes < 60) return '${d.inMinutes}분 전';
+    if (d.inHours < 24) return '${d.inHours}시간 전';
+    if (d.inDays == 1) return '어제';
+    return '${d.inDays}일 전';
   }
 
   String _mondayOfThisWeekString() {

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -32,6 +32,7 @@ class LocalApiInterceptor extends Interceptor {
     'GET /healthz': _healthz,
     'GET /version': _version,
     'GET /diet/days/today': _dietToday,
+    'GET /exercise/weeks/current': _exerciseCurrentWeek,
     // Vitals — three fixed kinds (weight | blood-pressure | blood-sugar).
     'POST /vitals/weight': _vitalsSubmit,
     'POST /vitals/blood-pressure': _vitalsSubmit,
@@ -152,6 +153,79 @@ class LocalApiInterceptor extends Interceptor {
     return '${now.year.toString().padLeft(4, '0')}-'
         '${now.month.toString().padLeft(2, '0')}-'
         '${now.day.toString().padLeft(2, '0')}';
+  }
+
+  // ---- Exercise ----
+
+  static const List<String> _weekdayLabels = <String>[
+    '월',
+    '화',
+    '수',
+    '목',
+    '금',
+    '토',
+    '일',
+  ];
+
+  Future<Response<Object?>> _exerciseCurrentWeek(RequestOptions options) async {
+    final weekStart = _mondayOfThisWeekString();
+    final rows = await (_db.select(
+      _db.exerciseSessions,
+    )..where((t) => t.weekStart.equals(weekStart))).get();
+
+    // Aggregate minutes per day-label so the bar chart can render even
+    // when a day is missing (React mock left Tue=0).
+    final perDay = <String, int>{
+      for (final l in _weekdayLabels) l: 0,
+    };
+    int totalMinutes = 0;
+    int totalCalories = 0;
+    final sessionsJson = <Map<String, Object?>>[];
+
+    for (final r in rows) {
+      totalMinutes += r.minutes;
+      totalCalories += r.calories;
+      perDay.update(
+        r.dayLabel,
+        (m) => m + r.minutes,
+        ifAbsent: () => r.minutes,
+      );
+      sessionsJson.add(<String, Object?>{
+        'id': r.id,
+        'day_label': r.dayLabel,
+        'type': r.type,
+        'minutes': r.minutes,
+        'calories': r.calories,
+      });
+    }
+
+    final dailyMinutes = <num>[
+      for (final l in _weekdayLabels) perDay[l] ?? 0,
+    ];
+
+    // "Streak" = consecutive non-zero days ending at today's weekday
+    // (or simply the count of non-zero days for the simple mock).
+    final streak = dailyMinutes.where((m) => m > 0).length;
+
+    return _ok(options, <String, Object?>{
+      'sessions': sessionsJson,
+      'daily_minutes': dailyMinutes,
+      'day_labels': _weekdayLabels,
+      'total_minutes': totalMinutes,
+      'total_calories': totalCalories,
+      'streak_days': streak,
+      'ai_coach_message': totalMinutes >= 240
+          ? '주간 운동 목표 80%를 달성했어요! 일요일에 가볍게 걷기를 더해 100%를 채워봐요.'
+          : '이번 주는 운동량이 조금 부족해요. 가벼운 산책부터 다시 시작해 봐요.',
+    });
+  }
+
+  String _mondayOfThisWeekString() {
+    final now = DateTime.now();
+    final monday = DateTime(now.year, now.month, now.day - (now.weekday - 1));
+    return '${monday.year.toString().padLeft(4, '0')}-'
+        '${monday.month.toString().padLeft(2, '0')}-'
+        '${monday.day.toString().padLeft(2, '0')}';
   }
 
   // ---- Vitals ----

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -132,10 +132,11 @@ class LocalApiInterceptor extends Interceptor {
     final todayLabel = _weekdayLabels[DateTime.now().weekday - 1];
     final weekStart = _mondayOfThisWeekString();
     // Two chained .where() calls are AND-joined by drift.
-    final exerciseRows = await (_db.select(_db.exerciseSessions)
-          ..where((t) => t.weekStart.equals(weekStart))
-          ..where((t) => t.dayLabel.equals(todayLabel)))
-        .get();
+    final exerciseRows =
+        await (_db.select(_db.exerciseSessions)
+              ..where((t) => t.weekStart.equals(weekStart))
+              ..where((t) => t.dayLabel.equals(todayLabel)))
+            .get();
     int exerciseMinutes = 0;
     for (final r in exerciseRows) {
       exerciseMinutes += r.minutes;
@@ -166,11 +167,7 @@ class LocalApiInterceptor extends Interceptor {
     )..where((t) => t.date.equals(today))).get();
     final schedJson = <Map<String, Object?>>[
       for (final r in schedRows)
-        <String, Object?>{
-          'time': r.time,
-          'title': r.title,
-          'emoji': r.emoji,
-        },
+        <String, Object?>{'time': r.time, 'title': r.title, 'emoji': r.emoji},
     ];
 
     // Heuristic "week score": stretch diet+exercise into a 0..100 band
@@ -292,9 +289,7 @@ class LocalApiInterceptor extends Interceptor {
 
     // Aggregate minutes per day-label so the bar chart can render even
     // when a day is missing (React mock left Tue=0).
-    final perDay = <String, int>{
-      for (final l in _weekdayLabels) l: 0,
-    };
+    final perDay = <String, int>{for (final l in _weekdayLabels) l: 0};
     int totalMinutes = 0;
     int totalCalories = 0;
     final sessionsJson = <Map<String, Object?>>[];
@@ -316,9 +311,7 @@ class LocalApiInterceptor extends Interceptor {
       });
     }
 
-    final dailyMinutes = <num>[
-      for (final l in _weekdayLabels) perDay[l] ?? 0,
-    ];
+    final dailyMinutes = <num>[for (final l in _weekdayLabels) perDay[l] ?? 0];
 
     // "Streak" = consecutive non-zero days ending at today's weekday
     // (or simply the count of non-zero days for the simple mock).
@@ -429,10 +422,7 @@ class LocalApiInterceptor extends Interceptor {
 
   Future<Response<Object?>> _usersMeHealth(RequestOptions options) async {
     return _ok(options, <String, Object?>{
-      'profile': <String, Object?>{
-        'name': '김민수',
-        'email': 'minsu@oncare.com',
-      },
+      'profile': <String, Object?>{'name': '김민수', 'email': 'minsu@oncare.com'},
       'risk': <String, Object?>{
         'title': '고혈압·당뇨 위험 주의',
         'body': '최근 혈압과 혈당 추세가 다소 높습니다. 식단·운동 관리에 신경 써주세요.',

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 
 import 'package:dio/dio.dart';
+import 'package:drift/drift.dart'
+    show OrderClauseGenerator, OrderingMode, OrderingTerm, Value;
 import 'package:logger/logger.dart';
 
 import 'package:oncare/core/storage/app_database.dart';
@@ -30,6 +32,13 @@ class LocalApiInterceptor extends Interceptor {
     'GET /healthz': _healthz,
     'GET /version': _version,
     'GET /diet/days/today': _dietToday,
+    // Vitals — three fixed kinds (weight | blood-pressure | blood-sugar).
+    'POST /vitals/weight': _vitalsSubmit,
+    'POST /vitals/blood-pressure': _vitalsSubmit,
+    'POST /vitals/blood-sugar': _vitalsSubmit,
+    'GET /vitals/weight/latest': _vitalsLatest,
+    'GET /vitals/blood-pressure/latest': _vitalsLatest,
+    'GET /vitals/blood-sugar/latest': _vitalsLatest,
   };
 
   @override
@@ -145,6 +154,91 @@ class LocalApiInterceptor extends Interceptor {
         '${now.day.toString().padLeft(2, '0')}';
   }
 
+  // ---- Vitals ----
+
+  /// Path tail → drift `kind` value. Centralised so POST and GET
+  /// agree on the same string.
+  String? _kindFromPath(String path) {
+    if (path.startsWith('/vitals/weight')) return 'weight';
+    if (path.startsWith('/vitals/blood-pressure')) return 'blood-pressure';
+    if (path.startsWith('/vitals/blood-sugar')) return 'blood-sugar';
+    return null;
+  }
+
+  Future<Response<Object?>> _vitalsSubmit(RequestOptions options) async {
+    final kind = _kindFromPath(options.path);
+    if (kind == null) {
+      return _badRequest(options, 'unknown vital kind: ${options.path}');
+    }
+
+    final body = options.data;
+    Map<String, Object?> payload;
+    if (body is Map) {
+      payload = body.cast<String, Object?>();
+    } else if (body is String && body.isNotEmpty) {
+      payload = (jsonDecode(body) as Map<Object?, Object?>)
+          .cast<String, Object?>();
+    } else {
+      payload = <String, Object?>{};
+    }
+
+    // Pluck `recorded_at` off the payload (if provided) and store the
+    // rest as the value blob.
+    final recordedAtRaw = payload.remove('recorded_at');
+    final recordedAt = recordedAtRaw is String && recordedAtRaw.isNotEmpty
+        ? DateTime.parse(recordedAtRaw)
+        : DateTime.now();
+
+    final id = 'v-${DateTime.now().microsecondsSinceEpoch}';
+    await _db
+        .into(_db.vitals)
+        .insert(
+          VitalsCompanion(
+            id: Value<String>(id),
+            kind: Value<String>(kind),
+            valueJson: Value<String>(jsonEncode(payload)),
+            recordedAt: Value<DateTime>(recordedAt),
+          ),
+        );
+
+    return _ok(options, <String, Object?>{
+      'id': id,
+      'kind': kind,
+      'value': payload,
+      'recorded_at': recordedAt.toIso8601String(),
+    });
+  }
+
+  Future<Response<Object?>> _vitalsLatest(RequestOptions options) async {
+    final kind = _kindFromPath(options.path);
+    if (kind == null) {
+      return _badRequest(options, 'unknown vital kind: ${options.path}');
+    }
+
+    final query = _db.select(_db.vitals)
+      ..where((t) => t.kind.equals(kind))
+      ..orderBy(<OrderClauseGenerator<$VitalsTable>>[
+        (t) => OrderingTerm(expression: t.recordedAt, mode: OrderingMode.desc),
+      ])
+      ..limit(1);
+    final row = await query.getSingleOrNull();
+
+    if (row == null) {
+      // No reading yet — return a 200 with empty body so the client
+      // can treat null as "no data". (FastAPI will mirror this with
+      // an explicit nullable response model.)
+      return _ok(options, <String, Object?>{});
+    }
+
+    return _ok(options, <String, Object?>{
+      'id': row.id,
+      'kind': row.kind,
+      'value': (jsonDecode(row.valueJson) as Map<Object?, Object?>)
+          .cast<String, Object?>(),
+      'recorded_at': row.recordedAt.toIso8601String(),
+    });
+  }
+
   // ---- helpers ----
 
   /// Build a 200 OK response carrying [body]. Subclasses of handlers
@@ -155,6 +249,14 @@ class LocalApiInterceptor extends Interceptor {
       requestOptions: options,
       statusCode: 200,
       data: body,
+    );
+  }
+
+  Response<Object?> _badRequest(RequestOptions options, String message) {
+    return Response<Object?>(
+      requestOptions: options,
+      statusCode: 400,
+      data: <String, Object?>{'code': 'bad_request', 'message': message},
     );
   }
 

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:dio/dio.dart';
 import 'package:logger/logger.dart';
 
@@ -27,6 +29,7 @@ class LocalApiInterceptor extends Interceptor {
     'GET /ping': _ping,
     'GET /healthz': _healthz,
     'GET /version': _version,
+    'GET /diet/days/today': _dietToday,
   };
 
   @override
@@ -88,6 +91,58 @@ class LocalApiInterceptor extends Interceptor {
       'api_version': 'v1',
       'app_version': '0.2.0+2',
     });
+  }
+
+  // ---- Diet ----
+
+  Future<Response<Object?>> _dietToday(RequestOptions options) async {
+    final today = _todayDateString();
+    final rows = await (_db.select(
+      _db.dietEntries,
+    )..where((t) => t.date.equals(today))).get();
+
+    int totalCalories = 0;
+    int totalSodium = 0;
+    int totalSugar = 0;
+    final entriesJson = <Map<String, Object?>>[];
+    for (final r in rows) {
+      totalCalories += r.totalCalories;
+      totalSodium += r.sodiumMg;
+      totalSugar += r.sugarG;
+      entriesJson.add(<String, Object?>{
+        'id': r.id,
+        'meal_type': r.mealType,
+        'time_label': r.timeLabel,
+        'foods': (jsonDecode(r.foodsJson) as List<Object?>).cast<Object?>(),
+        'total_calories': r.totalCalories,
+        'sodium_mg': r.sodiumMg,
+        'sugar_g': r.sugarG,
+      });
+    }
+
+    return _ok(options, <String, Object?>{
+      'entries': entriesJson,
+      'total_calories': totalCalories,
+      'total_sodium_mg': totalSodium,
+      'total_sugar_g': totalSugar,
+      // Macro breakdown isn't tracked per entry yet — return the
+      // demo split until a richer schema lands.
+      'macros': <String, Object?>{
+        'carbs_pct': 50,
+        'protein_pct': 30,
+        'fat_pct': 20,
+      },
+      'ai_coach_message': totalSodium > 2000
+          ? '오늘 점심에 나트륨이 많았어요. 저녁은 담백한 구이/샐러드로 균형을 맞춰봐요!'
+          : '균형 잡힌 하루였어요. 내일도 이대로 가요!',
+    });
+  }
+
+  String _todayDateString() {
+    final now = DateTime.now();
+    return '${now.year.toString().padLeft(4, '0')}-'
+        '${now.month.toString().padLeft(2, '0')}-'
+        '${now.day.toString().padLeft(2, '0')}';
   }
 
   // ---- helpers ----

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -1,0 +1,110 @@
+import 'package:dio/dio.dart';
+import 'package:logger/logger.dart';
+
+import 'package:oncare/core/storage/app_database.dart';
+
+/// A drift-backed dummy backend. Intercepts dio requests and serves
+/// them out of the local SQLite database so the app can run as a
+/// "local backend" before the real FastAPI server exists.
+///
+/// Path dispatch is done in `_handle()` — handlers return `null` to
+/// fall through to the next interceptor (and ultimately to the real
+/// network when `USE_MOCK_API=false`).
+///
+/// snake_case payloads are produced/consumed via
+/// `core/network/case_mapper.dart` so the contract matches the real
+/// server's Pydantic models.
+class LocalApiInterceptor extends Interceptor {
+  LocalApiInterceptor(this._db, this._logger);
+
+  final AppDatabase _db;
+  final Logger _logger;
+
+  // Path-pattern → handler map. Static paths get O(1) dispatch;
+  // path-with-id endpoints (`/diet/entries/{id}`) fall to the regex
+  // section below.
+  late final Map<String, _Handler> _routes = <String, _Handler>{
+    'GET /ping': _ping,
+    'GET /healthz': _healthz,
+    'GET /version': _version,
+  };
+
+  @override
+  Future<void> onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
+    final response = await _safeHandle(options);
+    if (response != null) {
+      handler.resolve(response);
+      return;
+    }
+    handler.next(options);
+  }
+
+  Future<Response<Object?>?> _safeHandle(RequestOptions options) async {
+    final method = options.method.toUpperCase();
+    final path = options.path;
+    final key = '$method $path';
+
+    try {
+      // Static dispatch first.
+      final exact = _routes[key];
+      if (exact != null) {
+        _logger.d('[local-api] $key (exact)');
+        return await exact(options);
+      }
+      // (Regex routes will be added by later phases — diet/exercise/
+      // vitals/notifications/schedule etc.)
+      return null;
+    } catch (e, st) {
+      _logger.e('[local-api] $key failed', error: e, stackTrace: st);
+      return Response<Object?>(
+        requestOptions: options,
+        statusCode: 500,
+        data: <String, Object?>{
+          'code': 'internal_error',
+          'message': e.toString(),
+        },
+      );
+    }
+  }
+
+  // ---- handlers ----
+
+  Future<Response<Object?>> _ping(RequestOptions options) async {
+    return _ok(options, <String, Object?>{'message': 'pong (local)'});
+  }
+
+  Future<Response<Object?>> _healthz(RequestOptions options) async {
+    return _ok(options, <String, Object?>{
+      'status': 'ok',
+      'backend': 'drift-local',
+    });
+  }
+
+  Future<Response<Object?>> _version(RequestOptions options) async {
+    return _ok(options, <String, Object?>{
+      'api_version': 'v1',
+      'app_version': '0.2.0+2',
+    });
+  }
+
+  // ---- helpers ----
+
+  /// Build a 200 OK response carrying [body]. Subclasses of handlers
+  /// will build their bodies as plain Map/List structures (snake_case)
+  /// before passing in.
+  Response<Object?> _ok(RequestOptions options, Object? body) {
+    return Response<Object?>(
+      requestOptions: options,
+      statusCode: 200,
+      data: body,
+    );
+  }
+
+  /// Expose the database to test scaffolding without leaking internals.
+  AppDatabase get database => _db;
+}
+
+typedef _Handler = Future<Response<Object?>> Function(RequestOptions);

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -31,6 +31,7 @@ class LocalApiInterceptor extends Interceptor {
     'GET /ping': _ping,
     'GET /healthz': _healthz,
     'GET /version': _version,
+    'GET /dashboard/summary': _dashboardSummary,
     'GET /diet/days/today': _dietToday,
     'GET /exercise/weeks/current': _exerciseCurrentWeek,
     'GET /schedule/events': _scheduleEvents,
@@ -102,6 +103,116 @@ class LocalApiInterceptor extends Interceptor {
     return _ok(options, <String, Object?>{
       'api_version': 'v1',
       'app_version': '0.2.0+2',
+    });
+  }
+
+  // ---- Dashboard ----
+
+  Future<Response<Object?>> _dashboardSummary(RequestOptions options) async {
+    final today = _todayDateString();
+
+    // Diet aggregates.
+    final dietRows = await (_db.select(
+      _db.dietEntries,
+    )..where((t) => t.date.equals(today))).get();
+    int totalCalories = 0;
+    int totalSodium = 0;
+    int totalSugar = 0;
+    for (final r in dietRows) {
+      totalCalories += r.totalCalories;
+      totalSodium += r.sodiumMg;
+      totalSugar += r.sugarG;
+    }
+
+    // Exercise minutes for today's day-label.
+    final todayLabel = _weekdayLabels[DateTime.now().weekday - 1];
+    final weekStart = _mondayOfThisWeekString();
+    // Two chained .where() calls are AND-joined by drift.
+    final exerciseRows = await (_db.select(_db.exerciseSessions)
+          ..where((t) => t.weekStart.equals(weekStart))
+          ..where((t) => t.dayLabel.equals(todayLabel)))
+        .get();
+    int exerciseMinutes = 0;
+    for (final r in exerciseRows) {
+      exerciseMinutes += r.minutes;
+    }
+
+    // Latest blood sugar reading (mg/dL) — defaults to 0 when none.
+    int bloodSugar = 0;
+    final bsRow =
+        await (_db.select(_db.vitals)
+              ..where((t) => t.kind.equals('blood-sugar'))
+              ..orderBy(<OrderClauseGenerator<$VitalsTable>>[
+                (t) => OrderingTerm(
+                  expression: t.recordedAt,
+                  mode: OrderingMode.desc,
+                ),
+              ])
+              ..limit(1))
+            .getSingleOrNull();
+    if (bsRow != null) {
+      final v = jsonDecode(bsRow.valueJson) as Map<Object?, Object?>;
+      final raw = v['mg_per_dl'];
+      if (raw is num) bloodSugar = raw.toInt();
+    }
+
+    // Today's schedule items.
+    final schedRows = await (_db.select(
+      _db.scheduleEvents,
+    )..where((t) => t.date.equals(today))).get();
+    final schedJson = <Map<String, Object?>>[
+      for (final r in schedRows)
+        <String, Object?>{
+          'time': r.time,
+          'title': r.title,
+          'emoji': r.emoji,
+        },
+    ];
+
+    // Heuristic "week score": stretch diet+exercise into a 0..100 band
+    // so the card always renders something even on an empty database.
+    final calRatio = (totalCalories / 2000.0).clamp(0.0, 1.0);
+    final exRatio = (exerciseMinutes / 60.0).clamp(0.0, 1.0);
+    final score = (50 + calRatio * 25 + exRatio * 25).round();
+
+    return _ok(options, <String, Object?>{
+      'indicators': <Map<String, Object?>>[
+        <String, Object?>{
+          'label': '칼로리',
+          'current': totalCalories,
+          'max': 2000,
+          'unit': 'kcal',
+        },
+        <String, Object?>{
+          'label': '나트륨',
+          'current': totalSodium,
+          'max': 2000,
+          'unit': 'mg',
+          'over_budget': totalSodium > 2000,
+        },
+        <String, Object?>{
+          'label': '당류',
+          'current': totalSugar,
+          'max': 50,
+          'unit': 'g',
+        },
+        <String, Object?>{
+          'label': '혈당',
+          'current': bloodSugar,
+          'max': 120,
+          'unit': 'mg/dL',
+        },
+      ],
+      'diet_entries': dietRows.length,
+      'exercise_minutes': exerciseMinutes,
+      'today_schedule': schedJson,
+      'week_score': score,
+      // Delta is a static demo number for now — full week-over-week
+      // diff lands in a later phase.
+      'week_score_delta': 12,
+      'sodium_warning': totalSodium > 2000
+          ? '오늘의 나트륨 섭취량이 높아요. 저녁에는 담백한 구이나 샐러드를 추천해요!'
+          : null,
     });
   }
 

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -36,6 +36,10 @@ class LocalApiInterceptor extends Interceptor {
     'GET /exercise/weeks/current': _exerciseCurrentWeek,
     'GET /schedule/events': _scheduleEvents,
     'GET /notifications': _notifications,
+    'GET /ai-coach/feedback': _aiCoachFeedback,
+    'GET /users/me': _usersMe,
+    'GET /users/me/health': _usersMeHealth,
+    'GET /places/nearby': _placesNearby,
     // Vitals — three fixed kinds (weight | blood-pressure | blood-sugar).
     'POST /vitals/weight': _vitalsSubmit,
     'POST /vitals/blood-pressure': _vitalsSubmit,
@@ -381,6 +385,140 @@ class LocalApiInterceptor extends Interceptor {
         },
     ];
     return _ok(options, list);
+  }
+
+  // ---- AI Coach ----
+
+  Future<Response<Object?>> _aiCoachFeedback(RequestOptions options) async {
+    return _ok(options, <String, Object?>{
+      'greeting': '안녕하세요, 오늘 컨디션은 어떠세요?',
+      'suggestions': <Map<String, Object?>>[
+        <String, Object?>{
+          'tag': 'diet',
+          'title': '점심에 단백질을 +10g 추가해 보세요',
+          'body': '오전 운동량을 보면 점심에 단백질을 조금 더 채우는 것이 좋아요.',
+        },
+        <String, Object?>{
+          'tag': 'exercise',
+          'title': '저녁 산책 15분',
+          'body': '저녁 시간대 가벼운 유산소는 수면의 질도 함께 끌어올립니다.',
+        },
+        <String, Object?>{
+          'tag': 'hydration',
+          'title': '수분 보충',
+          'body': '오늘 평소보다 활동량이 많았어요. 물 한 컵 더 마셔봐요.',
+        },
+        <String, Object?>{
+          'tag': 'sleep',
+          'title': '취침 1시간 전 화면 줄이기',
+          'body': '깊은 수면 비율이 낮은 패턴이 보입니다. 자극을 줄여보세요.',
+        },
+      ],
+    });
+  }
+
+  // ---- Users / Me ----
+
+  Future<Response<Object?>> _usersMe(RequestOptions options) async {
+    return _ok(options, <String, Object?>{
+      'id': 'user-demo',
+      'name': '김민수',
+      'email': 'minsu@oncare.com',
+    });
+  }
+
+  Future<Response<Object?>> _usersMeHealth(RequestOptions options) async {
+    return _ok(options, <String, Object?>{
+      'profile': <String, Object?>{
+        'name': '김민수',
+        'email': 'minsu@oncare.com',
+      },
+      'risk': <String, Object?>{
+        'title': '고혈압·당뇨 위험 주의',
+        'body': '최근 혈압과 혈당 추세가 다소 높습니다. 식단·운동 관리에 신경 써주세요.',
+        'level': 'medium',
+      },
+      'indicators': <Map<String, Object?>>[
+        <String, Object?>{
+          'kind': 'weight',
+          'label': '체중',
+          'latest_value': '68.2',
+          'unit': 'kg',
+          'delta_text': '-1.2kg (지난주 대비)',
+          'improving': true,
+          'last_7_days': <double>[0.95, 0.92, 0.90, 0.86, 0.83, 0.80, 0.76],
+        },
+        <String, Object?>{
+          'kind': 'blood-pressure',
+          'label': '혈압',
+          'latest_value': '124/82',
+          'unit': 'mmHg',
+          'delta_text': '+4 (지난주 대비)',
+          'improving': false,
+          'last_7_days': <double>[0.60, 0.62, 0.65, 0.70, 0.74, 0.78, 0.80],
+        },
+        <String, Object?>{
+          'kind': 'blood-sugar',
+          'label': '혈당',
+          'latest_value': '95',
+          'unit': 'mg/dL',
+          'delta_text': '-3 (지난주 대비)',
+          'improving': true,
+          'last_7_days': <double>[0.75, 0.74, 0.72, 0.71, 0.70, 0.69, 0.65],
+        },
+      ],
+      'activity_points': 1240,
+      'activity_rank': 14,
+      'settings': <Map<String, Object?>>[
+        <String, Object?>{'label': '개인 정보', 'icon': '👤'},
+        <String, Object?>{'label': '건강 데이터', 'icon': '📊'},
+        <String, Object?>{'label': '알림 설정', 'icon': '🔔'},
+        <String, Object?>{'label': '고객 지원', 'icon': '💬'},
+      ],
+    });
+  }
+
+  // ---- Places ----
+
+  Future<Response<Object?>> _placesNearby(RequestOptions options) async {
+    return _ok(options, <Map<String, Object?>>[
+      <String, Object?>{
+        'id': 'p1',
+        'name': '강남세브란스 가정의학과',
+        'category': 'medical',
+        'address': '서울특별시 강남구 테헤란로 123',
+        'distance_meters': 420,
+        'lat': 37.4979,
+        'lng': 127.0276,
+      },
+      <String, Object?>{
+        'id': 'p2',
+        'name': '온케어 피트니스',
+        'category': 'fitness',
+        'address': '서울특별시 강남구 역삼로 55',
+        'distance_meters': 680,
+        'lat': 37.5005,
+        'lng': 127.0319,
+      },
+      <String, Object?>{
+        'id': 'p3',
+        'name': '그린 샐러드 바',
+        'category': 'healthy_food',
+        'address': '서울특별시 강남구 강남대로 311',
+        'distance_meters': 250,
+        'lat': 37.4970,
+        'lng': 127.0270,
+      },
+      <String, Object?>{
+        'id': 'p4',
+        'name': '24시간 메디팜약국',
+        'category': 'pharmacy',
+        'address': '서울특별시 강남구 테헤란로 99',
+        'distance_meters': 800,
+        'lat': 37.4995,
+        'lng': 127.0263,
+      },
+    ]);
   }
 
   String _timeAgoKorean(Duration d) {

--- a/frontend/flutter/lib/core/storage/app_database.dart
+++ b/frontend/flutter/lib/core/storage/app_database.dart
@@ -25,8 +25,7 @@ class DietEntries extends Table {
   IntColumn get totalCalories => integer()();
   IntColumn get sodiumMg => integer().withDefault(const Constant(0))();
   IntColumn get sugarG => integer().withDefault(const Constant(0))();
-  DateTimeColumn get createdAt =>
-      dateTime().withDefault(currentDateAndTime)();
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
 
   @override
   Set<Column<Object>> get primaryKey => <Column<Object>>{id};
@@ -40,8 +39,7 @@ class ExerciseSessions extends Table {
   TextColumn get type => text()(); // cardio|strength|yoga|walking
   IntColumn get minutes => integer()();
   IntColumn get calories => integer()();
-  DateTimeColumn get createdAt =>
-      dateTime().withDefault(currentDateAndTime)();
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
 
   @override
   Set<Column<Object>> get primaryKey => <Column<Object>>{id};
@@ -51,7 +49,8 @@ class ExerciseSessions extends Table {
 class Vitals extends Table {
   TextColumn get id => text()();
   TextColumn get kind => text()(); // weight|blood-pressure|blood-sugar
-  TextColumn get valueJson => text()(); // {"kg":68.2} / {"systolic":..} / {"mg_per_dl":..}
+  TextColumn get valueJson =>
+      text()(); // {"kg":68.2} / {"systolic":..} / {"mg_per_dl":..}
   DateTimeColumn get recordedAt => dateTime()();
 
   @override
@@ -64,10 +63,10 @@ class ScheduleEvents extends Table {
   TextColumn get date => text()(); // YYYY-MM-DD
   TextColumn get time => text()(); // "10:00"
   TextColumn get title => text()();
-  TextColumn get category => text()(); // hospital|exercise|meal|medication|other
+  TextColumn get category =>
+      text()(); // hospital|exercise|meal|medication|other
   TextColumn get emoji => text().withDefault(const Constant(''))();
-  TextColumn get colorHex =>
-      text().withDefault(const Constant('#E0F2F7'))();
+  TextColumn get colorHex => text().withDefault(const Constant('#E0F2F7'))();
 
   @override
   Set<Column<Object>> get primaryKey => <Column<Object>>{id};

--- a/frontend/flutter/lib/core/storage/app_database.dart
+++ b/frontend/flutter/lib/core/storage/app_database.dart
@@ -4,10 +4,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 part 'app_database.g.dart';
 
-/// Generic key-value table. Hosts app-level small values that don't
-/// warrant their own schema (locale, onboarding flags, etc.). As Stage 4
-/// adds feature data, real tables (DietEntries, ExerciseSessions, …)
-/// land here too.
+/// Generic key-value table. Used for tiny app-level state (locale,
+/// onboarding flags) and as a stash for JSON snapshots that don't yet
+/// warrant their own table (MyHealthState, AiCoachState, …).
 class AppKeyValues extends Table {
   TextColumn get key => text()();
   TextColumn get value => text()();
@@ -16,7 +15,88 @@ class AppKeyValues extends Table {
   Set<Column<Object>> get primaryKey => <Column<Object>>{key};
 }
 
-@DriftDatabase(tables: <Type>[AppKeyValues])
+@DataClassName('DietEntryRow')
+class DietEntries extends Table {
+  TextColumn get id => text()();
+  TextColumn get date => text()(); // YYYY-MM-DD
+  TextColumn get mealType => text()(); // breakfast|lunch|dinner|snack
+  TextColumn get timeLabel => text()(); // "08:20"
+  TextColumn get foodsJson => text()(); // [{ "name": "...", "calories": ... }]
+  IntColumn get totalCalories => integer()();
+  IntColumn get sodiumMg => integer().withDefault(const Constant(0))();
+  IntColumn get sugarG => integer().withDefault(const Constant(0))();
+  DateTimeColumn get createdAt =>
+      dateTime().withDefault(currentDateAndTime)();
+
+  @override
+  Set<Column<Object>> get primaryKey => <Column<Object>>{id};
+}
+
+@DataClassName('ExerciseSessionRow')
+class ExerciseSessions extends Table {
+  TextColumn get id => text()();
+  TextColumn get weekStart => text()(); // Monday YYYY-MM-DD
+  TextColumn get dayLabel => text()(); // 월/화/수/...
+  TextColumn get type => text()(); // cardio|strength|yoga|walking
+  IntColumn get minutes => integer()();
+  IntColumn get calories => integer()();
+  DateTimeColumn get createdAt =>
+      dateTime().withDefault(currentDateAndTime)();
+
+  @override
+  Set<Column<Object>> get primaryKey => <Column<Object>>{id};
+}
+
+@DataClassName('VitalRow')
+class Vitals extends Table {
+  TextColumn get id => text()();
+  TextColumn get kind => text()(); // weight|blood-pressure|blood-sugar
+  TextColumn get valueJson => text()(); // {"kg":68.2} / {"systolic":..} / {"mg_per_dl":..}
+  DateTimeColumn get recordedAt => dateTime()();
+
+  @override
+  Set<Column<Object>> get primaryKey => <Column<Object>>{id};
+}
+
+@DataClassName('ScheduleEventRow')
+class ScheduleEvents extends Table {
+  TextColumn get id => text()();
+  TextColumn get date => text()(); // YYYY-MM-DD
+  TextColumn get time => text()(); // "10:00"
+  TextColumn get title => text()();
+  TextColumn get category => text()(); // hospital|exercise|meal|medication|other
+  TextColumn get emoji => text().withDefault(const Constant(''))();
+  TextColumn get colorHex =>
+      text().withDefault(const Constant('#E0F2F7'))();
+
+  @override
+  Set<Column<Object>> get primaryKey => <Column<Object>>{id};
+}
+
+@DataClassName('NotificationRow')
+class NotificationItems extends Table {
+  TextColumn get id => text()();
+  DateTimeColumn get createdAt => dateTime()();
+  TextColumn get title => text()();
+  TextColumn get body => text()();
+  TextColumn get category =>
+      text()(); // reminder|health_check|achievement|system
+  BoolColumn get read => boolean().withDefault(const Constant(false))();
+
+  @override
+  Set<Column<Object>> get primaryKey => <Column<Object>>{id};
+}
+
+@DriftDatabase(
+  tables: <Type>[
+    AppKeyValues,
+    DietEntries,
+    ExerciseSessions,
+    Vitals,
+    ScheduleEvents,
+    NotificationItems,
+  ],
+)
 class AppDatabase extends _$AppDatabase {
   AppDatabase() : super(driftDatabase(name: 'oncare'));
 
@@ -25,8 +105,25 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 1;
+  int get schemaVersion => 2;
 
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+    onCreate: (Migrator m) async {
+      await m.createAll();
+    },
+    onUpgrade: (Migrator m, int from, int to) async {
+      if (from < 2) {
+        await m.createTable(dietEntries);
+        await m.createTable(exerciseSessions);
+        await m.createTable(vitals);
+        await m.createTable(scheduleEvents);
+        await m.createTable(notificationItems);
+      }
+    },
+  );
+
+  // ---- AppKeyValues ----
   Future<void> putValue(String key, String value) {
     return into(appKeyValues).insertOnConflictUpdate(
       AppKeyValuesCompanion.insert(key: key, value: value),

--- a/frontend/flutter/lib/core/storage/app_database.dart
+++ b/frontend/flutter/lib/core/storage/app_database.dart
@@ -97,7 +97,19 @@ class NotificationItems extends Table {
   ],
 )
 class AppDatabase extends _$AppDatabase {
-  AppDatabase() : super(driftDatabase(name: 'oncare'));
+  AppDatabase()
+    : super(
+        driftDatabase(
+          name: 'oncare',
+          // On web, drift needs the sqlite3 WASM module and a worker
+          // script. The release CI downloads both into `web/` so the
+          // bundled `index.html` can fetch them at the same origin.
+          web: DriftWebOptions(
+            sqlite3Wasm: Uri.parse('sqlite3.wasm'),
+            driftWorker: Uri.parse('drift_worker.js'),
+          ),
+        ),
+      );
 
   /// Use in tests:
   ///   `AppDatabase.forTesting(NativeDatabase.memory())`

--- a/frontend/flutter/lib/core/storage/app_database.g.dart
+++ b/frontend/flutter/lib/core/storage/app_database.g.dart
@@ -211,15 +211,2198 @@ class AppKeyValuesCompanion extends UpdateCompanion<AppKeyValue> {
   }
 }
 
+class $DietEntriesTable extends DietEntries
+    with TableInfo<$DietEntriesTable, DietEntryRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $DietEntriesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _dateMeta = const VerificationMeta('date');
+  @override
+  late final GeneratedColumn<String> date = GeneratedColumn<String>(
+    'date',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _mealTypeMeta = const VerificationMeta(
+    'mealType',
+  );
+  @override
+  late final GeneratedColumn<String> mealType = GeneratedColumn<String>(
+    'meal_type',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _timeLabelMeta = const VerificationMeta(
+    'timeLabel',
+  );
+  @override
+  late final GeneratedColumn<String> timeLabel = GeneratedColumn<String>(
+    'time_label',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _foodsJsonMeta = const VerificationMeta(
+    'foodsJson',
+  );
+  @override
+  late final GeneratedColumn<String> foodsJson = GeneratedColumn<String>(
+    'foods_json',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _totalCaloriesMeta = const VerificationMeta(
+    'totalCalories',
+  );
+  @override
+  late final GeneratedColumn<int> totalCalories = GeneratedColumn<int>(
+    'total_calories',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _sodiumMgMeta = const VerificationMeta(
+    'sodiumMg',
+  );
+  @override
+  late final GeneratedColumn<int> sodiumMg = GeneratedColumn<int>(
+    'sodium_mg',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  static const VerificationMeta _sugarGMeta = const VerificationMeta('sugarG');
+  @override
+  late final GeneratedColumn<int> sugarG = GeneratedColumn<int>(
+    'sugar_g',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    date,
+    mealType,
+    timeLabel,
+    foodsJson,
+    totalCalories,
+    sodiumMg,
+    sugarG,
+    createdAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'diet_entries';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<DietEntryRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('date')) {
+      context.handle(
+        _dateMeta,
+        date.isAcceptableOrUnknown(data['date']!, _dateMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_dateMeta);
+    }
+    if (data.containsKey('meal_type')) {
+      context.handle(
+        _mealTypeMeta,
+        mealType.isAcceptableOrUnknown(data['meal_type']!, _mealTypeMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_mealTypeMeta);
+    }
+    if (data.containsKey('time_label')) {
+      context.handle(
+        _timeLabelMeta,
+        timeLabel.isAcceptableOrUnknown(data['time_label']!, _timeLabelMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_timeLabelMeta);
+    }
+    if (data.containsKey('foods_json')) {
+      context.handle(
+        _foodsJsonMeta,
+        foodsJson.isAcceptableOrUnknown(data['foods_json']!, _foodsJsonMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_foodsJsonMeta);
+    }
+    if (data.containsKey('total_calories')) {
+      context.handle(
+        _totalCaloriesMeta,
+        totalCalories.isAcceptableOrUnknown(
+          data['total_calories']!,
+          _totalCaloriesMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_totalCaloriesMeta);
+    }
+    if (data.containsKey('sodium_mg')) {
+      context.handle(
+        _sodiumMgMeta,
+        sodiumMg.isAcceptableOrUnknown(data['sodium_mg']!, _sodiumMgMeta),
+      );
+    }
+    if (data.containsKey('sugar_g')) {
+      context.handle(
+        _sugarGMeta,
+        sugarG.isAcceptableOrUnknown(data['sugar_g']!, _sugarGMeta),
+      );
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  DietEntryRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return DietEntryRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      date: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}date'],
+      )!,
+      mealType: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}meal_type'],
+      )!,
+      timeLabel: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}time_label'],
+      )!,
+      foodsJson: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}foods_json'],
+      )!,
+      totalCalories: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}total_calories'],
+      )!,
+      sodiumMg: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}sodium_mg'],
+      )!,
+      sugarG: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}sugar_g'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+    );
+  }
+
+  @override
+  $DietEntriesTable createAlias(String alias) {
+    return $DietEntriesTable(attachedDatabase, alias);
+  }
+}
+
+class DietEntryRow extends DataClass implements Insertable<DietEntryRow> {
+  final String id;
+  final String date;
+  final String mealType;
+  final String timeLabel;
+  final String foodsJson;
+  final int totalCalories;
+  final int sodiumMg;
+  final int sugarG;
+  final DateTime createdAt;
+  const DietEntryRow({
+    required this.id,
+    required this.date,
+    required this.mealType,
+    required this.timeLabel,
+    required this.foodsJson,
+    required this.totalCalories,
+    required this.sodiumMg,
+    required this.sugarG,
+    required this.createdAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['date'] = Variable<String>(date);
+    map['meal_type'] = Variable<String>(mealType);
+    map['time_label'] = Variable<String>(timeLabel);
+    map['foods_json'] = Variable<String>(foodsJson);
+    map['total_calories'] = Variable<int>(totalCalories);
+    map['sodium_mg'] = Variable<int>(sodiumMg);
+    map['sugar_g'] = Variable<int>(sugarG);
+    map['created_at'] = Variable<DateTime>(createdAt);
+    return map;
+  }
+
+  DietEntriesCompanion toCompanion(bool nullToAbsent) {
+    return DietEntriesCompanion(
+      id: Value(id),
+      date: Value(date),
+      mealType: Value(mealType),
+      timeLabel: Value(timeLabel),
+      foodsJson: Value(foodsJson),
+      totalCalories: Value(totalCalories),
+      sodiumMg: Value(sodiumMg),
+      sugarG: Value(sugarG),
+      createdAt: Value(createdAt),
+    );
+  }
+
+  factory DietEntryRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return DietEntryRow(
+      id: serializer.fromJson<String>(json['id']),
+      date: serializer.fromJson<String>(json['date']),
+      mealType: serializer.fromJson<String>(json['mealType']),
+      timeLabel: serializer.fromJson<String>(json['timeLabel']),
+      foodsJson: serializer.fromJson<String>(json['foodsJson']),
+      totalCalories: serializer.fromJson<int>(json['totalCalories']),
+      sodiumMg: serializer.fromJson<int>(json['sodiumMg']),
+      sugarG: serializer.fromJson<int>(json['sugarG']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'date': serializer.toJson<String>(date),
+      'mealType': serializer.toJson<String>(mealType),
+      'timeLabel': serializer.toJson<String>(timeLabel),
+      'foodsJson': serializer.toJson<String>(foodsJson),
+      'totalCalories': serializer.toJson<int>(totalCalories),
+      'sodiumMg': serializer.toJson<int>(sodiumMg),
+      'sugarG': serializer.toJson<int>(sugarG),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+    };
+  }
+
+  DietEntryRow copyWith({
+    String? id,
+    String? date,
+    String? mealType,
+    String? timeLabel,
+    String? foodsJson,
+    int? totalCalories,
+    int? sodiumMg,
+    int? sugarG,
+    DateTime? createdAt,
+  }) => DietEntryRow(
+    id: id ?? this.id,
+    date: date ?? this.date,
+    mealType: mealType ?? this.mealType,
+    timeLabel: timeLabel ?? this.timeLabel,
+    foodsJson: foodsJson ?? this.foodsJson,
+    totalCalories: totalCalories ?? this.totalCalories,
+    sodiumMg: sodiumMg ?? this.sodiumMg,
+    sugarG: sugarG ?? this.sugarG,
+    createdAt: createdAt ?? this.createdAt,
+  );
+  DietEntryRow copyWithCompanion(DietEntriesCompanion data) {
+    return DietEntryRow(
+      id: data.id.present ? data.id.value : this.id,
+      date: data.date.present ? data.date.value : this.date,
+      mealType: data.mealType.present ? data.mealType.value : this.mealType,
+      timeLabel: data.timeLabel.present ? data.timeLabel.value : this.timeLabel,
+      foodsJson: data.foodsJson.present ? data.foodsJson.value : this.foodsJson,
+      totalCalories: data.totalCalories.present
+          ? data.totalCalories.value
+          : this.totalCalories,
+      sodiumMg: data.sodiumMg.present ? data.sodiumMg.value : this.sodiumMg,
+      sugarG: data.sugarG.present ? data.sugarG.value : this.sugarG,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('DietEntryRow(')
+          ..write('id: $id, ')
+          ..write('date: $date, ')
+          ..write('mealType: $mealType, ')
+          ..write('timeLabel: $timeLabel, ')
+          ..write('foodsJson: $foodsJson, ')
+          ..write('totalCalories: $totalCalories, ')
+          ..write('sodiumMg: $sodiumMg, ')
+          ..write('sugarG: $sugarG, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    date,
+    mealType,
+    timeLabel,
+    foodsJson,
+    totalCalories,
+    sodiumMg,
+    sugarG,
+    createdAt,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is DietEntryRow &&
+          other.id == this.id &&
+          other.date == this.date &&
+          other.mealType == this.mealType &&
+          other.timeLabel == this.timeLabel &&
+          other.foodsJson == this.foodsJson &&
+          other.totalCalories == this.totalCalories &&
+          other.sodiumMg == this.sodiumMg &&
+          other.sugarG == this.sugarG &&
+          other.createdAt == this.createdAt);
+}
+
+class DietEntriesCompanion extends UpdateCompanion<DietEntryRow> {
+  final Value<String> id;
+  final Value<String> date;
+  final Value<String> mealType;
+  final Value<String> timeLabel;
+  final Value<String> foodsJson;
+  final Value<int> totalCalories;
+  final Value<int> sodiumMg;
+  final Value<int> sugarG;
+  final Value<DateTime> createdAt;
+  final Value<int> rowid;
+  const DietEntriesCompanion({
+    this.id = const Value.absent(),
+    this.date = const Value.absent(),
+    this.mealType = const Value.absent(),
+    this.timeLabel = const Value.absent(),
+    this.foodsJson = const Value.absent(),
+    this.totalCalories = const Value.absent(),
+    this.sodiumMg = const Value.absent(),
+    this.sugarG = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  DietEntriesCompanion.insert({
+    required String id,
+    required String date,
+    required String mealType,
+    required String timeLabel,
+    required String foodsJson,
+    required int totalCalories,
+    this.sodiumMg = const Value.absent(),
+    this.sugarG = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       date = Value(date),
+       mealType = Value(mealType),
+       timeLabel = Value(timeLabel),
+       foodsJson = Value(foodsJson),
+       totalCalories = Value(totalCalories);
+  static Insertable<DietEntryRow> custom({
+    Expression<String>? id,
+    Expression<String>? date,
+    Expression<String>? mealType,
+    Expression<String>? timeLabel,
+    Expression<String>? foodsJson,
+    Expression<int>? totalCalories,
+    Expression<int>? sodiumMg,
+    Expression<int>? sugarG,
+    Expression<DateTime>? createdAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (date != null) 'date': date,
+      if (mealType != null) 'meal_type': mealType,
+      if (timeLabel != null) 'time_label': timeLabel,
+      if (foodsJson != null) 'foods_json': foodsJson,
+      if (totalCalories != null) 'total_calories': totalCalories,
+      if (sodiumMg != null) 'sodium_mg': sodiumMg,
+      if (sugarG != null) 'sugar_g': sugarG,
+      if (createdAt != null) 'created_at': createdAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  DietEntriesCompanion copyWith({
+    Value<String>? id,
+    Value<String>? date,
+    Value<String>? mealType,
+    Value<String>? timeLabel,
+    Value<String>? foodsJson,
+    Value<int>? totalCalories,
+    Value<int>? sodiumMg,
+    Value<int>? sugarG,
+    Value<DateTime>? createdAt,
+    Value<int>? rowid,
+  }) {
+    return DietEntriesCompanion(
+      id: id ?? this.id,
+      date: date ?? this.date,
+      mealType: mealType ?? this.mealType,
+      timeLabel: timeLabel ?? this.timeLabel,
+      foodsJson: foodsJson ?? this.foodsJson,
+      totalCalories: totalCalories ?? this.totalCalories,
+      sodiumMg: sodiumMg ?? this.sodiumMg,
+      sugarG: sugarG ?? this.sugarG,
+      createdAt: createdAt ?? this.createdAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (date.present) {
+      map['date'] = Variable<String>(date.value);
+    }
+    if (mealType.present) {
+      map['meal_type'] = Variable<String>(mealType.value);
+    }
+    if (timeLabel.present) {
+      map['time_label'] = Variable<String>(timeLabel.value);
+    }
+    if (foodsJson.present) {
+      map['foods_json'] = Variable<String>(foodsJson.value);
+    }
+    if (totalCalories.present) {
+      map['total_calories'] = Variable<int>(totalCalories.value);
+    }
+    if (sodiumMg.present) {
+      map['sodium_mg'] = Variable<int>(sodiumMg.value);
+    }
+    if (sugarG.present) {
+      map['sugar_g'] = Variable<int>(sugarG.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('DietEntriesCompanion(')
+          ..write('id: $id, ')
+          ..write('date: $date, ')
+          ..write('mealType: $mealType, ')
+          ..write('timeLabel: $timeLabel, ')
+          ..write('foodsJson: $foodsJson, ')
+          ..write('totalCalories: $totalCalories, ')
+          ..write('sodiumMg: $sodiumMg, ')
+          ..write('sugarG: $sugarG, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $ExerciseSessionsTable extends ExerciseSessions
+    with TableInfo<$ExerciseSessionsTable, ExerciseSessionRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $ExerciseSessionsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _weekStartMeta = const VerificationMeta(
+    'weekStart',
+  );
+  @override
+  late final GeneratedColumn<String> weekStart = GeneratedColumn<String>(
+    'week_start',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _dayLabelMeta = const VerificationMeta(
+    'dayLabel',
+  );
+  @override
+  late final GeneratedColumn<String> dayLabel = GeneratedColumn<String>(
+    'day_label',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _typeMeta = const VerificationMeta('type');
+  @override
+  late final GeneratedColumn<String> type = GeneratedColumn<String>(
+    'type',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _minutesMeta = const VerificationMeta(
+    'minutes',
+  );
+  @override
+  late final GeneratedColumn<int> minutes = GeneratedColumn<int>(
+    'minutes',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _caloriesMeta = const VerificationMeta(
+    'calories',
+  );
+  @override
+  late final GeneratedColumn<int> calories = GeneratedColumn<int>(
+    'calories',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    weekStart,
+    dayLabel,
+    type,
+    minutes,
+    calories,
+    createdAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'exercise_sessions';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<ExerciseSessionRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('week_start')) {
+      context.handle(
+        _weekStartMeta,
+        weekStart.isAcceptableOrUnknown(data['week_start']!, _weekStartMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_weekStartMeta);
+    }
+    if (data.containsKey('day_label')) {
+      context.handle(
+        _dayLabelMeta,
+        dayLabel.isAcceptableOrUnknown(data['day_label']!, _dayLabelMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_dayLabelMeta);
+    }
+    if (data.containsKey('type')) {
+      context.handle(
+        _typeMeta,
+        type.isAcceptableOrUnknown(data['type']!, _typeMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_typeMeta);
+    }
+    if (data.containsKey('minutes')) {
+      context.handle(
+        _minutesMeta,
+        minutes.isAcceptableOrUnknown(data['minutes']!, _minutesMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_minutesMeta);
+    }
+    if (data.containsKey('calories')) {
+      context.handle(
+        _caloriesMeta,
+        calories.isAcceptableOrUnknown(data['calories']!, _caloriesMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_caloriesMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  ExerciseSessionRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return ExerciseSessionRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      weekStart: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}week_start'],
+      )!,
+      dayLabel: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}day_label'],
+      )!,
+      type: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}type'],
+      )!,
+      minutes: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}minutes'],
+      )!,
+      calories: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}calories'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+    );
+  }
+
+  @override
+  $ExerciseSessionsTable createAlias(String alias) {
+    return $ExerciseSessionsTable(attachedDatabase, alias);
+  }
+}
+
+class ExerciseSessionRow extends DataClass
+    implements Insertable<ExerciseSessionRow> {
+  final String id;
+  final String weekStart;
+  final String dayLabel;
+  final String type;
+  final int minutes;
+  final int calories;
+  final DateTime createdAt;
+  const ExerciseSessionRow({
+    required this.id,
+    required this.weekStart,
+    required this.dayLabel,
+    required this.type,
+    required this.minutes,
+    required this.calories,
+    required this.createdAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['week_start'] = Variable<String>(weekStart);
+    map['day_label'] = Variable<String>(dayLabel);
+    map['type'] = Variable<String>(type);
+    map['minutes'] = Variable<int>(minutes);
+    map['calories'] = Variable<int>(calories);
+    map['created_at'] = Variable<DateTime>(createdAt);
+    return map;
+  }
+
+  ExerciseSessionsCompanion toCompanion(bool nullToAbsent) {
+    return ExerciseSessionsCompanion(
+      id: Value(id),
+      weekStart: Value(weekStart),
+      dayLabel: Value(dayLabel),
+      type: Value(type),
+      minutes: Value(minutes),
+      calories: Value(calories),
+      createdAt: Value(createdAt),
+    );
+  }
+
+  factory ExerciseSessionRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return ExerciseSessionRow(
+      id: serializer.fromJson<String>(json['id']),
+      weekStart: serializer.fromJson<String>(json['weekStart']),
+      dayLabel: serializer.fromJson<String>(json['dayLabel']),
+      type: serializer.fromJson<String>(json['type']),
+      minutes: serializer.fromJson<int>(json['minutes']),
+      calories: serializer.fromJson<int>(json['calories']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'weekStart': serializer.toJson<String>(weekStart),
+      'dayLabel': serializer.toJson<String>(dayLabel),
+      'type': serializer.toJson<String>(type),
+      'minutes': serializer.toJson<int>(minutes),
+      'calories': serializer.toJson<int>(calories),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+    };
+  }
+
+  ExerciseSessionRow copyWith({
+    String? id,
+    String? weekStart,
+    String? dayLabel,
+    String? type,
+    int? minutes,
+    int? calories,
+    DateTime? createdAt,
+  }) => ExerciseSessionRow(
+    id: id ?? this.id,
+    weekStart: weekStart ?? this.weekStart,
+    dayLabel: dayLabel ?? this.dayLabel,
+    type: type ?? this.type,
+    minutes: minutes ?? this.minutes,
+    calories: calories ?? this.calories,
+    createdAt: createdAt ?? this.createdAt,
+  );
+  ExerciseSessionRow copyWithCompanion(ExerciseSessionsCompanion data) {
+    return ExerciseSessionRow(
+      id: data.id.present ? data.id.value : this.id,
+      weekStart: data.weekStart.present ? data.weekStart.value : this.weekStart,
+      dayLabel: data.dayLabel.present ? data.dayLabel.value : this.dayLabel,
+      type: data.type.present ? data.type.value : this.type,
+      minutes: data.minutes.present ? data.minutes.value : this.minutes,
+      calories: data.calories.present ? data.calories.value : this.calories,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ExerciseSessionRow(')
+          ..write('id: $id, ')
+          ..write('weekStart: $weekStart, ')
+          ..write('dayLabel: $dayLabel, ')
+          ..write('type: $type, ')
+          ..write('minutes: $minutes, ')
+          ..write('calories: $calories, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(id, weekStart, dayLabel, type, minutes, calories, createdAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is ExerciseSessionRow &&
+          other.id == this.id &&
+          other.weekStart == this.weekStart &&
+          other.dayLabel == this.dayLabel &&
+          other.type == this.type &&
+          other.minutes == this.minutes &&
+          other.calories == this.calories &&
+          other.createdAt == this.createdAt);
+}
+
+class ExerciseSessionsCompanion extends UpdateCompanion<ExerciseSessionRow> {
+  final Value<String> id;
+  final Value<String> weekStart;
+  final Value<String> dayLabel;
+  final Value<String> type;
+  final Value<int> minutes;
+  final Value<int> calories;
+  final Value<DateTime> createdAt;
+  final Value<int> rowid;
+  const ExerciseSessionsCompanion({
+    this.id = const Value.absent(),
+    this.weekStart = const Value.absent(),
+    this.dayLabel = const Value.absent(),
+    this.type = const Value.absent(),
+    this.minutes = const Value.absent(),
+    this.calories = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  ExerciseSessionsCompanion.insert({
+    required String id,
+    required String weekStart,
+    required String dayLabel,
+    required String type,
+    required int minutes,
+    required int calories,
+    this.createdAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       weekStart = Value(weekStart),
+       dayLabel = Value(dayLabel),
+       type = Value(type),
+       minutes = Value(minutes),
+       calories = Value(calories);
+  static Insertable<ExerciseSessionRow> custom({
+    Expression<String>? id,
+    Expression<String>? weekStart,
+    Expression<String>? dayLabel,
+    Expression<String>? type,
+    Expression<int>? minutes,
+    Expression<int>? calories,
+    Expression<DateTime>? createdAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (weekStart != null) 'week_start': weekStart,
+      if (dayLabel != null) 'day_label': dayLabel,
+      if (type != null) 'type': type,
+      if (minutes != null) 'minutes': minutes,
+      if (calories != null) 'calories': calories,
+      if (createdAt != null) 'created_at': createdAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  ExerciseSessionsCompanion copyWith({
+    Value<String>? id,
+    Value<String>? weekStart,
+    Value<String>? dayLabel,
+    Value<String>? type,
+    Value<int>? minutes,
+    Value<int>? calories,
+    Value<DateTime>? createdAt,
+    Value<int>? rowid,
+  }) {
+    return ExerciseSessionsCompanion(
+      id: id ?? this.id,
+      weekStart: weekStart ?? this.weekStart,
+      dayLabel: dayLabel ?? this.dayLabel,
+      type: type ?? this.type,
+      minutes: minutes ?? this.minutes,
+      calories: calories ?? this.calories,
+      createdAt: createdAt ?? this.createdAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (weekStart.present) {
+      map['week_start'] = Variable<String>(weekStart.value);
+    }
+    if (dayLabel.present) {
+      map['day_label'] = Variable<String>(dayLabel.value);
+    }
+    if (type.present) {
+      map['type'] = Variable<String>(type.value);
+    }
+    if (minutes.present) {
+      map['minutes'] = Variable<int>(minutes.value);
+    }
+    if (calories.present) {
+      map['calories'] = Variable<int>(calories.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ExerciseSessionsCompanion(')
+          ..write('id: $id, ')
+          ..write('weekStart: $weekStart, ')
+          ..write('dayLabel: $dayLabel, ')
+          ..write('type: $type, ')
+          ..write('minutes: $minutes, ')
+          ..write('calories: $calories, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $VitalsTable extends Vitals with TableInfo<$VitalsTable, VitalRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $VitalsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _kindMeta = const VerificationMeta('kind');
+  @override
+  late final GeneratedColumn<String> kind = GeneratedColumn<String>(
+    'kind',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _valueJsonMeta = const VerificationMeta(
+    'valueJson',
+  );
+  @override
+  late final GeneratedColumn<String> valueJson = GeneratedColumn<String>(
+    'value_json',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _recordedAtMeta = const VerificationMeta(
+    'recordedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> recordedAt = GeneratedColumn<DateTime>(
+    'recorded_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [id, kind, valueJson, recordedAt];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'vitals';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<VitalRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('kind')) {
+      context.handle(
+        _kindMeta,
+        kind.isAcceptableOrUnknown(data['kind']!, _kindMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_kindMeta);
+    }
+    if (data.containsKey('value_json')) {
+      context.handle(
+        _valueJsonMeta,
+        valueJson.isAcceptableOrUnknown(data['value_json']!, _valueJsonMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_valueJsonMeta);
+    }
+    if (data.containsKey('recorded_at')) {
+      context.handle(
+        _recordedAtMeta,
+        recordedAt.isAcceptableOrUnknown(data['recorded_at']!, _recordedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_recordedAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  VitalRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return VitalRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      kind: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}kind'],
+      )!,
+      valueJson: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}value_json'],
+      )!,
+      recordedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}recorded_at'],
+      )!,
+    );
+  }
+
+  @override
+  $VitalsTable createAlias(String alias) {
+    return $VitalsTable(attachedDatabase, alias);
+  }
+}
+
+class VitalRow extends DataClass implements Insertable<VitalRow> {
+  final String id;
+  final String kind;
+  final String valueJson;
+  final DateTime recordedAt;
+  const VitalRow({
+    required this.id,
+    required this.kind,
+    required this.valueJson,
+    required this.recordedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['kind'] = Variable<String>(kind);
+    map['value_json'] = Variable<String>(valueJson);
+    map['recorded_at'] = Variable<DateTime>(recordedAt);
+    return map;
+  }
+
+  VitalsCompanion toCompanion(bool nullToAbsent) {
+    return VitalsCompanion(
+      id: Value(id),
+      kind: Value(kind),
+      valueJson: Value(valueJson),
+      recordedAt: Value(recordedAt),
+    );
+  }
+
+  factory VitalRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return VitalRow(
+      id: serializer.fromJson<String>(json['id']),
+      kind: serializer.fromJson<String>(json['kind']),
+      valueJson: serializer.fromJson<String>(json['valueJson']),
+      recordedAt: serializer.fromJson<DateTime>(json['recordedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'kind': serializer.toJson<String>(kind),
+      'valueJson': serializer.toJson<String>(valueJson),
+      'recordedAt': serializer.toJson<DateTime>(recordedAt),
+    };
+  }
+
+  VitalRow copyWith({
+    String? id,
+    String? kind,
+    String? valueJson,
+    DateTime? recordedAt,
+  }) => VitalRow(
+    id: id ?? this.id,
+    kind: kind ?? this.kind,
+    valueJson: valueJson ?? this.valueJson,
+    recordedAt: recordedAt ?? this.recordedAt,
+  );
+  VitalRow copyWithCompanion(VitalsCompanion data) {
+    return VitalRow(
+      id: data.id.present ? data.id.value : this.id,
+      kind: data.kind.present ? data.kind.value : this.kind,
+      valueJson: data.valueJson.present ? data.valueJson.value : this.valueJson,
+      recordedAt: data.recordedAt.present
+          ? data.recordedAt.value
+          : this.recordedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('VitalRow(')
+          ..write('id: $id, ')
+          ..write('kind: $kind, ')
+          ..write('valueJson: $valueJson, ')
+          ..write('recordedAt: $recordedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, kind, valueJson, recordedAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is VitalRow &&
+          other.id == this.id &&
+          other.kind == this.kind &&
+          other.valueJson == this.valueJson &&
+          other.recordedAt == this.recordedAt);
+}
+
+class VitalsCompanion extends UpdateCompanion<VitalRow> {
+  final Value<String> id;
+  final Value<String> kind;
+  final Value<String> valueJson;
+  final Value<DateTime> recordedAt;
+  final Value<int> rowid;
+  const VitalsCompanion({
+    this.id = const Value.absent(),
+    this.kind = const Value.absent(),
+    this.valueJson = const Value.absent(),
+    this.recordedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  VitalsCompanion.insert({
+    required String id,
+    required String kind,
+    required String valueJson,
+    required DateTime recordedAt,
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       kind = Value(kind),
+       valueJson = Value(valueJson),
+       recordedAt = Value(recordedAt);
+  static Insertable<VitalRow> custom({
+    Expression<String>? id,
+    Expression<String>? kind,
+    Expression<String>? valueJson,
+    Expression<DateTime>? recordedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (kind != null) 'kind': kind,
+      if (valueJson != null) 'value_json': valueJson,
+      if (recordedAt != null) 'recorded_at': recordedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  VitalsCompanion copyWith({
+    Value<String>? id,
+    Value<String>? kind,
+    Value<String>? valueJson,
+    Value<DateTime>? recordedAt,
+    Value<int>? rowid,
+  }) {
+    return VitalsCompanion(
+      id: id ?? this.id,
+      kind: kind ?? this.kind,
+      valueJson: valueJson ?? this.valueJson,
+      recordedAt: recordedAt ?? this.recordedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (kind.present) {
+      map['kind'] = Variable<String>(kind.value);
+    }
+    if (valueJson.present) {
+      map['value_json'] = Variable<String>(valueJson.value);
+    }
+    if (recordedAt.present) {
+      map['recorded_at'] = Variable<DateTime>(recordedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('VitalsCompanion(')
+          ..write('id: $id, ')
+          ..write('kind: $kind, ')
+          ..write('valueJson: $valueJson, ')
+          ..write('recordedAt: $recordedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $ScheduleEventsTable extends ScheduleEvents
+    with TableInfo<$ScheduleEventsTable, ScheduleEventRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $ScheduleEventsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _dateMeta = const VerificationMeta('date');
+  @override
+  late final GeneratedColumn<String> date = GeneratedColumn<String>(
+    'date',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _timeMeta = const VerificationMeta('time');
+  @override
+  late final GeneratedColumn<String> time = GeneratedColumn<String>(
+    'time',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _titleMeta = const VerificationMeta('title');
+  @override
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+    'title',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _categoryMeta = const VerificationMeta(
+    'category',
+  );
+  @override
+  late final GeneratedColumn<String> category = GeneratedColumn<String>(
+    'category',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _emojiMeta = const VerificationMeta('emoji');
+  @override
+  late final GeneratedColumn<String> emoji = GeneratedColumn<String>(
+    'emoji',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(''),
+  );
+  static const VerificationMeta _colorHexMeta = const VerificationMeta(
+    'colorHex',
+  );
+  @override
+  late final GeneratedColumn<String> colorHex = GeneratedColumn<String>(
+    'color_hex',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('#E0F2F7'),
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    date,
+    time,
+    title,
+    category,
+    emoji,
+    colorHex,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'schedule_events';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<ScheduleEventRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('date')) {
+      context.handle(
+        _dateMeta,
+        date.isAcceptableOrUnknown(data['date']!, _dateMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_dateMeta);
+    }
+    if (data.containsKey('time')) {
+      context.handle(
+        _timeMeta,
+        time.isAcceptableOrUnknown(data['time']!, _timeMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_timeMeta);
+    }
+    if (data.containsKey('title')) {
+      context.handle(
+        _titleMeta,
+        title.isAcceptableOrUnknown(data['title']!, _titleMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_titleMeta);
+    }
+    if (data.containsKey('category')) {
+      context.handle(
+        _categoryMeta,
+        category.isAcceptableOrUnknown(data['category']!, _categoryMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_categoryMeta);
+    }
+    if (data.containsKey('emoji')) {
+      context.handle(
+        _emojiMeta,
+        emoji.isAcceptableOrUnknown(data['emoji']!, _emojiMeta),
+      );
+    }
+    if (data.containsKey('color_hex')) {
+      context.handle(
+        _colorHexMeta,
+        colorHex.isAcceptableOrUnknown(data['color_hex']!, _colorHexMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  ScheduleEventRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return ScheduleEventRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      date: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}date'],
+      )!,
+      time: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}time'],
+      )!,
+      title: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}title'],
+      )!,
+      category: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}category'],
+      )!,
+      emoji: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}emoji'],
+      )!,
+      colorHex: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}color_hex'],
+      )!,
+    );
+  }
+
+  @override
+  $ScheduleEventsTable createAlias(String alias) {
+    return $ScheduleEventsTable(attachedDatabase, alias);
+  }
+}
+
+class ScheduleEventRow extends DataClass
+    implements Insertable<ScheduleEventRow> {
+  final String id;
+  final String date;
+  final String time;
+  final String title;
+  final String category;
+  final String emoji;
+  final String colorHex;
+  const ScheduleEventRow({
+    required this.id,
+    required this.date,
+    required this.time,
+    required this.title,
+    required this.category,
+    required this.emoji,
+    required this.colorHex,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['date'] = Variable<String>(date);
+    map['time'] = Variable<String>(time);
+    map['title'] = Variable<String>(title);
+    map['category'] = Variable<String>(category);
+    map['emoji'] = Variable<String>(emoji);
+    map['color_hex'] = Variable<String>(colorHex);
+    return map;
+  }
+
+  ScheduleEventsCompanion toCompanion(bool nullToAbsent) {
+    return ScheduleEventsCompanion(
+      id: Value(id),
+      date: Value(date),
+      time: Value(time),
+      title: Value(title),
+      category: Value(category),
+      emoji: Value(emoji),
+      colorHex: Value(colorHex),
+    );
+  }
+
+  factory ScheduleEventRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return ScheduleEventRow(
+      id: serializer.fromJson<String>(json['id']),
+      date: serializer.fromJson<String>(json['date']),
+      time: serializer.fromJson<String>(json['time']),
+      title: serializer.fromJson<String>(json['title']),
+      category: serializer.fromJson<String>(json['category']),
+      emoji: serializer.fromJson<String>(json['emoji']),
+      colorHex: serializer.fromJson<String>(json['colorHex']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'date': serializer.toJson<String>(date),
+      'time': serializer.toJson<String>(time),
+      'title': serializer.toJson<String>(title),
+      'category': serializer.toJson<String>(category),
+      'emoji': serializer.toJson<String>(emoji),
+      'colorHex': serializer.toJson<String>(colorHex),
+    };
+  }
+
+  ScheduleEventRow copyWith({
+    String? id,
+    String? date,
+    String? time,
+    String? title,
+    String? category,
+    String? emoji,
+    String? colorHex,
+  }) => ScheduleEventRow(
+    id: id ?? this.id,
+    date: date ?? this.date,
+    time: time ?? this.time,
+    title: title ?? this.title,
+    category: category ?? this.category,
+    emoji: emoji ?? this.emoji,
+    colorHex: colorHex ?? this.colorHex,
+  );
+  ScheduleEventRow copyWithCompanion(ScheduleEventsCompanion data) {
+    return ScheduleEventRow(
+      id: data.id.present ? data.id.value : this.id,
+      date: data.date.present ? data.date.value : this.date,
+      time: data.time.present ? data.time.value : this.time,
+      title: data.title.present ? data.title.value : this.title,
+      category: data.category.present ? data.category.value : this.category,
+      emoji: data.emoji.present ? data.emoji.value : this.emoji,
+      colorHex: data.colorHex.present ? data.colorHex.value : this.colorHex,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ScheduleEventRow(')
+          ..write('id: $id, ')
+          ..write('date: $date, ')
+          ..write('time: $time, ')
+          ..write('title: $title, ')
+          ..write('category: $category, ')
+          ..write('emoji: $emoji, ')
+          ..write('colorHex: $colorHex')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(id, date, time, title, category, emoji, colorHex);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is ScheduleEventRow &&
+          other.id == this.id &&
+          other.date == this.date &&
+          other.time == this.time &&
+          other.title == this.title &&
+          other.category == this.category &&
+          other.emoji == this.emoji &&
+          other.colorHex == this.colorHex);
+}
+
+class ScheduleEventsCompanion extends UpdateCompanion<ScheduleEventRow> {
+  final Value<String> id;
+  final Value<String> date;
+  final Value<String> time;
+  final Value<String> title;
+  final Value<String> category;
+  final Value<String> emoji;
+  final Value<String> colorHex;
+  final Value<int> rowid;
+  const ScheduleEventsCompanion({
+    this.id = const Value.absent(),
+    this.date = const Value.absent(),
+    this.time = const Value.absent(),
+    this.title = const Value.absent(),
+    this.category = const Value.absent(),
+    this.emoji = const Value.absent(),
+    this.colorHex = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  ScheduleEventsCompanion.insert({
+    required String id,
+    required String date,
+    required String time,
+    required String title,
+    required String category,
+    this.emoji = const Value.absent(),
+    this.colorHex = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       date = Value(date),
+       time = Value(time),
+       title = Value(title),
+       category = Value(category);
+  static Insertable<ScheduleEventRow> custom({
+    Expression<String>? id,
+    Expression<String>? date,
+    Expression<String>? time,
+    Expression<String>? title,
+    Expression<String>? category,
+    Expression<String>? emoji,
+    Expression<String>? colorHex,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (date != null) 'date': date,
+      if (time != null) 'time': time,
+      if (title != null) 'title': title,
+      if (category != null) 'category': category,
+      if (emoji != null) 'emoji': emoji,
+      if (colorHex != null) 'color_hex': colorHex,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  ScheduleEventsCompanion copyWith({
+    Value<String>? id,
+    Value<String>? date,
+    Value<String>? time,
+    Value<String>? title,
+    Value<String>? category,
+    Value<String>? emoji,
+    Value<String>? colorHex,
+    Value<int>? rowid,
+  }) {
+    return ScheduleEventsCompanion(
+      id: id ?? this.id,
+      date: date ?? this.date,
+      time: time ?? this.time,
+      title: title ?? this.title,
+      category: category ?? this.category,
+      emoji: emoji ?? this.emoji,
+      colorHex: colorHex ?? this.colorHex,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (date.present) {
+      map['date'] = Variable<String>(date.value);
+    }
+    if (time.present) {
+      map['time'] = Variable<String>(time.value);
+    }
+    if (title.present) {
+      map['title'] = Variable<String>(title.value);
+    }
+    if (category.present) {
+      map['category'] = Variable<String>(category.value);
+    }
+    if (emoji.present) {
+      map['emoji'] = Variable<String>(emoji.value);
+    }
+    if (colorHex.present) {
+      map['color_hex'] = Variable<String>(colorHex.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ScheduleEventsCompanion(')
+          ..write('id: $id, ')
+          ..write('date: $date, ')
+          ..write('time: $time, ')
+          ..write('title: $title, ')
+          ..write('category: $category, ')
+          ..write('emoji: $emoji, ')
+          ..write('colorHex: $colorHex, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $NotificationItemsTable extends NotificationItems
+    with TableInfo<$NotificationItemsTable, NotificationRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $NotificationItemsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _titleMeta = const VerificationMeta('title');
+  @override
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+    'title',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _bodyMeta = const VerificationMeta('body');
+  @override
+  late final GeneratedColumn<String> body = GeneratedColumn<String>(
+    'body',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _categoryMeta = const VerificationMeta(
+    'category',
+  );
+  @override
+  late final GeneratedColumn<String> category = GeneratedColumn<String>(
+    'category',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _readMeta = const VerificationMeta('read');
+  @override
+  late final GeneratedColumn<bool> read = GeneratedColumn<bool>(
+    'read',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("read" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    createdAt,
+    title,
+    body,
+    category,
+    read,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'notification_items';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<NotificationRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    if (data.containsKey('title')) {
+      context.handle(
+        _titleMeta,
+        title.isAcceptableOrUnknown(data['title']!, _titleMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_titleMeta);
+    }
+    if (data.containsKey('body')) {
+      context.handle(
+        _bodyMeta,
+        body.isAcceptableOrUnknown(data['body']!, _bodyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_bodyMeta);
+    }
+    if (data.containsKey('category')) {
+      context.handle(
+        _categoryMeta,
+        category.isAcceptableOrUnknown(data['category']!, _categoryMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_categoryMeta);
+    }
+    if (data.containsKey('read')) {
+      context.handle(
+        _readMeta,
+        read.isAcceptableOrUnknown(data['read']!, _readMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  NotificationRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return NotificationRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      title: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}title'],
+      )!,
+      body: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}body'],
+      )!,
+      category: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}category'],
+      )!,
+      read: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}read'],
+      )!,
+    );
+  }
+
+  @override
+  $NotificationItemsTable createAlias(String alias) {
+    return $NotificationItemsTable(attachedDatabase, alias);
+  }
+}
+
+class NotificationRow extends DataClass implements Insertable<NotificationRow> {
+  final String id;
+  final DateTime createdAt;
+  final String title;
+  final String body;
+  final String category;
+  final bool read;
+  const NotificationRow({
+    required this.id,
+    required this.createdAt,
+    required this.title,
+    required this.body,
+    required this.category,
+    required this.read,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['created_at'] = Variable<DateTime>(createdAt);
+    map['title'] = Variable<String>(title);
+    map['body'] = Variable<String>(body);
+    map['category'] = Variable<String>(category);
+    map['read'] = Variable<bool>(read);
+    return map;
+  }
+
+  NotificationItemsCompanion toCompanion(bool nullToAbsent) {
+    return NotificationItemsCompanion(
+      id: Value(id),
+      createdAt: Value(createdAt),
+      title: Value(title),
+      body: Value(body),
+      category: Value(category),
+      read: Value(read),
+    );
+  }
+
+  factory NotificationRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return NotificationRow(
+      id: serializer.fromJson<String>(json['id']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      title: serializer.fromJson<String>(json['title']),
+      body: serializer.fromJson<String>(json['body']),
+      category: serializer.fromJson<String>(json['category']),
+      read: serializer.fromJson<bool>(json['read']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'title': serializer.toJson<String>(title),
+      'body': serializer.toJson<String>(body),
+      'category': serializer.toJson<String>(category),
+      'read': serializer.toJson<bool>(read),
+    };
+  }
+
+  NotificationRow copyWith({
+    String? id,
+    DateTime? createdAt,
+    String? title,
+    String? body,
+    String? category,
+    bool? read,
+  }) => NotificationRow(
+    id: id ?? this.id,
+    createdAt: createdAt ?? this.createdAt,
+    title: title ?? this.title,
+    body: body ?? this.body,
+    category: category ?? this.category,
+    read: read ?? this.read,
+  );
+  NotificationRow copyWithCompanion(NotificationItemsCompanion data) {
+    return NotificationRow(
+      id: data.id.present ? data.id.value : this.id,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      title: data.title.present ? data.title.value : this.title,
+      body: data.body.present ? data.body.value : this.body,
+      category: data.category.present ? data.category.value : this.category,
+      read: data.read.present ? data.read.value : this.read,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('NotificationRow(')
+          ..write('id: $id, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('title: $title, ')
+          ..write('body: $body, ')
+          ..write('category: $category, ')
+          ..write('read: $read')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, createdAt, title, body, category, read);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is NotificationRow &&
+          other.id == this.id &&
+          other.createdAt == this.createdAt &&
+          other.title == this.title &&
+          other.body == this.body &&
+          other.category == this.category &&
+          other.read == this.read);
+}
+
+class NotificationItemsCompanion extends UpdateCompanion<NotificationRow> {
+  final Value<String> id;
+  final Value<DateTime> createdAt;
+  final Value<String> title;
+  final Value<String> body;
+  final Value<String> category;
+  final Value<bool> read;
+  final Value<int> rowid;
+  const NotificationItemsCompanion({
+    this.id = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.title = const Value.absent(),
+    this.body = const Value.absent(),
+    this.category = const Value.absent(),
+    this.read = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  NotificationItemsCompanion.insert({
+    required String id,
+    required DateTime createdAt,
+    required String title,
+    required String body,
+    required String category,
+    this.read = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       createdAt = Value(createdAt),
+       title = Value(title),
+       body = Value(body),
+       category = Value(category);
+  static Insertable<NotificationRow> custom({
+    Expression<String>? id,
+    Expression<DateTime>? createdAt,
+    Expression<String>? title,
+    Expression<String>? body,
+    Expression<String>? category,
+    Expression<bool>? read,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (createdAt != null) 'created_at': createdAt,
+      if (title != null) 'title': title,
+      if (body != null) 'body': body,
+      if (category != null) 'category': category,
+      if (read != null) 'read': read,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  NotificationItemsCompanion copyWith({
+    Value<String>? id,
+    Value<DateTime>? createdAt,
+    Value<String>? title,
+    Value<String>? body,
+    Value<String>? category,
+    Value<bool>? read,
+    Value<int>? rowid,
+  }) {
+    return NotificationItemsCompanion(
+      id: id ?? this.id,
+      createdAt: createdAt ?? this.createdAt,
+      title: title ?? this.title,
+      body: body ?? this.body,
+      category: category ?? this.category,
+      read: read ?? this.read,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (title.present) {
+      map['title'] = Variable<String>(title.value);
+    }
+    if (body.present) {
+      map['body'] = Variable<String>(body.value);
+    }
+    if (category.present) {
+      map['category'] = Variable<String>(category.value);
+    }
+    if (read.present) {
+      map['read'] = Variable<bool>(read.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('NotificationItemsCompanion(')
+          ..write('id: $id, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('title: $title, ')
+          ..write('body: $body, ')
+          ..write('category: $category, ')
+          ..write('read: $read, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
   late final $AppKeyValuesTable appKeyValues = $AppKeyValuesTable(this);
+  late final $DietEntriesTable dietEntries = $DietEntriesTable(this);
+  late final $ExerciseSessionsTable exerciseSessions = $ExerciseSessionsTable(
+    this,
+  );
+  late final $VitalsTable vitals = $VitalsTable(this);
+  late final $ScheduleEventsTable scheduleEvents = $ScheduleEventsTable(this);
+  late final $NotificationItemsTable notificationItems =
+      $NotificationItemsTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
   @override
-  List<DatabaseSchemaEntity> get allSchemaEntities => [appKeyValues];
+  List<DatabaseSchemaEntity> get allSchemaEntities => [
+    appKeyValues,
+    dietEntries,
+    exerciseSessions,
+    vitals,
+    scheduleEvents,
+    notificationItems,
+  ];
 }
 
 typedef $$AppKeyValuesTableCreateCompanionBuilder =
@@ -361,10 +2544,1195 @@ typedef $$AppKeyValuesTableProcessedTableManager =
       AppKeyValue,
       PrefetchHooks Function()
     >;
+typedef $$DietEntriesTableCreateCompanionBuilder =
+    DietEntriesCompanion Function({
+      required String id,
+      required String date,
+      required String mealType,
+      required String timeLabel,
+      required String foodsJson,
+      required int totalCalories,
+      Value<int> sodiumMg,
+      Value<int> sugarG,
+      Value<DateTime> createdAt,
+      Value<int> rowid,
+    });
+typedef $$DietEntriesTableUpdateCompanionBuilder =
+    DietEntriesCompanion Function({
+      Value<String> id,
+      Value<String> date,
+      Value<String> mealType,
+      Value<String> timeLabel,
+      Value<String> foodsJson,
+      Value<int> totalCalories,
+      Value<int> sodiumMg,
+      Value<int> sugarG,
+      Value<DateTime> createdAt,
+      Value<int> rowid,
+    });
+
+class $$DietEntriesTableFilterComposer
+    extends Composer<_$AppDatabase, $DietEntriesTable> {
+  $$DietEntriesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get date => $composableBuilder(
+    column: $table.date,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get mealType => $composableBuilder(
+    column: $table.mealType,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get timeLabel => $composableBuilder(
+    column: $table.timeLabel,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get foodsJson => $composableBuilder(
+    column: $table.foodsJson,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get totalCalories => $composableBuilder(
+    column: $table.totalCalories,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get sodiumMg => $composableBuilder(
+    column: $table.sodiumMg,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get sugarG => $composableBuilder(
+    column: $table.sugarG,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$DietEntriesTableOrderingComposer
+    extends Composer<_$AppDatabase, $DietEntriesTable> {
+  $$DietEntriesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get date => $composableBuilder(
+    column: $table.date,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get mealType => $composableBuilder(
+    column: $table.mealType,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get timeLabel => $composableBuilder(
+    column: $table.timeLabel,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get foodsJson => $composableBuilder(
+    column: $table.foodsJson,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get totalCalories => $composableBuilder(
+    column: $table.totalCalories,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get sodiumMg => $composableBuilder(
+    column: $table.sodiumMg,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get sugarG => $composableBuilder(
+    column: $table.sugarG,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$DietEntriesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $DietEntriesTable> {
+  $$DietEntriesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get date =>
+      $composableBuilder(column: $table.date, builder: (column) => column);
+
+  GeneratedColumn<String> get mealType =>
+      $composableBuilder(column: $table.mealType, builder: (column) => column);
+
+  GeneratedColumn<String> get timeLabel =>
+      $composableBuilder(column: $table.timeLabel, builder: (column) => column);
+
+  GeneratedColumn<String> get foodsJson =>
+      $composableBuilder(column: $table.foodsJson, builder: (column) => column);
+
+  GeneratedColumn<int> get totalCalories => $composableBuilder(
+    column: $table.totalCalories,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get sodiumMg =>
+      $composableBuilder(column: $table.sodiumMg, builder: (column) => column);
+
+  GeneratedColumn<int> get sugarG =>
+      $composableBuilder(column: $table.sugarG, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+}
+
+class $$DietEntriesTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $DietEntriesTable,
+          DietEntryRow,
+          $$DietEntriesTableFilterComposer,
+          $$DietEntriesTableOrderingComposer,
+          $$DietEntriesTableAnnotationComposer,
+          $$DietEntriesTableCreateCompanionBuilder,
+          $$DietEntriesTableUpdateCompanionBuilder,
+          (
+            DietEntryRow,
+            BaseReferences<_$AppDatabase, $DietEntriesTable, DietEntryRow>,
+          ),
+          DietEntryRow,
+          PrefetchHooks Function()
+        > {
+  $$DietEntriesTableTableManager(_$AppDatabase db, $DietEntriesTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$DietEntriesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$DietEntriesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$DietEntriesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> date = const Value.absent(),
+                Value<String> mealType = const Value.absent(),
+                Value<String> timeLabel = const Value.absent(),
+                Value<String> foodsJson = const Value.absent(),
+                Value<int> totalCalories = const Value.absent(),
+                Value<int> sodiumMg = const Value.absent(),
+                Value<int> sugarG = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => DietEntriesCompanion(
+                id: id,
+                date: date,
+                mealType: mealType,
+                timeLabel: timeLabel,
+                foodsJson: foodsJson,
+                totalCalories: totalCalories,
+                sodiumMg: sodiumMg,
+                sugarG: sugarG,
+                createdAt: createdAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String date,
+                required String mealType,
+                required String timeLabel,
+                required String foodsJson,
+                required int totalCalories,
+                Value<int> sodiumMg = const Value.absent(),
+                Value<int> sugarG = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => DietEntriesCompanion.insert(
+                id: id,
+                date: date,
+                mealType: mealType,
+                timeLabel: timeLabel,
+                foodsJson: foodsJson,
+                totalCalories: totalCalories,
+                sodiumMg: sodiumMg,
+                sugarG: sugarG,
+                createdAt: createdAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$DietEntriesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $DietEntriesTable,
+      DietEntryRow,
+      $$DietEntriesTableFilterComposer,
+      $$DietEntriesTableOrderingComposer,
+      $$DietEntriesTableAnnotationComposer,
+      $$DietEntriesTableCreateCompanionBuilder,
+      $$DietEntriesTableUpdateCompanionBuilder,
+      (
+        DietEntryRow,
+        BaseReferences<_$AppDatabase, $DietEntriesTable, DietEntryRow>,
+      ),
+      DietEntryRow,
+      PrefetchHooks Function()
+    >;
+typedef $$ExerciseSessionsTableCreateCompanionBuilder =
+    ExerciseSessionsCompanion Function({
+      required String id,
+      required String weekStart,
+      required String dayLabel,
+      required String type,
+      required int minutes,
+      required int calories,
+      Value<DateTime> createdAt,
+      Value<int> rowid,
+    });
+typedef $$ExerciseSessionsTableUpdateCompanionBuilder =
+    ExerciseSessionsCompanion Function({
+      Value<String> id,
+      Value<String> weekStart,
+      Value<String> dayLabel,
+      Value<String> type,
+      Value<int> minutes,
+      Value<int> calories,
+      Value<DateTime> createdAt,
+      Value<int> rowid,
+    });
+
+class $$ExerciseSessionsTableFilterComposer
+    extends Composer<_$AppDatabase, $ExerciseSessionsTable> {
+  $$ExerciseSessionsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get weekStart => $composableBuilder(
+    column: $table.weekStart,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get dayLabel => $composableBuilder(
+    column: $table.dayLabel,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get type => $composableBuilder(
+    column: $table.type,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get minutes => $composableBuilder(
+    column: $table.minutes,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get calories => $composableBuilder(
+    column: $table.calories,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$ExerciseSessionsTableOrderingComposer
+    extends Composer<_$AppDatabase, $ExerciseSessionsTable> {
+  $$ExerciseSessionsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get weekStart => $composableBuilder(
+    column: $table.weekStart,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get dayLabel => $composableBuilder(
+    column: $table.dayLabel,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get type => $composableBuilder(
+    column: $table.type,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get minutes => $composableBuilder(
+    column: $table.minutes,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get calories => $composableBuilder(
+    column: $table.calories,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$ExerciseSessionsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $ExerciseSessionsTable> {
+  $$ExerciseSessionsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get weekStart =>
+      $composableBuilder(column: $table.weekStart, builder: (column) => column);
+
+  GeneratedColumn<String> get dayLabel =>
+      $composableBuilder(column: $table.dayLabel, builder: (column) => column);
+
+  GeneratedColumn<String> get type =>
+      $composableBuilder(column: $table.type, builder: (column) => column);
+
+  GeneratedColumn<int> get minutes =>
+      $composableBuilder(column: $table.minutes, builder: (column) => column);
+
+  GeneratedColumn<int> get calories =>
+      $composableBuilder(column: $table.calories, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+}
+
+class $$ExerciseSessionsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $ExerciseSessionsTable,
+          ExerciseSessionRow,
+          $$ExerciseSessionsTableFilterComposer,
+          $$ExerciseSessionsTableOrderingComposer,
+          $$ExerciseSessionsTableAnnotationComposer,
+          $$ExerciseSessionsTableCreateCompanionBuilder,
+          $$ExerciseSessionsTableUpdateCompanionBuilder,
+          (
+            ExerciseSessionRow,
+            BaseReferences<
+              _$AppDatabase,
+              $ExerciseSessionsTable,
+              ExerciseSessionRow
+            >,
+          ),
+          ExerciseSessionRow,
+          PrefetchHooks Function()
+        > {
+  $$ExerciseSessionsTableTableManager(
+    _$AppDatabase db,
+    $ExerciseSessionsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$ExerciseSessionsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$ExerciseSessionsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$ExerciseSessionsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> weekStart = const Value.absent(),
+                Value<String> dayLabel = const Value.absent(),
+                Value<String> type = const Value.absent(),
+                Value<int> minutes = const Value.absent(),
+                Value<int> calories = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => ExerciseSessionsCompanion(
+                id: id,
+                weekStart: weekStart,
+                dayLabel: dayLabel,
+                type: type,
+                minutes: minutes,
+                calories: calories,
+                createdAt: createdAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String weekStart,
+                required String dayLabel,
+                required String type,
+                required int minutes,
+                required int calories,
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => ExerciseSessionsCompanion.insert(
+                id: id,
+                weekStart: weekStart,
+                dayLabel: dayLabel,
+                type: type,
+                minutes: minutes,
+                calories: calories,
+                createdAt: createdAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$ExerciseSessionsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $ExerciseSessionsTable,
+      ExerciseSessionRow,
+      $$ExerciseSessionsTableFilterComposer,
+      $$ExerciseSessionsTableOrderingComposer,
+      $$ExerciseSessionsTableAnnotationComposer,
+      $$ExerciseSessionsTableCreateCompanionBuilder,
+      $$ExerciseSessionsTableUpdateCompanionBuilder,
+      (
+        ExerciseSessionRow,
+        BaseReferences<
+          _$AppDatabase,
+          $ExerciseSessionsTable,
+          ExerciseSessionRow
+        >,
+      ),
+      ExerciseSessionRow,
+      PrefetchHooks Function()
+    >;
+typedef $$VitalsTableCreateCompanionBuilder =
+    VitalsCompanion Function({
+      required String id,
+      required String kind,
+      required String valueJson,
+      required DateTime recordedAt,
+      Value<int> rowid,
+    });
+typedef $$VitalsTableUpdateCompanionBuilder =
+    VitalsCompanion Function({
+      Value<String> id,
+      Value<String> kind,
+      Value<String> valueJson,
+      Value<DateTime> recordedAt,
+      Value<int> rowid,
+    });
+
+class $$VitalsTableFilterComposer
+    extends Composer<_$AppDatabase, $VitalsTable> {
+  $$VitalsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get kind => $composableBuilder(
+    column: $table.kind,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get valueJson => $composableBuilder(
+    column: $table.valueJson,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get recordedAt => $composableBuilder(
+    column: $table.recordedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$VitalsTableOrderingComposer
+    extends Composer<_$AppDatabase, $VitalsTable> {
+  $$VitalsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get kind => $composableBuilder(
+    column: $table.kind,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get valueJson => $composableBuilder(
+    column: $table.valueJson,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get recordedAt => $composableBuilder(
+    column: $table.recordedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$VitalsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $VitalsTable> {
+  $$VitalsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get kind =>
+      $composableBuilder(column: $table.kind, builder: (column) => column);
+
+  GeneratedColumn<String> get valueJson =>
+      $composableBuilder(column: $table.valueJson, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get recordedAt => $composableBuilder(
+    column: $table.recordedAt,
+    builder: (column) => column,
+  );
+}
+
+class $$VitalsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $VitalsTable,
+          VitalRow,
+          $$VitalsTableFilterComposer,
+          $$VitalsTableOrderingComposer,
+          $$VitalsTableAnnotationComposer,
+          $$VitalsTableCreateCompanionBuilder,
+          $$VitalsTableUpdateCompanionBuilder,
+          (VitalRow, BaseReferences<_$AppDatabase, $VitalsTable, VitalRow>),
+          VitalRow,
+          PrefetchHooks Function()
+        > {
+  $$VitalsTableTableManager(_$AppDatabase db, $VitalsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$VitalsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$VitalsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$VitalsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> kind = const Value.absent(),
+                Value<String> valueJson = const Value.absent(),
+                Value<DateTime> recordedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => VitalsCompanion(
+                id: id,
+                kind: kind,
+                valueJson: valueJson,
+                recordedAt: recordedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String kind,
+                required String valueJson,
+                required DateTime recordedAt,
+                Value<int> rowid = const Value.absent(),
+              }) => VitalsCompanion.insert(
+                id: id,
+                kind: kind,
+                valueJson: valueJson,
+                recordedAt: recordedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$VitalsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $VitalsTable,
+      VitalRow,
+      $$VitalsTableFilterComposer,
+      $$VitalsTableOrderingComposer,
+      $$VitalsTableAnnotationComposer,
+      $$VitalsTableCreateCompanionBuilder,
+      $$VitalsTableUpdateCompanionBuilder,
+      (VitalRow, BaseReferences<_$AppDatabase, $VitalsTable, VitalRow>),
+      VitalRow,
+      PrefetchHooks Function()
+    >;
+typedef $$ScheduleEventsTableCreateCompanionBuilder =
+    ScheduleEventsCompanion Function({
+      required String id,
+      required String date,
+      required String time,
+      required String title,
+      required String category,
+      Value<String> emoji,
+      Value<String> colorHex,
+      Value<int> rowid,
+    });
+typedef $$ScheduleEventsTableUpdateCompanionBuilder =
+    ScheduleEventsCompanion Function({
+      Value<String> id,
+      Value<String> date,
+      Value<String> time,
+      Value<String> title,
+      Value<String> category,
+      Value<String> emoji,
+      Value<String> colorHex,
+      Value<int> rowid,
+    });
+
+class $$ScheduleEventsTableFilterComposer
+    extends Composer<_$AppDatabase, $ScheduleEventsTable> {
+  $$ScheduleEventsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get date => $composableBuilder(
+    column: $table.date,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get time => $composableBuilder(
+    column: $table.time,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get category => $composableBuilder(
+    column: $table.category,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get emoji => $composableBuilder(
+    column: $table.emoji,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get colorHex => $composableBuilder(
+    column: $table.colorHex,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$ScheduleEventsTableOrderingComposer
+    extends Composer<_$AppDatabase, $ScheduleEventsTable> {
+  $$ScheduleEventsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get date => $composableBuilder(
+    column: $table.date,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get time => $composableBuilder(
+    column: $table.time,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get category => $composableBuilder(
+    column: $table.category,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get emoji => $composableBuilder(
+    column: $table.emoji,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get colorHex => $composableBuilder(
+    column: $table.colorHex,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$ScheduleEventsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $ScheduleEventsTable> {
+  $$ScheduleEventsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get date =>
+      $composableBuilder(column: $table.date, builder: (column) => column);
+
+  GeneratedColumn<String> get time =>
+      $composableBuilder(column: $table.time, builder: (column) => column);
+
+  GeneratedColumn<String> get title =>
+      $composableBuilder(column: $table.title, builder: (column) => column);
+
+  GeneratedColumn<String> get category =>
+      $composableBuilder(column: $table.category, builder: (column) => column);
+
+  GeneratedColumn<String> get emoji =>
+      $composableBuilder(column: $table.emoji, builder: (column) => column);
+
+  GeneratedColumn<String> get colorHex =>
+      $composableBuilder(column: $table.colorHex, builder: (column) => column);
+}
+
+class $$ScheduleEventsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $ScheduleEventsTable,
+          ScheduleEventRow,
+          $$ScheduleEventsTableFilterComposer,
+          $$ScheduleEventsTableOrderingComposer,
+          $$ScheduleEventsTableAnnotationComposer,
+          $$ScheduleEventsTableCreateCompanionBuilder,
+          $$ScheduleEventsTableUpdateCompanionBuilder,
+          (
+            ScheduleEventRow,
+            BaseReferences<
+              _$AppDatabase,
+              $ScheduleEventsTable,
+              ScheduleEventRow
+            >,
+          ),
+          ScheduleEventRow,
+          PrefetchHooks Function()
+        > {
+  $$ScheduleEventsTableTableManager(
+    _$AppDatabase db,
+    $ScheduleEventsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$ScheduleEventsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$ScheduleEventsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$ScheduleEventsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> date = const Value.absent(),
+                Value<String> time = const Value.absent(),
+                Value<String> title = const Value.absent(),
+                Value<String> category = const Value.absent(),
+                Value<String> emoji = const Value.absent(),
+                Value<String> colorHex = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => ScheduleEventsCompanion(
+                id: id,
+                date: date,
+                time: time,
+                title: title,
+                category: category,
+                emoji: emoji,
+                colorHex: colorHex,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String date,
+                required String time,
+                required String title,
+                required String category,
+                Value<String> emoji = const Value.absent(),
+                Value<String> colorHex = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => ScheduleEventsCompanion.insert(
+                id: id,
+                date: date,
+                time: time,
+                title: title,
+                category: category,
+                emoji: emoji,
+                colorHex: colorHex,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$ScheduleEventsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $ScheduleEventsTable,
+      ScheduleEventRow,
+      $$ScheduleEventsTableFilterComposer,
+      $$ScheduleEventsTableOrderingComposer,
+      $$ScheduleEventsTableAnnotationComposer,
+      $$ScheduleEventsTableCreateCompanionBuilder,
+      $$ScheduleEventsTableUpdateCompanionBuilder,
+      (
+        ScheduleEventRow,
+        BaseReferences<_$AppDatabase, $ScheduleEventsTable, ScheduleEventRow>,
+      ),
+      ScheduleEventRow,
+      PrefetchHooks Function()
+    >;
+typedef $$NotificationItemsTableCreateCompanionBuilder =
+    NotificationItemsCompanion Function({
+      required String id,
+      required DateTime createdAt,
+      required String title,
+      required String body,
+      required String category,
+      Value<bool> read,
+      Value<int> rowid,
+    });
+typedef $$NotificationItemsTableUpdateCompanionBuilder =
+    NotificationItemsCompanion Function({
+      Value<String> id,
+      Value<DateTime> createdAt,
+      Value<String> title,
+      Value<String> body,
+      Value<String> category,
+      Value<bool> read,
+      Value<int> rowid,
+    });
+
+class $$NotificationItemsTableFilterComposer
+    extends Composer<_$AppDatabase, $NotificationItemsTable> {
+  $$NotificationItemsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get body => $composableBuilder(
+    column: $table.body,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get category => $composableBuilder(
+    column: $table.category,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get read => $composableBuilder(
+    column: $table.read,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$NotificationItemsTableOrderingComposer
+    extends Composer<_$AppDatabase, $NotificationItemsTable> {
+  $$NotificationItemsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get body => $composableBuilder(
+    column: $table.body,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get category => $composableBuilder(
+    column: $table.category,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get read => $composableBuilder(
+    column: $table.read,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$NotificationItemsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $NotificationItemsTable> {
+  $$NotificationItemsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<String> get title =>
+      $composableBuilder(column: $table.title, builder: (column) => column);
+
+  GeneratedColumn<String> get body =>
+      $composableBuilder(column: $table.body, builder: (column) => column);
+
+  GeneratedColumn<String> get category =>
+      $composableBuilder(column: $table.category, builder: (column) => column);
+
+  GeneratedColumn<bool> get read =>
+      $composableBuilder(column: $table.read, builder: (column) => column);
+}
+
+class $$NotificationItemsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $NotificationItemsTable,
+          NotificationRow,
+          $$NotificationItemsTableFilterComposer,
+          $$NotificationItemsTableOrderingComposer,
+          $$NotificationItemsTableAnnotationComposer,
+          $$NotificationItemsTableCreateCompanionBuilder,
+          $$NotificationItemsTableUpdateCompanionBuilder,
+          (
+            NotificationRow,
+            BaseReferences<
+              _$AppDatabase,
+              $NotificationItemsTable,
+              NotificationRow
+            >,
+          ),
+          NotificationRow,
+          PrefetchHooks Function()
+        > {
+  $$NotificationItemsTableTableManager(
+    _$AppDatabase db,
+    $NotificationItemsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$NotificationItemsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$NotificationItemsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$NotificationItemsTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<String> title = const Value.absent(),
+                Value<String> body = const Value.absent(),
+                Value<String> category = const Value.absent(),
+                Value<bool> read = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => NotificationItemsCompanion(
+                id: id,
+                createdAt: createdAt,
+                title: title,
+                body: body,
+                category: category,
+                read: read,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required DateTime createdAt,
+                required String title,
+                required String body,
+                required String category,
+                Value<bool> read = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => NotificationItemsCompanion.insert(
+                id: id,
+                createdAt: createdAt,
+                title: title,
+                body: body,
+                category: category,
+                read: read,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$NotificationItemsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $NotificationItemsTable,
+      NotificationRow,
+      $$NotificationItemsTableFilterComposer,
+      $$NotificationItemsTableOrderingComposer,
+      $$NotificationItemsTableAnnotationComposer,
+      $$NotificationItemsTableCreateCompanionBuilder,
+      $$NotificationItemsTableUpdateCompanionBuilder,
+      (
+        NotificationRow,
+        BaseReferences<_$AppDatabase, $NotificationItemsTable, NotificationRow>,
+      ),
+      NotificationRow,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
   $AppDatabaseManager(this._db);
   $$AppKeyValuesTableTableManager get appKeyValues =>
       $$AppKeyValuesTableTableManager(_db, _db.appKeyValues);
+  $$DietEntriesTableTableManager get dietEntries =>
+      $$DietEntriesTableTableManager(_db, _db.dietEntries);
+  $$ExerciseSessionsTableTableManager get exerciseSessions =>
+      $$ExerciseSessionsTableTableManager(_db, _db.exerciseSessions);
+  $$VitalsTableTableManager get vitals =>
+      $$VitalsTableTableManager(_db, _db.vitals);
+  $$ScheduleEventsTableTableManager get scheduleEvents =>
+      $$ScheduleEventsTableTableManager(_db, _db.scheduleEvents);
+  $$NotificationItemsTableTableManager get notificationItems =>
+      $$NotificationItemsTableTableManager(_db, _db.notificationItems);
 }

--- a/frontend/flutter/lib/core/storage/seed_data.dart
+++ b/frontend/flutter/lib/core/storage/seed_data.dart
@@ -1,0 +1,192 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+
+import 'package:oncare/core/storage/app_database.dart';
+
+/// Idempotent seeder. Runs at bootstrap; if the `seeded_v1` flag is
+/// already set in `AppKeyValues`, returns immediately. Otherwise it
+/// inserts the React prototype's mock data into the new resource
+/// tables.
+Future<void> seedIfEmpty(AppDatabase db) async {
+  final flag = await db.readValue('seeded_v1');
+  if (flag == 'true') return;
+
+  final today = _fmtDate(DateTime.now());
+  final weekStart = _fmtDate(_mondayOfThisWeek(DateTime.now()));
+
+  await db.transaction(() async {
+    // ---- Diet entries (3 meals for today) ----
+    await db.batch((Batch b) {
+      b.insertAll(db.dietEntries, <DietEntriesCompanion>[
+        DietEntriesCompanion.insert(
+          id: 'seed-diet-breakfast',
+          date: today,
+          mealType: 'breakfast',
+          timeLabel: '08:20',
+          foodsJson: jsonEncode(<Map<String, Object?>>[
+            <String, Object?>{'name': '오트밀', 'calories': 220},
+            <String, Object?>{'name': '바나나 1개', 'calories': 90},
+            <String, Object?>{'name': '아메리카노', 'calories': 5},
+          ]),
+          totalCalories: 315,
+          sodiumMg: const Value(380),
+          sugarG: const Value(18),
+        ),
+        DietEntriesCompanion.insert(
+          id: 'seed-diet-lunch',
+          date: today,
+          mealType: 'lunch',
+          timeLabel: '12:40',
+          foodsJson: jsonEncode(<Map<String, Object?>>[
+            <String, Object?>{'name': '닭가슴살 샐러드', 'calories': 380},
+            <String, Object?>{'name': '현미밥 반공기', 'calories': 150},
+          ]),
+          totalCalories: 530,
+          sodiumMg: const Value(1120),
+          sugarG: const Value(14),
+        ),
+        DietEntriesCompanion.insert(
+          id: 'seed-diet-dinner',
+          date: today,
+          mealType: 'dinner',
+          timeLabel: '19:00',
+          foodsJson: jsonEncode(<Map<String, Object?>>[
+            <String, Object?>{'name': '연어 스테이크', 'calories': 420},
+            <String, Object?>{'name': '구운 야채', 'calories': 155},
+          ]),
+          totalCalories: 575,
+          sodiumMg: const Value(600),
+          sugarG: const Value(13),
+        ),
+      ]);
+    });
+
+    // ---- Exercise sessions (6 sessions across this week) ----
+    await db.batch((Batch b) {
+      b.insertAll(db.exerciseSessions, <ExerciseSessionsCompanion>[
+        ExerciseSessionsCompanion.insert(
+          id: 'seed-ex-mon',
+          weekStart: weekStart,
+          dayLabel: '월',
+          type: 'cardio',
+          minutes: 30,
+          calories: 250,
+        ),
+        ExerciseSessionsCompanion.insert(
+          id: 'seed-ex-wed',
+          weekStart: weekStart,
+          dayLabel: '수',
+          type: 'strength',
+          minutes: 45,
+          calories: 320,
+        ),
+        ExerciseSessionsCompanion.insert(
+          id: 'seed-ex-thu',
+          weekStart: weekStart,
+          dayLabel: '목',
+          type: 'yoga',
+          minutes: 20,
+          calories: 100,
+        ),
+        ExerciseSessionsCompanion.insert(
+          id: 'seed-ex-fri',
+          weekStart: weekStart,
+          dayLabel: '금',
+          type: 'cardio',
+          minutes: 60,
+          calories: 480,
+        ),
+        ExerciseSessionsCompanion.insert(
+          id: 'seed-ex-sat',
+          weekStart: weekStart,
+          dayLabel: '토',
+          type: 'walking',
+          minutes: 35,
+          calories: 180,
+        ),
+        ExerciseSessionsCompanion.insert(
+          id: 'seed-ex-sun',
+          weekStart: weekStart,
+          dayLabel: '일',
+          type: 'strength',
+          minutes: 50,
+          calories: 360,
+        ),
+      ]);
+    });
+
+    // ---- Today's schedule (2 events) ----
+    await db.batch((Batch b) {
+      b.insertAll(db.scheduleEvents, <ScheduleEventsCompanion>[
+        ScheduleEventsCompanion.insert(
+          id: 'seed-evt-hospital',
+          date: today,
+          time: '10:00',
+          title: '병원 정기검진',
+          category: 'hospital',
+          emoji: const Value('🏥'),
+          colorHex: const Value('#FEE2E2'),
+        ),
+        ScheduleEventsCompanion.insert(
+          id: 'seed-evt-gym',
+          date: today,
+          time: '18:00',
+          title: '헬스장 운동',
+          category: 'exercise',
+          emoji: const Value('💪'),
+          colorHex: const Value('#DCFCE7'),
+        ),
+      ]);
+    });
+
+    // ---- Notifications ----
+    final now = DateTime.now();
+    await db.batch((Batch b) {
+      b.insertAll(db.notificationItems, <NotificationItemsCompanion>[
+        NotificationItemsCompanion.insert(
+          id: 'seed-noti-1',
+          createdAt: now.subtract(const Duration(minutes: 10)),
+          title: '식단 입력 알림',
+          body: '오늘 점심 입력이 비어있어요.',
+          category: 'reminder',
+        ),
+        NotificationItemsCompanion.insert(
+          id: 'seed-noti-2',
+          createdAt: now.subtract(const Duration(hours: 1)),
+          title: '운동 목표 달성',
+          body: '주간 운동 240분 달성!',
+          category: 'achievement',
+        ),
+        NotificationItemsCompanion.insert(
+          id: 'seed-noti-3',
+          createdAt: now.subtract(const Duration(hours: 3)),
+          title: '체중 측정 권장',
+          body: '오늘 체중을 기록해 보세요.',
+          category: 'health_check',
+          read: const Value(true),
+        ),
+        NotificationItemsCompanion.insert(
+          id: 'seed-noti-4',
+          createdAt: now.subtract(const Duration(days: 1)),
+          title: '서비스 점검 안내',
+          body: '내일 02:00~03:00 점검 예정입니다.',
+          category: 'system',
+          read: const Value(true),
+        ),
+      ]);
+    });
+  });
+
+  await db.putValue('seeded_v1', 'true');
+}
+
+String _fmtDate(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+DateTime _mondayOfThisWeek(DateTime now) {
+  final weekday = now.weekday; // 1 = Mon ... 7 = Sun
+  return DateTime(now.year, now.month, now.day - (weekday - 1));
+}

--- a/frontend/flutter/lib/core/storage/seed_data.dart
+++ b/frontend/flutter/lib/core/storage/seed_data.dart
@@ -140,6 +140,18 @@ Future<void> seedIfEmpty(AppDatabase db) async {
       ]);
     });
 
+    // ---- Vitals (latest blood sugar, matches React mock 95 mg/dL) ----
+    await db
+        .into(db.vitals)
+        .insert(
+          VitalsCompanion.insert(
+            id: 'seed-vital-bs',
+            kind: 'blood-sugar',
+            valueJson: jsonEncode(<String, Object?>{'mg_per_dl': 95}),
+            recordedAt: DateTime.now().subtract(const Duration(hours: 1)),
+          ),
+        );
+
     // ---- Notifications ----
     final now = DateTime.now();
     await db.batch((Batch b) {

--- a/frontend/flutter/lib/features/ai_coach/data/repositories/dio_ai_coach_repository.dart
+++ b/frontend/flutter/lib/features/ai_coach/data/repositories/dio_ai_coach_repository.dart
@@ -1,0 +1,15 @@
+import 'package:dio/dio.dart';
+
+import 'package:oncare/features/ai_coach/domain/entities/ai_coach_state.dart';
+import 'package:oncare/features/ai_coach/domain/repositories/ai_coach_repository.dart';
+
+class DioAiCoachRepository implements AiCoachRepository {
+  DioAiCoachRepository(this._dio);
+  final Dio _dio;
+
+  @override
+  Future<AiCoachState> fetchState() async {
+    final res = await _dio.get<Map<String, Object?>>('/ai-coach/feedback');
+    return AiCoachState.fromJson(res.data!);
+  }
+}

--- a/frontend/flutter/lib/features/ai_coach/domain/entities/ai_coach_state.dart
+++ b/frontend/flutter/lib/features/ai_coach/domain/entities/ai_coach_state.dart
@@ -1,10 +1,9 @@
 enum AiSuggestionTag { diet, exercise, sleep, hydration }
 
-AiSuggestionTag _tagFromString(String s) =>
-    AiSuggestionTag.values.firstWhere(
-      (t) => t.name == s,
-      orElse: () => AiSuggestionTag.diet,
-    );
+AiSuggestionTag _tagFromString(String s) => AiSuggestionTag.values.firstWhere(
+  (t) => t.name == s,
+  orElse: () => AiSuggestionTag.diet,
+);
 
 class AiSuggestion {
   const AiSuggestion({

--- a/frontend/flutter/lib/features/ai_coach/domain/entities/ai_coach_state.dart
+++ b/frontend/flutter/lib/features/ai_coach/domain/entities/ai_coach_state.dart
@@ -1,5 +1,11 @@
 enum AiSuggestionTag { diet, exercise, sleep, hydration }
 
+AiSuggestionTag _tagFromString(String s) =>
+    AiSuggestionTag.values.firstWhere(
+      (t) => t.name == s,
+      orElse: () => AiSuggestionTag.diet,
+    );
+
 class AiSuggestion {
   const AiSuggestion({
     required this.title,
@@ -10,10 +16,24 @@ class AiSuggestion {
   final String title;
   final String body;
   final AiSuggestionTag tag;
+
+  factory AiSuggestion.fromJson(Map<String, Object?> json) => AiSuggestion(
+    title: json['title']! as String,
+    body: json['body']! as String,
+    tag: _tagFromString(json['tag']! as String),
+  );
 }
 
 class AiCoachState {
   const AiCoachState({required this.greeting, required this.suggestions});
   final String greeting;
   final List<AiSuggestion> suggestions;
+
+  factory AiCoachState.fromJson(Map<String, Object?> json) => AiCoachState(
+    greeting: json['greeting']! as String,
+    suggestions: (json['suggestions']! as List<Object?>)
+        .cast<Map<String, Object?>>()
+        .map(AiSuggestion.fromJson)
+        .toList(),
+  );
 }

--- a/frontend/flutter/lib/features/ai_coach/presentation/controllers/ai_coach_controller.dart
+++ b/frontend/flutter/lib/features/ai_coach/presentation/controllers/ai_coach_controller.dart
@@ -1,11 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:oncare/features/ai_coach/data/repositories/mock_ai_coach_repository.dart';
+import 'package:oncare/core/network/dio_client.dart';
+import 'package:oncare/features/ai_coach/data/repositories/dio_ai_coach_repository.dart';
 import 'package:oncare/features/ai_coach/domain/entities/ai_coach_state.dart';
 import 'package:oncare/features/ai_coach/domain/repositories/ai_coach_repository.dart';
 
 final aiCoachRepositoryProvider = Provider<AiCoachRepository>(
-  (ref) => const MockAiCoachRepository(),
+  (ref) => DioAiCoachRepository(ref.watch(dioProvider)),
   name: 'aiCoachRepository',
 );
 

--- a/frontend/flutter/lib/features/dashboard/data/repositories/dio_dashboard_repository.dart
+++ b/frontend/flutter/lib/features/dashboard/data/repositories/dio_dashboard_repository.dart
@@ -1,0 +1,18 @@
+import 'package:dio/dio.dart';
+
+import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
+import 'package:oncare/features/dashboard/domain/repositories/dashboard_repository.dart';
+
+/// Network-side [DashboardRepository]. dev/local builds get served by
+/// `LocalApiInterceptor` (drift aggregation); prod hits FastAPI's
+/// `GET /dashboard/summary`.
+class DioDashboardRepository implements DashboardRepository {
+  DioDashboardRepository(this._dio);
+  final Dio _dio;
+
+  @override
+  Future<DashboardSummary> fetchSummary() async {
+    final res = await _dio.get<Map<String, Object?>>('/dashboard/summary');
+    return DashboardSummary.fromJson(res.data!);
+  }
+}

--- a/frontend/flutter/lib/features/dashboard/domain/entities/dashboard_summary.dart
+++ b/frontend/flutter/lib/features/dashboard/domain/entities/dashboard_summary.dart
@@ -20,6 +20,15 @@ class HealthIndicator {
 
   double get progress =>
       max == 0 ? 0 : (current / max).clamp(0.0, 1.0).toDouble();
+
+  factory HealthIndicator.fromJson(Map<String, Object?> json) =>
+      HealthIndicator(
+        label: json['label']! as String,
+        current: json['current']! as num,
+        max: json['max']! as num,
+        unit: json['unit']! as String,
+        overBudget: (json['over_budget'] as bool?) ?? false,
+      );
 }
 
 class ScheduleItem {
@@ -32,6 +41,12 @@ class ScheduleItem {
   final String time;
   final String title;
   final String emoji;
+
+  factory ScheduleItem.fromJson(Map<String, Object?> json) => ScheduleItem(
+    time: json['time']! as String,
+    title: json['title']! as String,
+    emoji: (json['emoji'] as String?) ?? '',
+  );
 }
 
 /// Snapshot displayed on the home dashboard. Mirrors the data the
@@ -67,4 +82,21 @@ class DashboardSummary {
   /// One-line warning shown above the indicator list when something
   /// is over budget (e.g. sodium intake).
   final String? sodiumWarning;
+
+  factory DashboardSummary.fromJson(Map<String, Object?> json) =>
+      DashboardSummary(
+        indicators: (json['indicators']! as List<Object?>)
+            .cast<Map<String, Object?>>()
+            .map(HealthIndicator.fromJson)
+            .toList(),
+        dietEntries: (json['diet_entries']! as num).toInt(),
+        exerciseMinutes: (json['exercise_minutes']! as num).toInt(),
+        todaySchedule: (json['today_schedule']! as List<Object?>)
+            .cast<Map<String, Object?>>()
+            .map(ScheduleItem.fromJson)
+            .toList(),
+        weekScore: (json['week_score']! as num).toInt(),
+        weekScoreDelta: (json['week_score_delta']! as num).toInt(),
+        sodiumWarning: json['sodium_warning'] as String?,
+      );
 }

--- a/frontend/flutter/lib/features/dashboard/presentation/controllers/dashboard_controller.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/controllers/dashboard_controller.dart
@@ -1,11 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:oncare/features/dashboard/data/repositories/mock_dashboard_repository.dart';
+import 'package:oncare/core/network/dio_client.dart';
+import 'package:oncare/features/dashboard/data/repositories/dio_dashboard_repository.dart';
 import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
 import 'package:oncare/features/dashboard/domain/repositories/dashboard_repository.dart';
 
 final dashboardRepositoryProvider = Provider<DashboardRepository>(
-  (ref) => const MockDashboardRepository(),
+  (ref) => DioDashboardRepository(ref.watch(dioProvider)),
   name: 'dashboardRepository',
 );
 

--- a/frontend/flutter/lib/features/diet/data/repositories/dio_diet_repository.dart
+++ b/frontend/flutter/lib/features/diet/data/repositories/dio_diet_repository.dart
@@ -1,0 +1,19 @@
+import 'package:dio/dio.dart';
+
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+import 'package:oncare/features/diet/domain/repositories/diet_repository.dart';
+
+/// Real-network implementation of [DietRepository]. Issues HTTP
+/// requests via [Dio]; the dev/local build serves them out of
+/// `LocalApiInterceptor` (drift-backed). FastAPI takes over once
+/// `USE_MOCK_API=false`.
+class DioDietRepository implements DietRepository {
+  DioDietRepository(this._dio);
+  final Dio _dio;
+
+  @override
+  Future<DietDay> fetchToday() async {
+    final res = await _dio.get<Map<String, Object?>>('/diet/days/today');
+    return DietDay.fromJson(res.data!);
+  }
+}

--- a/frontend/flutter/lib/features/diet/domain/entities/diet_day.dart
+++ b/frontend/flutter/lib/features/diet/domain/entities/diet_day.dart
@@ -1,13 +1,22 @@
 enum MealType { breakfast, lunch, dinner, snack }
 
+MealType _mealFromString(String s) =>
+    MealType.values.firstWhere((m) => m.name == s);
+
 class FoodItem {
   const FoodItem({required this.name, required this.calories});
   final String name;
   final int calories;
+
+  factory FoodItem.fromJson(Map<String, Object?> json) => FoodItem(
+    name: json['name']! as String,
+    calories: (json['calories']! as num).toInt(),
+  );
 }
 
 class DietEntry {
   const DietEntry({
+    this.id,
     required this.mealType,
     required this.timeLabel,
     required this.foods,
@@ -16,12 +25,26 @@ class DietEntry {
     this.sugarG = 0,
   });
 
+  final String? id;
   final MealType mealType;
   final String timeLabel;
   final List<FoodItem> foods;
   final int totalCalories;
   final int sodiumMg;
   final int sugarG;
+
+  factory DietEntry.fromJson(Map<String, Object?> json) => DietEntry(
+    id: json['id'] as String?,
+    mealType: _mealFromString(json['meal_type']! as String),
+    timeLabel: json['time_label']! as String,
+    foods: (json['foods']! as List<Object?>)
+        .cast<Map<String, Object?>>()
+        .map(FoodItem.fromJson)
+        .toList(),
+    totalCalories: (json['total_calories']! as num).toInt(),
+    sodiumMg: (json['sodium_mg'] as num?)?.toInt() ?? 0,
+    sugarG: (json['sugar_g'] as num?)?.toInt() ?? 0,
+  );
 }
 
 class DietMacros {
@@ -34,6 +57,12 @@ class DietMacros {
   final int carbsPct;
   final int proteinPct;
   final int fatPct;
+
+  factory DietMacros.fromJson(Map<String, Object?> json) => DietMacros(
+    carbsPct: (json['carbs_pct']! as num).toInt(),
+    proteinPct: (json['protein_pct']! as num).toInt(),
+    fatPct: (json['fat_pct']! as num).toInt(),
+  );
 }
 
 class DietDay {
@@ -51,7 +80,17 @@ class DietDay {
   final DietMacros macros;
   final int totalSodiumMg;
   final int totalSugarG;
-
-  /// One-line feedback shown in the AI coach card on the Diet tab.
   final String aiCoachMessage;
+
+  factory DietDay.fromJson(Map<String, Object?> json) => DietDay(
+    entries: (json['entries']! as List<Object?>)
+        .cast<Map<String, Object?>>()
+        .map(DietEntry.fromJson)
+        .toList(),
+    totalCalories: (json['total_calories']! as num).toInt(),
+    totalSodiumMg: (json['total_sodium_mg']! as num).toInt(),
+    totalSugarG: (json['total_sugar_g']! as num).toInt(),
+    macros: DietMacros.fromJson(json['macros']! as Map<String, Object?>),
+    aiCoachMessage: json['ai_coach_message']! as String,
+  );
 }

--- a/frontend/flutter/lib/features/diet/presentation/controllers/diet_controller.dart
+++ b/frontend/flutter/lib/features/diet/presentation/controllers/diet_controller.dart
@@ -1,11 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
+import 'package:oncare/core/network/dio_client.dart';
+import 'package:oncare/features/diet/data/repositories/dio_diet_repository.dart';
 import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/diet/domain/repositories/diet_repository.dart';
 
 final dietRepositoryProvider = Provider<DietRepository>(
-  (ref) => const MockDietRepository(),
+  (ref) => DioDietRepository(ref.watch(dioProvider)),
   name: 'dietRepository',
 );
 

--- a/frontend/flutter/lib/features/exercise/data/repositories/dio_exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/dio_exercise_repository.dart
@@ -1,0 +1,19 @@
+import 'package:dio/dio.dart';
+
+import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
+import 'package:oncare/features/exercise/domain/repositories/exercise_repository.dart';
+
+/// Network-side [ExerciseRepository]. dev/local builds get served by
+/// `LocalApiInterceptor` (drift-backed); prod hits FastAPI.
+class DioExerciseRepository implements ExerciseRepository {
+  DioExerciseRepository(this._dio);
+  final Dio _dio;
+
+  @override
+  Future<ExerciseWeek> fetchThisWeek() async {
+    final res = await _dio.get<Map<String, Object?>>(
+      '/exercise/weeks/current',
+    );
+    return ExerciseWeek.fromJson(res.data!);
+  }
+}

--- a/frontend/flutter/lib/features/exercise/data/repositories/dio_exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/dio_exercise_repository.dart
@@ -11,9 +11,7 @@ class DioExerciseRepository implements ExerciseRepository {
 
   @override
   Future<ExerciseWeek> fetchThisWeek() async {
-    final res = await _dio.get<Map<String, Object?>>(
-      '/exercise/weeks/current',
-    );
+    final res = await _dio.get<Map<String, Object?>>('/exercise/weeks/current');
     return ExerciseWeek.fromJson(res.data!);
   }
 }

--- a/frontend/flutter/lib/features/exercise/domain/entities/exercise_week.dart
+++ b/frontend/flutter/lib/features/exercise/domain/entities/exercise_week.dart
@@ -1,17 +1,31 @@
 enum ExerciseType { cardio, strength, yoga, walking }
 
+ExerciseType _exerciseTypeFromString(String s) =>
+    ExerciseType.values.firstWhere((t) => t.name == s);
+
 class ExerciseSession {
   const ExerciseSession({
+    this.id,
     required this.dayLabel,
     required this.type,
     required this.minutes,
     required this.calories,
   });
 
+  final String? id;
   final String dayLabel;
   final ExerciseType type;
   final int minutes;
   final int calories;
+
+  factory ExerciseSession.fromJson(Map<String, Object?> json) =>
+      ExerciseSession(
+        id: json['id'] as String?,
+        dayLabel: json['day_label']! as String,
+        type: _exerciseTypeFromString(json['type']! as String),
+        minutes: (json['minutes']! as num).toInt(),
+        calories: (json['calories']! as num).toInt(),
+      );
 }
 
 class ExerciseWeek {
@@ -34,4 +48,19 @@ class ExerciseWeek {
   final String aiCoachMessage;
 
   int get workoutCount => sessions.length;
+
+  factory ExerciseWeek.fromJson(Map<String, Object?> json) => ExerciseWeek(
+    sessions: (json['sessions']! as List<Object?>)
+        .cast<Map<String, Object?>>()
+        .map(ExerciseSession.fromJson)
+        .toList(),
+    dailyMinutes: (json['daily_minutes']! as List<Object?>)
+        .map((v) => (v! as num).toDouble())
+        .toList(),
+    dayLabels: (json['day_labels']! as List<Object?>).cast<String>().toList(),
+    totalMinutes: (json['total_minutes']! as num).toInt(),
+    totalCalories: (json['total_calories']! as num).toInt(),
+    streakDays: (json['streak_days']! as num).toInt(),
+    aiCoachMessage: json['ai_coach_message']! as String,
+  );
 }

--- a/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
@@ -1,11 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:oncare/features/exercise/data/repositories/mock_exercise_repository.dart';
+import 'package:oncare/core/network/dio_client.dart';
+import 'package:oncare/features/exercise/data/repositories/dio_exercise_repository.dart';
 import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 import 'package:oncare/features/exercise/domain/repositories/exercise_repository.dart';
 
 final exerciseRepositoryProvider = Provider<ExerciseRepository>(
-  (ref) => const MockExerciseRepository(),
+  (ref) => DioExerciseRepository(ref.watch(dioProvider)),
   name: 'exerciseRepository',
 );
 

--- a/frontend/flutter/lib/features/my_health/data/repositories/dio_my_health_repository.dart
+++ b/frontend/flutter/lib/features/my_health/data/repositories/dio_my_health_repository.dart
@@ -1,0 +1,15 @@
+import 'package:dio/dio.dart';
+
+import 'package:oncare/features/my_health/domain/entities/health_history.dart';
+import 'package:oncare/features/my_health/domain/repositories/my_health_repository.dart';
+
+class DioMyHealthRepository implements MyHealthRepository {
+  DioMyHealthRepository(this._dio);
+  final Dio _dio;
+
+  @override
+  Future<MyHealthState> fetchState() async {
+    final res = await _dio.get<Map<String, Object?>>('/users/me/health');
+    return MyHealthState.fromJson(res.data!);
+  }
+}

--- a/frontend/flutter/lib/features/my_health/domain/entities/health_history.dart
+++ b/frontend/flutter/lib/features/my_health/domain/entities/health_history.dart
@@ -11,8 +11,10 @@ class UserProfile {
 
 enum RiskLevel { low, medium, high }
 
-RiskLevel _riskFromString(String s) =>
-    RiskLevel.values.firstWhere((r) => r.name == s, orElse: () => RiskLevel.low);
+RiskLevel _riskFromString(String s) => RiskLevel.values.firstWhere(
+  (r) => r.name == s,
+  orElse: () => RiskLevel.low,
+);
 
 class RiskAlert {
   const RiskAlert({

--- a/frontend/flutter/lib/features/my_health/domain/entities/health_history.dart
+++ b/frontend/flutter/lib/features/my_health/domain/entities/health_history.dart
@@ -2,9 +2,17 @@ class UserProfile {
   const UserProfile({required this.name, required this.email});
   final String name;
   final String email;
+
+  factory UserProfile.fromJson(Map<String, Object?> json) => UserProfile(
+    name: json['name']! as String,
+    email: json['email']! as String,
+  );
 }
 
 enum RiskLevel { low, medium, high }
+
+RiskLevel _riskFromString(String s) =>
+    RiskLevel.values.firstWhere((r) => r.name == s, orElse: () => RiskLevel.low);
 
 class RiskAlert {
   const RiskAlert({
@@ -15,9 +23,23 @@ class RiskAlert {
   final String title;
   final String body;
   final RiskLevel level;
+
+  factory RiskAlert.fromJson(Map<String, Object?> json) => RiskAlert(
+    title: json['title']! as String,
+    body: json['body']! as String,
+    level: _riskFromString(json['level']! as String),
+  );
 }
 
 enum IndicatorKind { weight, bloodPressure, bloodSugar }
+
+/// Hyphenated wire form: weight | blood-pressure | blood-sugar.
+/// Same convention as `VitalKind` so the wire format stays consistent.
+IndicatorKind _indicatorFromWire(String s) => switch (s) {
+  'blood-pressure' => IndicatorKind.bloodPressure,
+  'blood-sugar' => IndicatorKind.bloodSugar,
+  _ => IndicatorKind.weight,
+};
 
 class IndicatorTrend {
   const IndicatorTrend({
@@ -39,12 +61,29 @@ class IndicatorTrend {
 
   /// Normalised series (0..1) used to paint the small inline sparkline.
   final List<double> last7Days;
+
+  factory IndicatorTrend.fromJson(Map<String, Object?> json) => IndicatorTrend(
+    kind: _indicatorFromWire(json['kind']! as String),
+    label: json['label']! as String,
+    latestValue: json['latest_value']! as String,
+    unit: json['unit']! as String,
+    deltaText: json['delta_text']! as String,
+    improving: json['improving']! as bool,
+    last7Days: (json['last_7_days']! as List<Object?>)
+        .map((v) => (v! as num).toDouble())
+        .toList(),
+  );
 }
 
 class SettingsItem {
   const SettingsItem({required this.label, required this.icon});
   final String label;
   final String icon; // emoji
+
+  factory SettingsItem.fromJson(Map<String, Object?> json) => SettingsItem(
+    label: json['label']! as String,
+    icon: json['icon']! as String,
+  );
 }
 
 class MyHealthState {
@@ -63,4 +102,19 @@ class MyHealthState {
   final int activityPoints;
   final int activityRank;
   final List<SettingsItem> settings;
+
+  factory MyHealthState.fromJson(Map<String, Object?> json) => MyHealthState(
+    profile: UserProfile.fromJson(json['profile']! as Map<String, Object?>),
+    risk: RiskAlert.fromJson(json['risk']! as Map<String, Object?>),
+    indicators: (json['indicators']! as List<Object?>)
+        .cast<Map<String, Object?>>()
+        .map(IndicatorTrend.fromJson)
+        .toList(),
+    activityPoints: (json['activity_points']! as num).toInt(),
+    activityRank: (json['activity_rank']! as num).toInt(),
+    settings: (json['settings']! as List<Object?>)
+        .cast<Map<String, Object?>>()
+        .map(SettingsItem.fromJson)
+        .toList(),
+  );
 }

--- a/frontend/flutter/lib/features/my_health/presentation/controllers/my_health_controller.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/controllers/my_health_controller.dart
@@ -1,11 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:oncare/features/my_health/data/repositories/mock_my_health_repository.dart';
+import 'package:oncare/core/network/dio_client.dart';
+import 'package:oncare/features/my_health/data/repositories/dio_my_health_repository.dart';
 import 'package:oncare/features/my_health/domain/entities/health_history.dart';
 import 'package:oncare/features/my_health/domain/repositories/my_health_repository.dart';
 
 final myHealthRepositoryProvider = Provider<MyHealthRepository>(
-  (ref) => const MockMyHealthRepository(),
+  (ref) => DioMyHealthRepository(ref.watch(dioProvider)),
   name: 'myHealthRepository',
 );
 

--- a/frontend/flutter/lib/features/notification/data/repositories/dio_notification_repository.dart
+++ b/frontend/flutter/lib/features/notification/data/repositories/dio_notification_repository.dart
@@ -1,0 +1,36 @@
+import 'package:dio/dio.dart';
+
+import 'package:oncare/features/notification/domain/entities/alert_item.dart';
+import 'package:oncare/features/notification/domain/repositories/notification_repository.dart';
+
+/// Network-side [NotificationRepository]. Calls go through `Dio`; the
+/// dev/local build short-circuits them in `LocalApiInterceptor`.
+class DioNotificationRepository implements NotificationRepository {
+  DioNotificationRepository(this._dio);
+  final Dio _dio;
+
+  @override
+  Future<List<AlertItem>> fetchAll() async {
+    final res = await _dio.get<List<Object?>>('/notifications');
+    final rows = res.data ?? const <Object?>[];
+    return rows.cast<Map<String, Object?>>().map(_fromJson).toList();
+  }
+
+  static AlertItem _fromJson(Map<String, Object?> json) {
+    return AlertItem(
+      id: json['id']! as String,
+      title: json['title']! as String,
+      body: json['body']! as String,
+      timeAgo: (json['time_ago'] as String?) ?? '',
+      category: _categoryFrom(json['category']! as String),
+      read: (json['read'] as bool?) ?? false,
+    );
+  }
+
+  static AlertCategory _categoryFrom(String s) => switch (s) {
+    'reminder' => AlertCategory.reminder,
+    'health_check' => AlertCategory.healthCheck,
+    'achievement' => AlertCategory.achievement,
+    _ => AlertCategory.system,
+  };
+}

--- a/frontend/flutter/lib/features/notification/data/repositories/mock_notification_repository.dart
+++ b/frontend/flutter/lib/features/notification/data/repositories/mock_notification_repository.dart
@@ -1,0 +1,43 @@
+import 'package:oncare/features/notification/domain/entities/alert_item.dart';
+import 'package:oncare/features/notification/domain/repositories/notification_repository.dart';
+
+class MockNotificationRepository implements NotificationRepository {
+  const MockNotificationRepository();
+
+  @override
+  Future<List<AlertItem>> fetchAll() async {
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+    return const <AlertItem>[
+      AlertItem(
+        id: 'a1',
+        title: '식단 입력 알림',
+        body: '오늘 점심 입력이 비어있어요.',
+        timeAgo: '10분 전',
+        category: AlertCategory.reminder,
+      ),
+      AlertItem(
+        id: 'a2',
+        title: '운동 목표 달성',
+        body: '주간 운동 240분 달성!',
+        timeAgo: '1시간 전',
+        category: AlertCategory.achievement,
+      ),
+      AlertItem(
+        id: 'a3',
+        title: '체중 측정 권장',
+        body: '오늘 체중을 기록해 보세요.',
+        timeAgo: '3시간 전',
+        category: AlertCategory.healthCheck,
+        read: true,
+      ),
+      AlertItem(
+        id: 'a4',
+        title: '서비스 점검 안내',
+        body: '내일 02:00~03:00 점검 예정입니다.',
+        timeAgo: '어제',
+        category: AlertCategory.system,
+        read: true,
+      ),
+    ];
+  }
+}

--- a/frontend/flutter/lib/features/notification/domain/repositories/notification_repository.dart
+++ b/frontend/flutter/lib/features/notification/domain/repositories/notification_repository.dart
@@ -1,0 +1,6 @@
+import 'package:oncare/features/notification/domain/entities/alert_item.dart';
+
+abstract class NotificationRepository {
+  /// All notifications, newest first.
+  Future<List<AlertItem>> fetchAll();
+}

--- a/frontend/flutter/lib/features/notification/presentation/controllers/notification_controller.dart
+++ b/frontend/flutter/lib/features/notification/presentation/controllers/notification_controller.dart
@@ -1,6 +1,9 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:oncare/core/network/dio_client.dart';
+import 'package:oncare/features/notification/data/repositories/dio_notification_repository.dart';
 import 'package:oncare/features/notification/domain/entities/alert_item.dart';
+import 'package:oncare/features/notification/domain/repositories/notification_repository.dart';
 
 class NotificationController extends StateNotifier<NotificationState> {
   NotificationController() : super(_seed());
@@ -76,3 +79,20 @@ final notificationControllerProvider =
       (ref) => NotificationController(),
       name: 'notifications',
     );
+
+/// Network-side notification source. Production code talks to dio →
+/// LocalApiInterceptor (drift) → FastAPI. Tests override this with a
+/// `MockNotificationRepository`.
+final notificationRepositoryProvider = Provider<NotificationRepository>(
+  (ref) => DioNotificationRepository(ref.watch(dioProvider)),
+  name: 'notificationRepository',
+);
+
+/// FutureProvider variant of the notifications list, sourced from the
+/// repo. The legacy [notificationControllerProvider] still holds the
+/// in-session mutations (markRead / simulatePush) — wholesale unifying
+/// is intentionally deferred to keep the UI/test surface stable.
+final notificationListProvider = FutureProvider.autoDispose<List<AlertItem>>(
+  (ref) => ref.watch(notificationRepositoryProvider).fetchAll(),
+  name: 'notificationList',
+);

--- a/frontend/flutter/lib/features/place/data/repositories/dio_place_repository.dart
+++ b/frontend/flutter/lib/features/place/data/repositories/dio_place_repository.dart
@@ -1,0 +1,16 @@
+import 'package:dio/dio.dart';
+
+import 'package:oncare/features/place/domain/entities/place.dart';
+import 'package:oncare/features/place/domain/repositories/place_repository.dart';
+
+class DioPlaceRepository implements PlaceRepository {
+  DioPlaceRepository(this._dio);
+  final Dio _dio;
+
+  @override
+  Future<List<Place>> nearbyPlaces() async {
+    final res = await _dio.get<List<Object?>>('/places/nearby');
+    final rows = res.data ?? const <Object?>[];
+    return rows.cast<Map<String, Object?>>().map(Place.fromJson).toList();
+  }
+}

--- a/frontend/flutter/lib/features/place/domain/entities/place.dart
+++ b/frontend/flutter/lib/features/place/domain/entities/place.dart
@@ -1,5 +1,13 @@
 enum PlaceCategory { medical, fitness, healthyFood, pharmacy }
 
+/// Wire form: `medical | fitness | healthy_food | pharmacy`.
+PlaceCategory _categoryFromWire(String s) => switch (s) {
+  'healthy_food' => PlaceCategory.healthyFood,
+  'fitness' => PlaceCategory.fitness,
+  'pharmacy' => PlaceCategory.pharmacy,
+  _ => PlaceCategory.medical,
+};
+
 class Place {
   const Place({
     required this.id,
@@ -18,4 +26,14 @@ class Place {
   final int distanceMeters;
   final double lat;
   final double lng;
+
+  factory Place.fromJson(Map<String, Object?> json) => Place(
+    id: json['id']! as String,
+    name: json['name']! as String,
+    category: _categoryFromWire(json['category']! as String),
+    address: json['address']! as String,
+    distanceMeters: (json['distance_meters']! as num).toInt(),
+    lat: (json['lat']! as num).toDouble(),
+    lng: (json['lng']! as num).toDouble(),
+  );
 }

--- a/frontend/flutter/lib/features/place/presentation/controllers/place_controller.dart
+++ b/frontend/flutter/lib/features/place/presentation/controllers/place_controller.dart
@@ -1,11 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:oncare/features/place/data/repositories/mock_place_repository.dart';
+import 'package:oncare/core/network/dio_client.dart';
+import 'package:oncare/features/place/data/repositories/dio_place_repository.dart';
 import 'package:oncare/features/place/domain/entities/place.dart';
 import 'package:oncare/features/place/domain/repositories/place_repository.dart';
 
 final placeRepositoryProvider = Provider<PlaceRepository>(
-  (ref) => const MockPlaceRepository(),
+  (ref) => DioPlaceRepository(ref.watch(dioProvider)),
   name: 'placeRepository',
 );
 

--- a/frontend/flutter/lib/features/schedule/data/repositories/dio_schedule_repository.dart
+++ b/frontend/flutter/lib/features/schedule/data/repositories/dio_schedule_repository.dart
@@ -1,0 +1,24 @@
+import 'package:dio/dio.dart';
+
+import 'package:oncare/features/schedule/domain/entities/schedule_event.dart';
+import 'package:oncare/features/schedule/domain/repositories/schedule_repository.dart';
+
+/// Network-side [ScheduleRepository]. dev/local builds get served by
+/// `LocalApiInterceptor`; prod hits FastAPI's `GET /schedule/events`.
+class DioScheduleRepository implements ScheduleRepository {
+  DioScheduleRepository(this._dio);
+  final Dio _dio;
+
+  @override
+  Future<List<ScheduleEvent>> fetchByDate(String date) async {
+    final res = await _dio.get<List<Object?>>(
+      '/schedule/events',
+      queryParameters: <String, Object?>{'date': date},
+    );
+    final rows = res.data ?? const <Object?>[];
+    return rows
+        .cast<Map<String, Object?>>()
+        .map(ScheduleEvent.fromJson)
+        .toList();
+  }
+}

--- a/frontend/flutter/lib/features/schedule/data/repositories/mock_schedule_repository.dart
+++ b/frontend/flutter/lib/features/schedule/data/repositories/mock_schedule_repository.dart
@@ -1,0 +1,31 @@
+import 'package:oncare/features/schedule/domain/entities/schedule_event.dart';
+import 'package:oncare/features/schedule/domain/repositories/schedule_repository.dart';
+
+class MockScheduleRepository implements ScheduleRepository {
+  const MockScheduleRepository();
+
+  @override
+  Future<List<ScheduleEvent>> fetchByDate(String date) async {
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+    return <ScheduleEvent>[
+      ScheduleEvent(
+        id: 'mock-hospital',
+        date: date,
+        time: '10:00',
+        title: '병원 정기검진',
+        category: ScheduleCategory.hospital,
+        emoji: '🏥',
+        colorHex: '#FEE2E2',
+      ),
+      ScheduleEvent(
+        id: 'mock-gym',
+        date: date,
+        time: '18:00',
+        title: '헬스장 운동',
+        category: ScheduleCategory.exercise,
+        emoji: '💪',
+        colorHex: '#DCFCE7',
+      ),
+    ];
+  }
+}

--- a/frontend/flutter/lib/features/schedule/domain/entities/schedule_event.dart
+++ b/frontend/flutter/lib/features/schedule/domain/entities/schedule_event.dart
@@ -1,0 +1,42 @@
+enum ScheduleCategory { hospital, exercise, meal, medication, other }
+
+ScheduleCategory _categoryFromString(String s) {
+  return ScheduleCategory.values.firstWhere(
+    (c) => c.name == s,
+    orElse: () => ScheduleCategory.other,
+  );
+}
+
+/// A user-visible event on today's calendar. Mirrors the React
+/// prototype's `ScheduleEvent` shape so a FastAPI build is a drop-in.
+class ScheduleEvent {
+  const ScheduleEvent({
+    required this.id,
+    required this.date,
+    required this.time,
+    required this.title,
+    required this.category,
+    this.emoji = '',
+    this.colorHex = '#E0F2F7',
+  });
+
+  final String id;
+  /// `YYYY-MM-DD`.
+  final String date;
+  /// `HH:MM`.
+  final String time;
+  final String title;
+  final ScheduleCategory category;
+  final String emoji;
+  final String colorHex;
+
+  factory ScheduleEvent.fromJson(Map<String, Object?> json) => ScheduleEvent(
+    id: json['id']! as String,
+    date: json['date']! as String,
+    time: json['time']! as String,
+    title: json['title']! as String,
+    category: _categoryFromString(json['category']! as String),
+    emoji: (json['emoji'] as String?) ?? '',
+    colorHex: (json['color_hex'] as String?) ?? '#E0F2F7',
+  );
+}

--- a/frontend/flutter/lib/features/schedule/domain/entities/schedule_event.dart
+++ b/frontend/flutter/lib/features/schedule/domain/entities/schedule_event.dart
@@ -21,8 +21,10 @@ class ScheduleEvent {
   });
 
   final String id;
+
   /// `YYYY-MM-DD`.
   final String date;
+
   /// `HH:MM`.
   final String time;
   final String title;

--- a/frontend/flutter/lib/features/schedule/domain/repositories/schedule_repository.dart
+++ b/frontend/flutter/lib/features/schedule/domain/repositories/schedule_repository.dart
@@ -1,0 +1,6 @@
+import 'package:oncare/features/schedule/domain/entities/schedule_event.dart';
+
+abstract class ScheduleRepository {
+  /// Events whose `date` matches the given `YYYY-MM-DD` string.
+  Future<List<ScheduleEvent>> fetchByDate(String date);
+}

--- a/frontend/flutter/lib/features/schedule/presentation/controllers/schedule_controller.dart
+++ b/frontend/flutter/lib/features/schedule/presentation/controllers/schedule_controller.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare/core/network/dio_client.dart';
+import 'package:oncare/features/schedule/data/repositories/dio_schedule_repository.dart';
+import 'package:oncare/features/schedule/domain/entities/schedule_event.dart';
+import 'package:oncare/features/schedule/domain/repositories/schedule_repository.dart';
+
+final scheduleRepositoryProvider = Provider<ScheduleRepository>(
+  (ref) => DioScheduleRepository(ref.watch(dioProvider)),
+  name: 'scheduleRepository',
+);
+
+/// Events for a given `YYYY-MM-DD` (defaults are read directly by the
+/// caller). Auto-disposes so navigating away frees the cache.
+final scheduleEventsProvider = FutureProvider.autoDispose
+    .family<List<ScheduleEvent>, String>(
+      (ref, date) => ref.watch(scheduleRepositoryProvider).fetchByDate(date),
+      name: 'scheduleEvents',
+    );

--- a/frontend/flutter/lib/features/vitals/data/repositories/dio_vitals_repository.dart
+++ b/frontend/flutter/lib/features/vitals/data/repositories/dio_vitals_repository.dart
@@ -1,0 +1,35 @@
+import 'package:dio/dio.dart';
+
+import 'package:oncare/features/vitals/domain/entities/vital.dart';
+import 'package:oncare/features/vitals/domain/repositories/vitals_repository.dart';
+
+/// Network-side [VitalsRepository]. Calls go through `Dio`; the
+/// dev/local build short-circuits them in `LocalApiInterceptor`,
+/// the prod build forwards to FastAPI.
+class DioVitalsRepository implements VitalsRepository {
+  DioVitalsRepository(this._dio);
+  final Dio _dio;
+
+  @override
+  Future<VitalRecord> submit(VitalSubmission submission) async {
+    final body = <String, Object?>{
+      ...submission.toJson(),
+      'recorded_at': DateTime.now().toIso8601String(),
+    };
+    final res = await _dio.post<Map<String, Object?>>(
+      '/vitals/${submission.kind.path}',
+      data: body,
+    );
+    return VitalRecord.fromJson(res.data!);
+  }
+
+  @override
+  Future<VitalRecord?> latest(VitalKind kind) async {
+    final res = await _dio.get<Map<String, Object?>>(
+      '/vitals/${kind.path}/latest',
+    );
+    final data = res.data;
+    if (data == null || data.isEmpty) return null;
+    return VitalRecord.fromJson(data);
+  }
+}

--- a/frontend/flutter/lib/features/vitals/data/repositories/mock_vitals_repository.dart
+++ b/frontend/flutter/lib/features/vitals/data/repositories/mock_vitals_repository.dart
@@ -1,0 +1,32 @@
+import 'package:oncare/features/vitals/domain/entities/vital.dart';
+import 'package:oncare/features/vitals/domain/repositories/vitals_repository.dart';
+
+/// In-memory [VitalsRepository] for tests. Submitted values stick
+/// around for the lifetime of the instance, so callers can verify
+/// `latest()` after `submit()`.
+class MockVitalsRepository implements VitalsRepository {
+  MockVitalsRepository();
+
+  final List<VitalRecord> _records = <VitalRecord>[];
+  int _seq = 0;
+
+  @override
+  Future<VitalRecord> submit(VitalSubmission submission) async {
+    _seq += 1;
+    final record = VitalRecord(
+      id: 'mock-vital-$_seq',
+      kind: submission.kind,
+      value: submission.toJson(),
+      recordedAt: DateTime.now(),
+    );
+    _records.add(record);
+    return record;
+  }
+
+  @override
+  Future<VitalRecord?> latest(VitalKind kind) async {
+    final matching = _records.where((r) => r.kind == kind).toList()
+      ..sort((a, b) => b.recordedAt.compareTo(a.recordedAt));
+    return matching.isEmpty ? null : matching.first;
+  }
+}

--- a/frontend/flutter/lib/features/vitals/domain/entities/vital.dart
+++ b/frontend/flutter/lib/features/vitals/domain/entities/vital.dart
@@ -1,0 +1,105 @@
+/// Vital sign domain primitives.
+///
+/// The React prototype's "Quick Input" modal (체중/혈압/혈당) submits
+/// one of three measurement shapes. We model them as a sealed family
+/// so the repository layer can serialize each one to the matching
+/// FastAPI endpoint without runtime guessing.
+library;
+
+/// The three measurement kinds the app records. The `path` segment
+/// matches the FastAPI route component (`/vitals/{path}`).
+enum VitalKind {
+  weight('weight'),
+  bloodPressure('blood-pressure'),
+  bloodSugar('blood-sugar');
+
+  const VitalKind(this.path);
+  final String path;
+
+  static VitalKind fromPath(String s) =>
+      VitalKind.values.firstWhere((k) => k.path == s);
+}
+
+/// What the UI hands to the repository when the user taps "저장하기".
+/// Sealed so each variant carries exactly the fields the corresponding
+/// endpoint expects.
+sealed class VitalSubmission {
+  const VitalSubmission();
+
+  VitalKind get kind;
+
+  /// snake_case map that becomes the POST body. `recorded_at` is added
+  /// by the repository so the UI doesn't have to think about clocks.
+  Map<String, Object?> toJson();
+}
+
+class WeightSubmission extends VitalSubmission {
+  const WeightSubmission({required this.kg});
+  final double kg;
+
+  @override
+  VitalKind get kind => VitalKind.weight;
+
+  @override
+  Map<String, Object?> toJson() => <String, Object?>{'kg': kg};
+}
+
+class BloodPressureSubmission extends VitalSubmission {
+  const BloodPressureSubmission({
+    required this.systolic,
+    required this.diastolic,
+  });
+  final int systolic;
+  final int diastolic;
+
+  @override
+  VitalKind get kind => VitalKind.bloodPressure;
+
+  @override
+  Map<String, Object?> toJson() => <String, Object?>{
+    'systolic': systolic,
+    'diastolic': diastolic,
+  };
+}
+
+class BloodSugarSubmission extends VitalSubmission {
+  const BloodSugarSubmission({required this.mgPerDl});
+  final int mgPerDl;
+
+  @override
+  VitalKind get kind => VitalKind.bloodSugar;
+
+  @override
+  Map<String, Object?> toJson() => <String, Object?>{'mg_per_dl': mgPerDl};
+}
+
+/// A persisted vital row. `value` keeps the snake_case map as the
+/// server sent it — UI code reads `value['kg']`, `value['systolic']`,
+/// `value['mg_per_dl']` etc.
+class VitalRecord {
+  const VitalRecord({
+    required this.id,
+    required this.kind,
+    required this.value,
+    required this.recordedAt,
+  });
+
+  final String id;
+  final VitalKind kind;
+  final Map<String, Object?> value;
+  final DateTime recordedAt;
+
+  factory VitalRecord.fromJson(Map<String, Object?> json) => VitalRecord(
+    id: json['id']! as String,
+    kind: VitalKind.fromPath(json['kind']! as String),
+    value: (json['value']! as Map<Object?, Object?>).cast<String, Object?>(),
+    recordedAt: DateTime.parse(json['recorded_at']! as String),
+  );
+
+  Map<String, Object?> toJson() => <String, Object?>{
+    'id': id,
+    'kind': kind.path,
+    'value': value,
+    'recorded_at': recordedAt.toIso8601String(),
+  };
+}

--- a/frontend/flutter/lib/features/vitals/domain/repositories/vitals_repository.dart
+++ b/frontend/flutter/lib/features/vitals/domain/repositories/vitals_repository.dart
@@ -1,0 +1,14 @@
+import 'package:oncare/features/vitals/domain/entities/vital.dart';
+
+/// Persistence + lookup contract for the Quick Input modal and
+/// MyHealth indicators. The Dio implementation (Stage 9.5+) hits
+/// `/vitals/{kind}` endpoints served by `LocalApiInterceptor`
+/// during dev; the FastAPI build will swap in for free.
+abstract class VitalsRepository {
+  /// Append a new reading. Returns the persisted [VitalRecord] so the
+  /// caller can read back the assigned `id` and `recordedAt`.
+  Future<VitalRecord> submit(VitalSubmission submission);
+
+  /// Latest reading of [kind], or null if the table is empty.
+  Future<VitalRecord?> latest(VitalKind kind);
+}

--- a/frontend/flutter/lib/features/vitals/presentation/controllers/vitals_controller.dart
+++ b/frontend/flutter/lib/features/vitals/presentation/controllers/vitals_controller.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare/core/network/dio_client.dart';
+import 'package:oncare/features/vitals/data/repositories/dio_vitals_repository.dart';
+import 'package:oncare/features/vitals/domain/entities/vital.dart';
+import 'package:oncare/features/vitals/domain/repositories/vitals_repository.dart';
+
+/// Production wiring: dio → LocalApiInterceptor (dev) / FastAPI (prod).
+/// Tests override this with a [MockVitalsRepository].
+final vitalsRepositoryProvider = Provider<VitalsRepository>(
+  (ref) => DioVitalsRepository(ref.watch(dioProvider)),
+  name: 'vitalsRepository',
+);
+
+/// Latest reading for a given [VitalKind]. Auto-disposes so the cache
+/// drops when no widget is listening — important after the user
+/// submits a new value via [vitalsRepositoryProvider], which calls
+/// `ref.invalidate` on this family.
+final latestVitalProvider = FutureProvider.autoDispose
+    .family<VitalRecord?, VitalKind>(
+      (ref, kind) => ref.watch(vitalsRepositoryProvider).latest(kind),
+      name: 'latestVital',
+    );

--- a/frontend/flutter/lib/shared/widgets/modals/quick_input_dialog.dart
+++ b/frontend/flutter/lib/shared/widgets/modals/quick_input_dialog.dart
@@ -1,16 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare/design_system/atoms/app_button.dart';
 import 'package:oncare/design_system/atoms/app_input.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/design_system/tokens/radius.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/vitals/domain/entities/vital.dart';
+import 'package:oncare/features/vitals/presentation/controllers/vitals_controller.dart';
 
 enum QuickInputKind { weight, bloodPressure, bloodSugar }
 
 /// Centered dialog that mirrors the React Dashboard's "체중/혈압/혈당
-/// 입력" modal. Saving is currently a no-op — we just close the dialog
-/// since real persistence belongs to a later stage.
+/// 입력" modal. Submitting now persists through [VitalsRepository] so
+/// the value survives the drift round-trip; the `latestVitalProvider`
+/// family is invalidated on success so MyHealth/Dashboard can refetch.
 Future<void> showQuickInputDialog(
   BuildContext context, {
   required QuickInputKind kind,
@@ -18,91 +22,176 @@ Future<void> showQuickInputDialog(
   return showDialog<void>(
     context: context,
     barrierColor: Colors.black54,
-    builder: (BuildContext ctx) {
-      final title = switch (kind) {
-        QuickInputKind.weight => '체중 입력',
-        QuickInputKind.bloodPressure => '혈압 입력',
-        QuickInputKind.bloodSugar => '혈당 입력',
-      };
-      return Dialog(
-        backgroundColor: AppColors.background,
-        shape: const RoundedRectangleBorder(
-          borderRadius: BorderRadius.all(AppRadius.card),
-        ),
-        insetPadding: const EdgeInsets.symmetric(
-          horizontal: AppSpacing.lg,
-          vertical: AppSpacing.xl,
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(AppSpacing.lg),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              Row(
-                children: <Widget>[
-                  Expanded(
-                    child: Text(
-                      title,
-                      style: Theme.of(ctx).textTheme.titleLarge?.copyWith(
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                  ),
-                  _CloseButton(onTap: () => Navigator.of(ctx).pop()),
-                ],
-              ),
-              const SizedBox(height: AppSpacing.md),
-              ..._fieldsFor(kind),
-              const SizedBox(height: AppSpacing.lg),
-              AppButton(
-                label: '저장하기',
-                fullWidth: true,
-                onPressed: () => Navigator.of(ctx).pop(),
-              ),
-            ],
-          ),
-        ),
-      );
-    },
+    builder: (BuildContext ctx) => _QuickInputDialog(kind: kind),
   );
 }
 
-List<Widget> _fieldsFor(QuickInputKind kind) {
-  return switch (kind) {
-    QuickInputKind.weight => const <Widget>[
-      AppInput(
-        label: '체중 (kg)',
-        hint: '72.0',
-        keyboardType: TextInputType.number,
-      ),
-    ],
-    QuickInputKind.bloodPressure => const <Widget>[
-      AppInput(
-        label: '수축기 (mmHg)',
-        hint: '120',
-        keyboardType: TextInputType.number,
-      ),
-      SizedBox(height: AppSpacing.sm),
-      AppInput(
-        label: '이완기 (mmHg)',
-        hint: '80',
-        keyboardType: TextInputType.number,
-      ),
-    ],
-    QuickInputKind.bloodSugar => const <Widget>[
-      AppInput(
-        label: '혈당 (mg/dL)',
-        hint: '95',
-        keyboardType: TextInputType.number,
-      ),
-    ],
+class _QuickInputDialog extends ConsumerStatefulWidget {
+  const _QuickInputDialog({required this.kind});
+  final QuickInputKind kind;
+
+  @override
+  ConsumerState<_QuickInputDialog> createState() => _QuickInputDialogState();
+}
+
+class _QuickInputDialogState extends ConsumerState<_QuickInputDialog> {
+  final TextEditingController _primary = TextEditingController();
+  final TextEditingController _secondary = TextEditingController();
+  bool _saving = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _primary.dispose();
+    _secondary.dispose();
+    super.dispose();
+  }
+
+  String get _title => switch (widget.kind) {
+    QuickInputKind.weight => '체중 입력',
+    QuickInputKind.bloodPressure => '혈압 입력',
+    QuickInputKind.bloodSugar => '혈당 입력',
   };
+
+  VitalSubmission? _buildSubmission() {
+    switch (widget.kind) {
+      case QuickInputKind.weight:
+        final kg = double.tryParse(_primary.text.trim());
+        if (kg == null || kg <= 0) return null;
+        return WeightSubmission(kg: kg);
+      case QuickInputKind.bloodPressure:
+        final s = int.tryParse(_primary.text.trim());
+        final d = int.tryParse(_secondary.text.trim());
+        if (s == null || d == null || s <= 0 || d <= 0) return null;
+        return BloodPressureSubmission(systolic: s, diastolic: d);
+      case QuickInputKind.bloodSugar:
+        final mg = int.tryParse(_primary.text.trim());
+        if (mg == null || mg <= 0) return null;
+        return BloodSugarSubmission(mgPerDl: mg);
+    }
+  }
+
+  Future<void> _save() async {
+    final submission = _buildSubmission();
+    if (submission == null) {
+      setState(() => _error = '값을 확인해 주세요.');
+      return;
+    }
+    setState(() {
+      _saving = true;
+      _error = null;
+    });
+    try {
+      final repo = ref.read(vitalsRepositoryProvider);
+      await repo.submit(submission);
+      // Refresh listeners (MyHealth IndicatorTile / Dashboard tiles).
+      ref.invalidate(latestVitalProvider(submission.kind));
+      if (!mounted) return;
+      Navigator.of(context).pop();
+    } catch (e) {
+      setState(() {
+        _saving = false;
+        _error = '저장 실패: $e';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: AppColors.background,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(AppRadius.card),
+      ),
+      insetPadding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.lg,
+        vertical: AppSpacing.xl,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: Text(
+                    _title,
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+                _CloseButton(
+                  onTap: _saving ? null : () => Navigator.of(context).pop(),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.md),
+            ..._fields(),
+            if (_error != null) ...<Widget>[
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                _error!,
+                style: const TextStyle(color: Colors.redAccent),
+              ),
+            ],
+            const SizedBox(height: AppSpacing.lg),
+            AppButton(
+              label: _saving ? '저장 중…' : '저장하기',
+              fullWidth: true,
+              onPressed: _saving ? null : _save,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _fields() {
+    switch (widget.kind) {
+      case QuickInputKind.weight:
+        return <Widget>[
+          AppInput(
+            controller: _primary,
+            label: '체중 (kg)',
+            hint: '72.0',
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+          ),
+        ];
+      case QuickInputKind.bloodPressure:
+        return <Widget>[
+          AppInput(
+            controller: _primary,
+            label: '수축기 (mmHg)',
+            hint: '120',
+            keyboardType: TextInputType.number,
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          AppInput(
+            controller: _secondary,
+            label: '이완기 (mmHg)',
+            hint: '80',
+            keyboardType: TextInputType.number,
+          ),
+        ];
+      case QuickInputKind.bloodSugar:
+        return <Widget>[
+          AppInput(
+            controller: _primary,
+            label: '혈당 (mg/dL)',
+            hint: '95',
+            keyboardType: TextInputType.number,
+          ),
+        ];
+    }
+  }
 }
 
 class _CloseButton extends StatelessWidget {
   const _CloseButton({required this.onTap});
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {

--- a/frontend/flutter/lib/shared/widgets/modals/quick_input_dialog.dart
+++ b/frontend/flutter/lib/shared/widgets/modals/quick_input_dialog.dart
@@ -132,10 +132,7 @@ class _QuickInputDialogState extends ConsumerState<_QuickInputDialog> {
             ..._fields(),
             if (_error != null) ...<Widget>[
               const SizedBox(height: AppSpacing.sm),
-              Text(
-                _error!,
-                style: const TextStyle(color: Colors.redAccent),
-              ),
+              Text(_error!, style: const TextStyle(color: Colors.redAccent)),
             ],
             const SizedBox(height: AppSpacing.lg),
             AppButton(

--- a/frontend/flutter/pubspec.yaml
+++ b/frontend/flutter/pubspec.yaml
@@ -3,7 +3,7 @@ description: "Oncare prototype reconstructed in Flutter (Android / iOS / Web)."
 publish_to: 'none'
 
 # Versioning is managed via --build-name / --build-number at build time.
-version: 0.2.0+2
+version: 0.3.0+3
 
 environment:
   sdk: ^3.10.0

--- a/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
@@ -1,0 +1,76 @@
+import 'package:dio/dio.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+
+import 'package:oncare/core/network/interceptors/local_api_interceptor.dart';
+import 'package:oncare/core/storage/app_database.dart';
+
+void main() {
+  late AppDatabase db;
+  late Dio dio;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    dio = Dio(BaseOptions(baseUrl: 'https://example.test'));
+    dio.interceptors.add(LocalApiInterceptor(db, Logger(level: Level.off)));
+  });
+
+  tearDown(() async {
+    await db.close();
+    dio.close();
+  });
+
+  test('GET /ai-coach/feedback returns greeting + 4 suggestions', () async {
+    final res = await dio.get<Map<String, Object?>>('/ai-coach/feedback');
+    expect(res.statusCode, 200);
+    expect(res.data!['greeting'], isNotEmpty);
+    final suggestions =
+        (res.data!['suggestions']! as List<Object?>).cast<Map<String, Object?>>();
+    expect(suggestions.length, 4);
+    final tags = suggestions.map((s) => s['tag']! as String).toSet();
+    expect(tags, containsAll(<String>['diet', 'exercise', 'sleep', 'hydration']));
+  });
+
+  test('GET /users/me returns the demo profile', () async {
+    final res = await dio.get<Map<String, Object?>>('/users/me');
+    expect(res.statusCode, 200);
+    expect(res.data!['email'], 'minsu@oncare.com');
+  });
+
+  test('GET /users/me/health returns the full MyHealthState shape', () async {
+    final res = await dio.get<Map<String, Object?>>('/users/me/health');
+    expect(res.statusCode, 200);
+    final body = res.data!;
+    expect((body['profile']! as Map)['name'], '김민수');
+    expect((body['risk']! as Map)['level'], 'medium');
+    final indicators =
+        (body['indicators']! as List<Object?>).cast<Map<String, Object?>>();
+    expect(indicators.length, 3);
+    expect(indicators.map((i) => i['kind']).toList(), <String>[
+      'weight',
+      'blood-pressure',
+      'blood-sugar',
+    ]);
+    expect(body['activity_points'], 1240);
+  });
+
+  test('GET /places/nearby returns four places with all categories', () async {
+    final res = await dio.get<List<Object?>>('/places/nearby');
+    expect(res.statusCode, 200);
+    final places = res.data!.cast<Map<String, Object?>>();
+    expect(places.length, 4);
+    final categories = places.map((p) => p['category']! as String).toSet();
+    expect(
+      categories,
+      containsAll(<String>['medical', 'fitness', 'healthy_food', 'pharmacy']),
+    );
+  });
+
+  test('GET /healthz returns drift-local marker', () async {
+    final res = await dio.get<Map<String, Object?>>('/healthz');
+    expect(res.statusCode, 200);
+    expect(res.data!['status'], 'ok');
+    expect(res.data!['backend'], 'drift-local');
+  });
+}

--- a/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
@@ -25,11 +25,14 @@ void main() {
     final res = await dio.get<Map<String, Object?>>('/ai-coach/feedback');
     expect(res.statusCode, 200);
     expect(res.data!['greeting'], isNotEmpty);
-    final suggestions =
-        (res.data!['suggestions']! as List<Object?>).cast<Map<String, Object?>>();
+    final suggestions = (res.data!['suggestions']! as List<Object?>)
+        .cast<Map<String, Object?>>();
     expect(suggestions.length, 4);
     final tags = suggestions.map((s) => s['tag']! as String).toSet();
-    expect(tags, containsAll(<String>['diet', 'exercise', 'sleep', 'hydration']));
+    expect(
+      tags,
+      containsAll(<String>['diet', 'exercise', 'sleep', 'hydration']),
+    );
   });
 
   test('GET /users/me returns the demo profile', () async {
@@ -44,8 +47,8 @@ void main() {
     final body = res.data!;
     expect((body['profile']! as Map)['name'], '김민수');
     expect((body['risk']! as Map)['level'], 'medium');
-    final indicators =
-        (body['indicators']! as List<Object?>).cast<Map<String, Object?>>();
+    final indicators = (body['indicators']! as List<Object?>)
+        .cast<Map<String, Object?>>();
     expect(indicators.length, 3);
     expect(indicators.map((i) => i['kind']).toList(), <String>[
       'weight',

--- a/frontend/flutter/test/core/network/local_api_interceptor_dashboard_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_dashboard_test.dart
@@ -1,0 +1,190 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+
+import 'package:oncare/core/network/interceptors/local_api_interceptor.dart';
+import 'package:oncare/core/storage/app_database.dart';
+
+const _weekdayLabels = <String>['월', '화', '수', '목', '금', '토', '일'];
+
+String _todayDateString() {
+  final now = DateTime.now();
+  return '${now.year.toString().padLeft(4, '0')}-'
+      '${now.month.toString().padLeft(2, '0')}-'
+      '${now.day.toString().padLeft(2, '0')}';
+}
+
+String _currentMonday() {
+  final now = DateTime.now();
+  final m = DateTime(now.year, now.month, now.day - (now.weekday - 1));
+  return '${m.year.toString().padLeft(4, '0')}-'
+      '${m.month.toString().padLeft(2, '0')}-'
+      '${m.day.toString().padLeft(2, '0')}';
+}
+
+void main() {
+  late AppDatabase db;
+  late Dio dio;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    dio = Dio(BaseOptions(baseUrl: 'https://example.test'));
+    dio.interceptors.add(LocalApiInterceptor(db, Logger(level: Level.off)));
+
+    final today = _todayDateString();
+    final ws = _currentMonday();
+    final todayLabel = _weekdayLabels[DateTime.now().weekday - 1];
+
+    // Diet rows that mirror the React mock totals.
+    await db.batch((b) {
+      b.insertAll(db.dietEntries, <DietEntriesCompanion>[
+        DietEntriesCompanion.insert(
+          id: 'd-b',
+          date: today,
+          mealType: 'breakfast',
+          timeLabel: '08:20',
+          foodsJson: jsonEncode(<Object?>[]),
+          totalCalories: 315,
+          sodiumMg: const Value(380),
+          sugarG: const Value(18),
+        ),
+        DietEntriesCompanion.insert(
+          id: 'd-l',
+          date: today,
+          mealType: 'lunch',
+          timeLabel: '12:40',
+          foodsJson: jsonEncode(<Object?>[]),
+          totalCalories: 530,
+          sodiumMg: const Value(1120),
+          sugarG: const Value(14),
+        ),
+        DietEntriesCompanion.insert(
+          id: 'd-d',
+          date: today,
+          mealType: 'dinner',
+          timeLabel: '19:00',
+          foodsJson: jsonEncode(<Object?>[]),
+          totalCalories: 575,
+          sodiumMg: const Value(600),
+          sugarG: const Value(13),
+        ),
+      ]);
+    });
+
+    // One session tagged to today's weekday — fixes the expected total
+    // regardless of when the test actually runs.
+    await db
+        .into(db.exerciseSessions)
+        .insert(
+          ExerciseSessionsCompanion.insert(
+            id: 'ex-today',
+            weekStart: ws,
+            dayLabel: todayLabel,
+            type: 'cardio',
+            minutes: 45,
+            calories: 320,
+          ),
+        );
+
+    // Latest blood-sugar reading.
+    await db
+        .into(db.vitals)
+        .insert(
+          VitalsCompanion.insert(
+            id: 'v-bs',
+            kind: 'blood-sugar',
+            valueJson: jsonEncode(<String, Object?>{'mg_per_dl': 95}),
+            recordedAt: DateTime.now().subtract(const Duration(minutes: 30)),
+          ),
+        );
+
+    // Today's schedule (matches the React mock).
+    await db.batch((b) {
+      b.insertAll(db.scheduleEvents, <ScheduleEventsCompanion>[
+        ScheduleEventsCompanion.insert(
+          id: 'evt-1',
+          date: today,
+          time: '10:00',
+          title: '병원 정기검진',
+          category: 'hospital',
+          emoji: const Value('🏥'),
+        ),
+        ScheduleEventsCompanion.insert(
+          id: 'evt-2',
+          date: today,
+          time: '18:00',
+          title: '헬스장 운동',
+          category: 'exercise',
+          emoji: const Value('💪'),
+        ),
+      ]);
+    });
+  });
+
+  tearDown(() async {
+    await db.close();
+    dio.close();
+  });
+
+  test('GET /dashboard/summary aggregates diet + exercise + vital + schedule', () async {
+    final res = await dio.get<Map<String, Object?>>('/dashboard/summary');
+    expect(res.statusCode, 200);
+    final body = res.data!;
+
+    // Indicators — 4 rows, matching React mock totals.
+    final indicators = (body['indicators']! as List<Object?>)
+        .cast<Map<String, Object?>>();
+    expect(indicators.length, 4);
+    final byLabel = <String, Map<String, Object?>>{
+      for (final i in indicators) i['label']! as String: i,
+    };
+    expect(byLabel['칼로리']!['current'], 1420);
+    expect(byLabel['나트륨']!['current'], 2100);
+    expect(byLabel['나트륨']!['over_budget'], isTrue);
+    expect(byLabel['당류']!['current'], 45);
+    expect(byLabel['혈당']!['current'], 95);
+
+    // Quick stats.
+    expect(body['diet_entries'], 3);
+    expect(body['exercise_minutes'], 45);
+
+    // Schedule.
+    final schedule = (body['today_schedule']! as List<Object?>)
+        .cast<Map<String, Object?>>();
+    expect(schedule.length, 2);
+    expect(schedule.first['title'], '병원 정기검진');
+
+    // Sodium warning is set when total > 2000.
+    expect(body['sodium_warning'], isNotNull);
+
+    // Week score is in the 0..100 band.
+    final score = body['week_score']! as int;
+    expect(score, inInclusiveRange(0, 100));
+  });
+
+  test('sodium_warning is null when total stays under budget', () async {
+    // Wipe and re-seed with a single low-sodium meal.
+    await (db.delete(db.dietEntries)).go();
+    await db
+        .into(db.dietEntries)
+        .insert(
+          DietEntriesCompanion.insert(
+            id: 'd-snack',
+            date: _todayDateString(),
+            mealType: 'snack',
+            timeLabel: '15:00',
+            foodsJson: jsonEncode(<Object?>[]),
+            totalCalories: 100,
+            sodiumMg: const Value(50),
+            sugarG: const Value(2),
+          ),
+        );
+
+    final res = await dio.get<Map<String, Object?>>('/dashboard/summary');
+    expect(res.data!['sodium_warning'], isNull);
+  });
+}

--- a/frontend/flutter/test/core/network/local_api_interceptor_dashboard_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_dashboard_test.dart
@@ -130,41 +130,44 @@ void main() {
     dio.close();
   });
 
-  test('GET /dashboard/summary aggregates diet + exercise + vital + schedule', () async {
-    final res = await dio.get<Map<String, Object?>>('/dashboard/summary');
-    expect(res.statusCode, 200);
-    final body = res.data!;
+  test(
+    'GET /dashboard/summary aggregates diet + exercise + vital + schedule',
+    () async {
+      final res = await dio.get<Map<String, Object?>>('/dashboard/summary');
+      expect(res.statusCode, 200);
+      final body = res.data!;
 
-    // Indicators — 4 rows, matching React mock totals.
-    final indicators = (body['indicators']! as List<Object?>)
-        .cast<Map<String, Object?>>();
-    expect(indicators.length, 4);
-    final byLabel = <String, Map<String, Object?>>{
-      for (final i in indicators) i['label']! as String: i,
-    };
-    expect(byLabel['칼로리']!['current'], 1420);
-    expect(byLabel['나트륨']!['current'], 2100);
-    expect(byLabel['나트륨']!['over_budget'], isTrue);
-    expect(byLabel['당류']!['current'], 45);
-    expect(byLabel['혈당']!['current'], 95);
+      // Indicators — 4 rows, matching React mock totals.
+      final indicators = (body['indicators']! as List<Object?>)
+          .cast<Map<String, Object?>>();
+      expect(indicators.length, 4);
+      final byLabel = <String, Map<String, Object?>>{
+        for (final i in indicators) i['label']! as String: i,
+      };
+      expect(byLabel['칼로리']!['current'], 1420);
+      expect(byLabel['나트륨']!['current'], 2100);
+      expect(byLabel['나트륨']!['over_budget'], isTrue);
+      expect(byLabel['당류']!['current'], 45);
+      expect(byLabel['혈당']!['current'], 95);
 
-    // Quick stats.
-    expect(body['diet_entries'], 3);
-    expect(body['exercise_minutes'], 45);
+      // Quick stats.
+      expect(body['diet_entries'], 3);
+      expect(body['exercise_minutes'], 45);
 
-    // Schedule.
-    final schedule = (body['today_schedule']! as List<Object?>)
-        .cast<Map<String, Object?>>();
-    expect(schedule.length, 2);
-    expect(schedule.first['title'], '병원 정기검진');
+      // Schedule.
+      final schedule = (body['today_schedule']! as List<Object?>)
+          .cast<Map<String, Object?>>();
+      expect(schedule.length, 2);
+      expect(schedule.first['title'], '병원 정기검진');
 
-    // Sodium warning is set when total > 2000.
-    expect(body['sodium_warning'], isNotNull);
+      // Sodium warning is set when total > 2000.
+      expect(body['sodium_warning'], isNotNull);
 
-    // Week score is in the 0..100 band.
-    final score = body['week_score']! as int;
-    expect(score, inInclusiveRange(0, 100));
-  });
+      // Week score is in the 0..100 band.
+      final score = body['week_score']! as int;
+      expect(score, inInclusiveRange(0, 100));
+    },
+  );
 
   test('sodium_warning is null when total stays under budget', () async {
     // Wipe and re-seed with a single low-sodium meal.

--- a/frontend/flutter/test/core/network/local_api_interceptor_exercise_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_exercise_test.dart
@@ -1,0 +1,131 @@
+import 'package:dio/dio.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+
+import 'package:oncare/core/network/interceptors/local_api_interceptor.dart';
+import 'package:oncare/core/storage/app_database.dart';
+
+String _currentMonday() {
+  final now = DateTime.now();
+  final m = DateTime(now.year, now.month, now.day - (now.weekday - 1));
+  return '${m.year.toString().padLeft(4, '0')}-'
+      '${m.month.toString().padLeft(2, '0')}-'
+      '${m.day.toString().padLeft(2, '0')}';
+}
+
+void main() {
+  late AppDatabase db;
+  late Dio dio;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    dio = Dio(BaseOptions(baseUrl: 'https://example.test'));
+    dio.interceptors.add(LocalApiInterceptor(db, Logger(level: Level.off)));
+
+    // Seed a few sessions for the current week — same shape the
+    // production `seedIfEmpty` would have written.
+    final ws = _currentMonday();
+    await db.batch((b) {
+      b.insertAll(db.exerciseSessions, <ExerciseSessionsCompanion>[
+        ExerciseSessionsCompanion.insert(
+          id: 'ex-mon',
+          weekStart: ws,
+          dayLabel: '월',
+          type: 'cardio',
+          minutes: 30,
+          calories: 250,
+        ),
+        ExerciseSessionsCompanion.insert(
+          id: 'ex-wed',
+          weekStart: ws,
+          dayLabel: '수',
+          type: 'strength',
+          minutes: 45,
+          calories: 320,
+        ),
+        ExerciseSessionsCompanion.insert(
+          id: 'ex-fri',
+          weekStart: ws,
+          dayLabel: '금',
+          type: 'cardio',
+          minutes: 60,
+          calories: 480,
+        ),
+      ]);
+    });
+  });
+
+  tearDown(() async {
+    await db.close();
+    dio.close();
+  });
+
+  test(
+    'GET /exercise/weeks/current aggregates daily minutes Mon..Sun',
+    () async {
+      final res = await dio.get<Map<String, Object?>>(
+        '/exercise/weeks/current',
+      );
+      expect(res.statusCode, 200);
+      final body = res.data!;
+
+      final daily = (body['daily_minutes']! as List<Object?>)
+          .cast<num>()
+          .toList();
+      // Mon=30, Tue=0, Wed=45, Thu=0, Fri=60, Sat=0, Sun=0.
+      expect(daily, <num>[30, 0, 45, 0, 60, 0, 0]);
+
+      expect(body['total_minutes'], 135);
+      expect(body['total_calories'], 1050);
+      // Three non-zero days.
+      expect(body['streak_days'], 3);
+      // Day labels are always Mon..Sun in Korean.
+      expect(body['day_labels'], <String>['월', '화', '수', '목', '금', '토', '일']);
+    },
+  );
+
+  test('weeks/current ignores rows from other weeks', () async {
+    // Inject a row tagged to a different weekStart — it shouldn't show up.
+    await db
+        .into(db.exerciseSessions)
+        .insert(
+          ExerciseSessionsCompanion.insert(
+            id: 'ex-old',
+            weekStart: '2000-01-03', // arbitrary Monday in the past
+            dayLabel: '월',
+            type: 'cardio',
+            minutes: 999,
+            calories: 9999,
+          ),
+        );
+    final res = await dio.get<Map<String, Object?>>(
+      '/exercise/weeks/current',
+    );
+    final daily = (res.data!['daily_minutes']! as List<Object?>)
+        .cast<num>()
+        .toList();
+    expect(daily.first, 30); // monday still 30 — old row was filtered out
+  });
+
+  test('weeks/current returns zeros + empty list when no rows', () async {
+    // Fresh DB with no inserts.
+    await db.close();
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    final freshDio = Dio(BaseOptions(baseUrl: 'https://example.test'));
+    addTearDown(() async {
+      freshDio.close();
+    });
+    freshDio.interceptors.add(
+      LocalApiInterceptor(db, Logger(level: Level.off)),
+    );
+    final res = await freshDio.get<Map<String, Object?>>(
+      '/exercise/weeks/current',
+    );
+    final body = res.data!;
+    expect(body['total_minutes'], 0);
+    expect(body['total_calories'], 0);
+    expect(body['streak_days'], 0);
+    expect((body['sessions']! as List<Object?>), isEmpty);
+  });
+}

--- a/frontend/flutter/test/core/network/local_api_interceptor_exercise_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_exercise_test.dart
@@ -99,9 +99,7 @@ void main() {
             calories: 9999,
           ),
         );
-    final res = await dio.get<Map<String, Object?>>(
-      '/exercise/weeks/current',
-    );
+    final res = await dio.get<Map<String, Object?>>('/exercise/weeks/current');
     final daily = (res.data!['daily_minutes']! as List<Object?>)
         .cast<num>()
         .toList();

--- a/frontend/flutter/test/core/network/local_api_interceptor_notifications_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_notifications_test.dart
@@ -1,0 +1,73 @@
+import 'package:dio/dio.dart';
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+
+import 'package:oncare/core/network/interceptors/local_api_interceptor.dart';
+import 'package:oncare/core/storage/app_database.dart';
+
+void main() {
+  late AppDatabase db;
+  late Dio dio;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    dio = Dio(BaseOptions(baseUrl: 'https://example.test'));
+    dio.interceptors.add(LocalApiInterceptor(db, Logger(level: Level.off)));
+
+    final now = DateTime.now();
+    await db.batch((b) {
+      b.insertAll(db.notificationItems, <NotificationItemsCompanion>[
+        NotificationItemsCompanion.insert(
+          id: 'n-1',
+          createdAt: now.subtract(const Duration(minutes: 10)),
+          title: '식단 입력 알림',
+          body: '오늘 점심 입력이 비어있어요.',
+          category: 'reminder',
+        ),
+        NotificationItemsCompanion.insert(
+          id: 'n-2',
+          createdAt: now.subtract(const Duration(hours: 1)),
+          title: '운동 목표 달성',
+          body: '주간 240분 달성',
+          category: 'achievement',
+        ),
+        NotificationItemsCompanion.insert(
+          id: 'n-3',
+          createdAt: now.subtract(const Duration(days: 1)),
+          title: '서비스 점검 안내',
+          body: '내일 02:00~03:00 점검 예정입니다.',
+          category: 'system',
+          read: const Value(true),
+        ),
+      ]);
+    });
+  });
+
+  tearDown(() async {
+    await db.close();
+    dio.close();
+  });
+
+  test('GET /notifications returns rows newest-first with time_ago', () async {
+    final res = await dio.get<List<Object?>>('/notifications');
+    expect(res.statusCode, 200);
+    final list = res.data!.cast<Map<String, Object?>>();
+    expect(list.length, 3);
+    expect(list.first['id'], 'n-1');
+    expect(list.first['time_ago'], '10분 전');
+    expect(list[1]['time_ago'], '1시간 전');
+    expect(list[2]['time_ago'], '어제');
+  });
+
+  test('Read flag round-trips through the response', () async {
+    final res = await dio.get<List<Object?>>('/notifications');
+    final list = res.data!.cast<Map<String, Object?>>();
+    final byId = <String, Map<String, Object?>>{
+      for (final e in list) e['id']! as String: e,
+    };
+    expect(byId['n-1']!['read'], isFalse);
+    expect(byId['n-3']!['read'], isTrue);
+  });
+}

--- a/frontend/flutter/test/core/network/local_api_interceptor_schedule_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_schedule_test.dart
@@ -1,0 +1,79 @@
+import 'package:dio/dio.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+
+import 'package:oncare/core/network/interceptors/local_api_interceptor.dart';
+import 'package:oncare/core/storage/app_database.dart';
+
+String _todayDateString() {
+  final now = DateTime.now();
+  return '${now.year.toString().padLeft(4, '0')}-'
+      '${now.month.toString().padLeft(2, '0')}-'
+      '${now.day.toString().padLeft(2, '0')}';
+}
+
+void main() {
+  late AppDatabase db;
+  late Dio dio;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    dio = Dio(BaseOptions(baseUrl: 'https://example.test'));
+    dio.interceptors.add(LocalApiInterceptor(db, Logger(level: Level.off)));
+
+    final today = _todayDateString();
+    await db.batch((b) {
+      b.insertAll(db.scheduleEvents, <ScheduleEventsCompanion>[
+        ScheduleEventsCompanion.insert(
+          id: 'evt-1',
+          date: today,
+          time: '10:00',
+          title: '병원 정기검진',
+          category: 'hospital',
+        ),
+        ScheduleEventsCompanion.insert(
+          id: 'evt-2',
+          date: today,
+          time: '18:00',
+          title: '헬스장 운동',
+          category: 'exercise',
+        ),
+        // Different date — must NOT appear in today's response.
+        ScheduleEventsCompanion.insert(
+          id: 'evt-3',
+          date: '2000-01-01',
+          time: '12:00',
+          title: '아카이브',
+          category: 'other',
+        ),
+      ]);
+    });
+  });
+
+  tearDown(() async {
+    await db.close();
+    dio.close();
+  });
+
+  test('GET /schedule/events?date=<today> returns matching rows', () async {
+    final res = await dio.get<List<Object?>>(
+      '/schedule/events',
+      queryParameters: <String, Object?>{'date': _todayDateString()},
+    );
+    expect(res.statusCode, 200);
+    final list = res.data!.cast<Map<String, Object?>>();
+    expect(list.length, 2);
+    expect(list.map((e) => e['id']).toList(), <Object>['evt-1', 'evt-2']);
+  });
+
+  test('GET /schedule/events filters out other dates', () async {
+    final res = await dio.get<List<Object?>>(
+      '/schedule/events',
+      queryParameters: <String, Object?>{'date': '2000-01-01'},
+    );
+    final list = res.data!.cast<Map<String, Object?>>();
+    expect(list.length, 1);
+    expect(list.first['title'], '아카이브');
+  });
+}

--- a/frontend/flutter/test/core/network/local_api_interceptor_vitals_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_vitals_test.dart
@@ -1,0 +1,65 @@
+import 'package:dio/dio.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+
+import 'package:oncare/core/network/interceptors/local_api_interceptor.dart';
+import 'package:oncare/core/storage/app_database.dart';
+
+void main() {
+  late AppDatabase db;
+  late Dio dio;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    dio = Dio(BaseOptions(baseUrl: 'https://example.test'));
+    dio.interceptors.add(LocalApiInterceptor(db, Logger(level: Level.off)));
+  });
+
+  tearDown(() async {
+    await db.close();
+    dio.close();
+  });
+
+  test('POST /vitals/weight persists and returns the new record', () async {
+    final res = await dio.post<Map<String, Object?>>(
+      '/vitals/weight',
+      data: <String, Object?>{
+        'kg': 70.3,
+        'recorded_at': '2026-05-20T08:00:00.000Z',
+      },
+    );
+    expect(res.statusCode, 200);
+    expect(res.data?['kind'], 'weight');
+    final value = res.data?['value']! as Map<Object?, Object?>;
+    expect(value['kg'], 70.3);
+    expect(res.data?['recorded_at'], '2026-05-20T08:00:00.000Z');
+
+    // Round-trip through GET /vitals/weight/latest.
+    final latest = await dio.get<Map<String, Object?>>(
+      '/vitals/weight/latest',
+    );
+    expect(latest.statusCode, 200);
+    final latestValue = latest.data?['value']! as Map<Object?, Object?>;
+    expect(latestValue['kg'], 70.3);
+  });
+
+  test('POST /vitals/blood-pressure persists systolic + diastolic', () async {
+    final res = await dio.post<Map<String, Object?>>(
+      '/vitals/blood-pressure',
+      data: <String, Object?>{'systolic': 118, 'diastolic': 76},
+    );
+    expect(res.statusCode, 200);
+    final value = res.data?['value']! as Map<Object?, Object?>;
+    expect(value['systolic'], 118);
+    expect(value['diastolic'], 76);
+  });
+
+  test('GET /vitals/blood-sugar/latest returns empty body when none', () async {
+    final res = await dio.get<Map<String, Object?>>(
+      '/vitals/blood-sugar/latest',
+    );
+    expect(res.statusCode, 200);
+    expect(res.data, isEmpty);
+  });
+}

--- a/frontend/flutter/test/core/network/local_api_interceptor_vitals_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_vitals_test.dart
@@ -36,9 +36,7 @@ void main() {
     expect(res.data?['recorded_at'], '2026-05-20T08:00:00.000Z');
 
     // Round-trip through GET /vitals/weight/latest.
-    final latest = await dio.get<Map<String, Object?>>(
-      '/vitals/weight/latest',
-    );
+    final latest = await dio.get<Map<String, Object?>>('/vitals/weight/latest');
     expect(latest.statusCode, 200);
     final latestValue = latest.data?['value']! as Map<Object?, Object?>;
     expect(latestValue['kg'], 70.3);

--- a/frontend/flutter/test/core/network/local_api_smoke_test.dart
+++ b/frontend/flutter/test/core/network/local_api_smoke_test.dart
@@ -1,0 +1,69 @@
+import 'package:dio/dio.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+
+import 'package:oncare/core/network/interceptors/local_api_interceptor.dart';
+import 'package:oncare/core/storage/app_database.dart';
+import 'package:oncare/core/storage/seed_data.dart';
+import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
+
+/// End-to-end smoke test for Stage 9: drift seeded → dio → LocalApi
+/// interceptor → JSON → fromJson factory. If any of these layers
+/// drift apart, this lights up first.
+void main() {
+  late AppDatabase db;
+  late Dio dio;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    await seedIfEmpty(db); // production seed path
+    dio = Dio(BaseOptions(baseUrl: 'https://example.test'));
+    dio.interceptors.add(LocalApiInterceptor(db, Logger(level: Level.off)));
+  });
+
+  tearDown(() async {
+    await db.close();
+    dio.close();
+  });
+
+  test('dio → LocalApi → DietDay.fromJson round-trips totals', () async {
+    final res = await dio.get<Map<String, Object?>>('/diet/days/today');
+    final day = DietDay.fromJson(res.data!);
+    expect(day.entries.length, 3);
+    expect(day.totalCalories, 315 + 530 + 575);
+    expect(day.totalSodiumMg, 380 + 1120 + 600);
+  });
+
+  test('dio → LocalApi → ExerciseWeek.fromJson stays Mon..Sun', () async {
+    final res = await dio.get<Map<String, Object?>>(
+      '/exercise/weeks/current',
+    );
+    final week = ExerciseWeek.fromJson(res.data!);
+    expect(week.dailyMinutes.length, 7);
+    expect(week.dayLabels, <String>['월', '화', '수', '목', '금', '토', '일']);
+    // Seed totals: 30+45+20+60+35+50 = 240
+    expect(week.totalMinutes, 240);
+  });
+
+  test(
+    'dio → LocalApi → DashboardSummary aggregates seeded data',
+    () async {
+      final res = await dio.get<Map<String, Object?>>('/dashboard/summary');
+      final summary = DashboardSummary.fromJson(res.data!);
+      expect(summary.indicators.length, 4);
+      // Seeded diet totals.
+      final cal = summary.indicators.firstWhere((i) => i.label == '칼로리');
+      expect(cal.current, 1420);
+      // Seeded blood sugar.
+      final bs = summary.indicators.firstWhere((i) => i.label == '혈당');
+      expect(bs.current, 95);
+      // 3 seeded meals.
+      expect(summary.dietEntries, 3);
+      // Two seeded schedule events.
+      expect(summary.todaySchedule.length, 2);
+    },
+  );
+}

--- a/frontend/flutter/test/core/network/local_api_smoke_test.dart
+++ b/frontend/flutter/test/core/network/local_api_smoke_test.dart
@@ -38,9 +38,7 @@ void main() {
   });
 
   test('dio → LocalApi → ExerciseWeek.fromJson stays Mon..Sun', () async {
-    final res = await dio.get<Map<String, Object?>>(
-      '/exercise/weeks/current',
-    );
+    final res = await dio.get<Map<String, Object?>>('/exercise/weeks/current');
     final week = ExerciseWeek.fromJson(res.data!);
     expect(week.dailyMinutes.length, 7);
     expect(week.dayLabels, <String>['월', '화', '수', '목', '금', '토', '일']);
@@ -48,22 +46,19 @@ void main() {
     expect(week.totalMinutes, 240);
   });
 
-  test(
-    'dio → LocalApi → DashboardSummary aggregates seeded data',
-    () async {
-      final res = await dio.get<Map<String, Object?>>('/dashboard/summary');
-      final summary = DashboardSummary.fromJson(res.data!);
-      expect(summary.indicators.length, 4);
-      // Seeded diet totals.
-      final cal = summary.indicators.firstWhere((i) => i.label == '칼로리');
-      expect(cal.current, 1420);
-      // Seeded blood sugar.
-      final bs = summary.indicators.firstWhere((i) => i.label == '혈당');
-      expect(bs.current, 95);
-      // 3 seeded meals.
-      expect(summary.dietEntries, 3);
-      // Two seeded schedule events.
-      expect(summary.todaySchedule.length, 2);
-    },
-  );
+  test('dio → LocalApi → DashboardSummary aggregates seeded data', () async {
+    final res = await dio.get<Map<String, Object?>>('/dashboard/summary');
+    final summary = DashboardSummary.fromJson(res.data!);
+    expect(summary.indicators.length, 4);
+    // Seeded diet totals.
+    final cal = summary.indicators.firstWhere((i) => i.label == '칼로리');
+    expect(cal.current, 1420);
+    // Seeded blood sugar.
+    final bs = summary.indicators.firstWhere((i) => i.label == '혈당');
+    expect(bs.current, 95);
+    // 3 seeded meals.
+    expect(summary.dietEntries, 3);
+    // Two seeded schedule events.
+    expect(summary.todaySchedule.length, 2);
+  });
 }

--- a/frontend/flutter/test/features/ai_coach/ai_coach_controller_test.dart
+++ b/frontend/flutter/test/features/ai_coach/ai_coach_controller_test.dart
@@ -1,12 +1,21 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:oncare/features/ai_coach/data/repositories/mock_ai_coach_repository.dart';
 import 'package:oncare/features/ai_coach/domain/entities/ai_coach_state.dart';
 import 'package:oncare/features/ai_coach/presentation/controllers/ai_coach_controller.dart';
 
 void main() {
   test('aiCoachStateProvider returns greeting + suggestions', () async {
-    final container = ProviderContainer();
+    final container = ProviderContainer(
+      overrides: <Override>[
+        // Default repo is DioAiCoachRepository (Stage 9.9); use the
+        // in-memory mock for the unit test.
+        aiCoachRepositoryProvider.overrideWithValue(
+          const MockAiCoachRepository(),
+        ),
+      ],
+    );
     addTearDown(container.dispose);
     final state = await container.read(aiCoachStateProvider.future);
     expect(state.greeting, isNotEmpty);

--- a/frontend/flutter/test/features/dashboard/dashboard_controller_test.dart
+++ b/frontend/flutter/test/features/dashboard/dashboard_controller_test.dart
@@ -7,7 +7,15 @@ import 'package:oncare/features/dashboard/presentation/controllers/dashboard_con
 
 void main() {
   test('dashboardSummaryProvider returns mock indicators + schedule', () async {
-    final container = ProviderContainer();
+    final container = ProviderContainer(
+      overrides: <Override>[
+        // Default impl is DioDashboardRepository (Stage 9.8). For
+        // this unit test the React-shaped mock is enough.
+        dashboardRepositoryProvider.overrideWithValue(
+          const MockDashboardRepository(),
+        ),
+      ],
+    );
     addTearDown(container.dispose);
     final summary = await container.read(dashboardSummaryProvider.future);
     expect(summary, isA<DashboardSummary>());

--- a/frontend/flutter/test/features/diet/diet_controller_test.dart
+++ b/frontend/flutter/test/features/diet/diet_controller_test.dart
@@ -1,13 +1,23 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
 import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
 
 void main() {
-  test('dietTodayProvider returns a day with three meals + totals', () async {
-    final container = ProviderContainer();
+  test('dietTodayProvider returns mock day (stub repo)', () async {
+    final container = ProviderContainer(
+      overrides: <Override>[
+        // Default repo is DioDietRepository (needs db + dio overrides);
+        // for this unit test the in-memory mock from stage 4 is enough.
+        dietRepositoryProvider.overrideWithValue(
+          const MockDietRepository(),
+        ),
+      ],
+    );
     addTearDown(container.dispose);
+
     final day = await container.read(dietTodayProvider.future);
     expect(day, isA<DietDay>());
     expect(day.entries.length, 3);

--- a/frontend/flutter/test/features/diet/diet_controller_test.dart
+++ b/frontend/flutter/test/features/diet/diet_controller_test.dart
@@ -11,9 +11,7 @@ void main() {
       overrides: <Override>[
         // Default repo is DioDietRepository (needs db + dio overrides);
         // for this unit test the in-memory mock from stage 4 is enough.
-        dietRepositoryProvider.overrideWithValue(
-          const MockDietRepository(),
-        ),
+        dietRepositoryProvider.overrideWithValue(const MockDietRepository()),
       ],
     );
     addTearDown(container.dispose);

--- a/frontend/flutter/test/features/exercise/exercise_controller_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_controller_test.dart
@@ -1,11 +1,20 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:oncare/features/exercise/data/repositories/mock_exercise_repository.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 
 void main() {
   test('exerciseWeekProvider provides 7 days, sane totals', () async {
-    final container = ProviderContainer();
+    final container = ProviderContainer(
+      overrides: <Override>[
+        // Production repo is DioExerciseRepository (needs dio + db);
+        // unit test only needs the React-shaped in-memory mock.
+        exerciseRepositoryProvider.overrideWithValue(
+          const MockExerciseRepository(),
+        ),
+      ],
+    );
     addTearDown(container.dispose);
     final week = await container.read(exerciseWeekProvider.future);
     expect(week.dailyMinutes.length, 7);

--- a/frontend/flutter/test/features/exercise/exercise_week_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_week_test.dart
@@ -18,4 +18,29 @@ void main() {
     expect(week.streakDays, 3);
     expect(week.workoutCount, 0);
   });
+
+  test('ExerciseWeek.fromJson parses the LocalApi shape', () {
+    final week = ExerciseWeek.fromJson(<String, Object?>{
+      'sessions': <Object?>[
+        <String, Object?>{
+          'id': 's-1',
+          'day_label': '월',
+          'type': 'cardio',
+          'minutes': 30,
+          'calories': 250,
+        },
+      ],
+      'daily_minutes': <Object?>[30, 0, 45, 0, 60, 0, 0],
+      'day_labels': <Object?>['월', '화', '수', '목', '금', '토', '일'],
+      'total_minutes': 135,
+      'total_calories': 1050,
+      'streak_days': 3,
+      'ai_coach_message': 'hi',
+    });
+    expect(week.sessions.length, 1);
+    expect(week.sessions.first.id, 's-1');
+    expect(week.sessions.first.type, ExerciseType.cardio);
+    expect(week.dailyMinutes, <double>[30, 0, 45, 0, 60, 0, 0]);
+    expect(week.streakDays, 3);
+  });
 }

--- a/frontend/flutter/test/features/my_health/my_health_controller_test.dart
+++ b/frontend/flutter/test/features/my_health/my_health_controller_test.dart
@@ -1,12 +1,21 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:oncare/features/my_health/data/repositories/mock_my_health_repository.dart';
 import 'package:oncare/features/my_health/domain/entities/health_history.dart';
 import 'package:oncare/features/my_health/presentation/controllers/my_health_controller.dart';
 
 void main() {
   test('myHealthStateProvider returns full state with 3 indicators', () async {
-    final container = ProviderContainer();
+    final container = ProviderContainer(
+      overrides: <Override>[
+        // Default repo is DioMyHealthRepository (Stage 9.9); use the
+        // in-memory mock for the unit test.
+        myHealthRepositoryProvider.overrideWithValue(
+          const MockMyHealthRepository(),
+        ),
+      ],
+    );
     addTearDown(container.dispose);
     final state = await container.read(myHealthStateProvider.future);
     expect(state.profile.name, '김민수');

--- a/frontend/flutter/test/features/notification/notification_list_provider_test.dart
+++ b/frontend/flutter/test/features/notification/notification_list_provider_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/notification/data/repositories/mock_notification_repository.dart';
+import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
+
+void main() {
+  test('notificationListProvider returns the mock repo payload', () async {
+    final container = ProviderContainer(
+      overrides: <Override>[
+        notificationRepositoryProvider.overrideWithValue(
+          const MockNotificationRepository(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final list = await container.read(notificationListProvider.future);
+    expect(list.length, 4);
+    expect(list.first.id, 'a1');
+    // Mix of read/unread for the unreadCount badge logic to lean on.
+    expect(list.any((e) => !e.read), isTrue);
+    expect(list.any((e) => e.read), isTrue);
+  });
+}

--- a/frontend/flutter/test/features/place/place_controller_test.dart
+++ b/frontend/flutter/test/features/place/place_controller_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:oncare/features/place/data/repositories/mock_place_repository.dart';
 import 'package:oncare/features/place/domain/entities/place.dart';
 import 'package:oncare/features/place/presentation/controllers/place_controller.dart';
 
@@ -8,7 +9,15 @@ void main() {
   test(
     'nearbyPlacesProvider returns mock places with all categories',
     () async {
-      final container = ProviderContainer();
+      final container = ProviderContainer(
+        overrides: <Override>[
+          // Default repo is DioPlaceRepository (Stage 9.9); use the
+          // in-memory mock for the unit test.
+          placeRepositoryProvider.overrideWithValue(
+            const MockPlaceRepository(),
+          ),
+        ],
+      );
       addTearDown(container.dispose);
       final places = await container.read(nearbyPlacesProvider.future);
       expect(places, isNotEmpty);

--- a/frontend/flutter/test/features/schedule/schedule_controller_test.dart
+++ b/frontend/flutter/test/features/schedule/schedule_controller_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/schedule/data/repositories/mock_schedule_repository.dart';
+import 'package:oncare/features/schedule/domain/entities/schedule_event.dart';
+import 'package:oncare/features/schedule/presentation/controllers/schedule_controller.dart';
+
+void main() {
+  test('scheduleEventsProvider returns mock list for the requested date', () async {
+    final container = ProviderContainer(
+      overrides: <Override>[
+        scheduleRepositoryProvider.overrideWithValue(
+          const MockScheduleRepository(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    const date = '2026-05-20';
+    final events = await container.read(
+      scheduleEventsProvider(date).future,
+    );
+    expect(events.length, 2);
+    expect(events.first.title, '병원 정기검진');
+    expect(events.first.category, ScheduleCategory.hospital);
+    expect(events.last.category, ScheduleCategory.exercise);
+    // All events carry the requested date.
+    for (final e in events) {
+      expect(e.date, date);
+    }
+  });
+}

--- a/frontend/flutter/test/features/schedule/schedule_controller_test.dart
+++ b/frontend/flutter/test/features/schedule/schedule_controller_test.dart
@@ -6,27 +6,28 @@ import 'package:oncare/features/schedule/domain/entities/schedule_event.dart';
 import 'package:oncare/features/schedule/presentation/controllers/schedule_controller.dart';
 
 void main() {
-  test('scheduleEventsProvider returns mock list for the requested date', () async {
-    final container = ProviderContainer(
-      overrides: <Override>[
-        scheduleRepositoryProvider.overrideWithValue(
-          const MockScheduleRepository(),
-        ),
-      ],
-    );
-    addTearDown(container.dispose);
+  test(
+    'scheduleEventsProvider returns mock list for the requested date',
+    () async {
+      final container = ProviderContainer(
+        overrides: <Override>[
+          scheduleRepositoryProvider.overrideWithValue(
+            const MockScheduleRepository(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
 
-    const date = '2026-05-20';
-    final events = await container.read(
-      scheduleEventsProvider(date).future,
-    );
-    expect(events.length, 2);
-    expect(events.first.title, '병원 정기검진');
-    expect(events.first.category, ScheduleCategory.hospital);
-    expect(events.last.category, ScheduleCategory.exercise);
-    // All events carry the requested date.
-    for (final e in events) {
-      expect(e.date, date);
-    }
-  });
+      const date = '2026-05-20';
+      final events = await container.read(scheduleEventsProvider(date).future);
+      expect(events.length, 2);
+      expect(events.first.title, '병원 정기검진');
+      expect(events.first.category, ScheduleCategory.hospital);
+      expect(events.last.category, ScheduleCategory.exercise);
+      // All events carry the requested date.
+      for (final e in events) {
+        expect(e.date, date);
+      }
+    },
+  );
 }

--- a/frontend/flutter/test/features/vitals/vital_entity_test.dart
+++ b/frontend/flutter/test/features/vitals/vital_entity_test.dart
@@ -27,10 +27,7 @@ void main() {
     test('BloodPressureSubmission encodes systolic + diastolic', () {
       const s = BloodPressureSubmission(systolic: 120, diastolic: 80);
       expect(s.kind, VitalKind.bloodPressure);
-      expect(
-        s.toJson(),
-        <String, Object?>{'systolic': 120, 'diastolic': 80},
-      );
+      expect(s.toJson(), <String, Object?>{'systolic': 120, 'diastolic': 80});
     });
 
     test('BloodSugarSubmission encodes mg_per_dl', () {

--- a/frontend/flutter/test/features/vitals/vital_entity_test.dart
+++ b/frontend/flutter/test/features/vitals/vital_entity_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/vitals/domain/entities/vital.dart';
+
+void main() {
+  group('VitalKind', () {
+    test('round-trips through .path', () {
+      for (final kind in VitalKind.values) {
+        expect(VitalKind.fromPath(kind.path), kind);
+      }
+    });
+
+    test('path matches FastAPI route segments', () {
+      expect(VitalKind.weight.path, 'weight');
+      expect(VitalKind.bloodPressure.path, 'blood-pressure');
+      expect(VitalKind.bloodSugar.path, 'blood-sugar');
+    });
+  });
+
+  group('VitalSubmission', () {
+    test('WeightSubmission encodes to {"kg": ...}', () {
+      const s = WeightSubmission(kg: 72.5);
+      expect(s.kind, VitalKind.weight);
+      expect(s.toJson(), <String, Object?>{'kg': 72.5});
+    });
+
+    test('BloodPressureSubmission encodes systolic + diastolic', () {
+      const s = BloodPressureSubmission(systolic: 120, diastolic: 80);
+      expect(s.kind, VitalKind.bloodPressure);
+      expect(
+        s.toJson(),
+        <String, Object?>{'systolic': 120, 'diastolic': 80},
+      );
+    });
+
+    test('BloodSugarSubmission encodes mg_per_dl', () {
+      const s = BloodSugarSubmission(mgPerDl: 95);
+      expect(s.kind, VitalKind.bloodSugar);
+      expect(s.toJson(), <String, Object?>{'mg_per_dl': 95});
+    });
+  });
+
+  group('VitalRecord.fromJson', () {
+    test('parses a full record', () {
+      final r = VitalRecord.fromJson(<String, Object?>{
+        'id': 'v-1',
+        'kind': 'weight',
+        'value': <String, Object?>{'kg': 71.4},
+        'recorded_at': '2026-05-20T08:00:00.000Z',
+      });
+      expect(r.id, 'v-1');
+      expect(r.kind, VitalKind.weight);
+      expect(r.value['kg'], 71.4);
+      expect(r.recordedAt.year, 2026);
+      expect(r.recordedAt.month, 5);
+    });
+  });
+}

--- a/frontend/flutter/test/features/vitals/vitals_controller_test.dart
+++ b/frontend/flutter/test/features/vitals/vitals_controller_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/vitals/data/repositories/mock_vitals_repository.dart';
+import 'package:oncare/features/vitals/domain/entities/vital.dart';
+import 'package:oncare/features/vitals/presentation/controllers/vitals_controller.dart';
+
+void main() {
+  test('submit + latest round-trip through MockVitalsRepository', () async {
+    final container = ProviderContainer(
+      overrides: <Override>[
+        // Default impl is DioVitalsRepository → needs dio + db
+        // overrides; in-memory mock is enough for the unit test.
+        vitalsRepositoryProvider.overrideWithValue(MockVitalsRepository()),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final repo = container.read(vitalsRepositoryProvider);
+    final saved = await repo.submit(const WeightSubmission(kg: 70.1));
+    expect(saved.kind, VitalKind.weight);
+    expect(saved.value['kg'], 70.1);
+
+    final latest = await container.read(
+      latestVitalProvider(VitalKind.weight).future,
+    );
+    expect(latest, isNotNull);
+    expect(latest!.value['kg'], 70.1);
+  });
+
+  test('latest filters by kind', () async {
+    final container = ProviderContainer(
+      overrides: <Override>[
+        vitalsRepositoryProvider.overrideWithValue(MockVitalsRepository()),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final repo = container.read(vitalsRepositoryProvider);
+    await repo.submit(const WeightSubmission(kg: 70.0));
+    await repo.submit(
+      const BloodPressureSubmission(systolic: 118, diastolic: 76),
+    );
+
+    final bp = await container.read(
+      latestVitalProvider(VitalKind.bloodPressure).future,
+    );
+    expect(bp, isNotNull);
+    expect(bp!.value['systolic'], 118);
+    expect(bp.value['diastolic'], 76);
+
+    final sugar = await container.read(
+      latestVitalProvider(VitalKind.bloodSugar).future,
+    );
+    expect(sugar, isNull);
+  });
+}

--- a/frontend/flutter/test/widget_test.dart
+++ b/frontend/flutter/test/widget_test.dart
@@ -9,6 +9,9 @@ import 'package:oncare/core/logging/app_logger.dart';
 import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
 import 'package:oncare/features/diet/domain/repositories/diet_repository.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
+import 'package:oncare/features/exercise/data/repositories/mock_exercise_repository.dart';
+import 'package:oncare/features/exercise/domain/repositories/exercise_repository.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/services/locale_provider.dart';
 
@@ -28,6 +31,11 @@ void main() {
           // needs a real dio+db. Swap to the in-memory mock here.
           dietRepositoryProvider.overrideWithValue(
             const MockDietRepository() as DietRepository,
+          ),
+          // Same reason — exercise repo defaults to DioExerciseRepository
+          // (Stage 9.6); swap to the in-memory mock here.
+          exerciseRepositoryProvider.overrideWithValue(
+            const MockExerciseRepository() as ExerciseRepository,
           ),
           if (locale != null) localeProvider.overrideWith((ref) => locale),
         ],

--- a/frontend/flutter/test/widget_test.dart
+++ b/frontend/flutter/test/widget_test.dart
@@ -6,6 +6,9 @@ import 'package:logger/logger.dart';
 import 'package:oncare/app/app.dart';
 import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/core/logging/app_logger.dart';
+import 'package:oncare/features/dashboard/data/repositories/mock_dashboard_repository.dart';
+import 'package:oncare/features/dashboard/domain/repositories/dashboard_repository.dart';
+import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
 import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
 import 'package:oncare/features/diet/domain/repositories/diet_repository.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
@@ -36,6 +39,12 @@ void main() {
           // (Stage 9.6); swap to the in-memory mock here.
           exerciseRepositoryProvider.overrideWithValue(
             const MockExerciseRepository() as ExerciseRepository,
+          ),
+          // Dashboard summary defaults to DioDashboardRepository (Stage
+          // 9.8); the smoke test only inspects the nav, so the mock is
+          // plenty.
+          dashboardRepositoryProvider.overrideWithValue(
+            const MockDashboardRepository() as DashboardRepository,
           ),
           if (locale != null) localeProvider.overrideWith((ref) => locale),
         ],

--- a/frontend/flutter/test/widget_test.dart
+++ b/frontend/flutter/test/widget_test.dart
@@ -6,6 +6,9 @@ import 'package:logger/logger.dart';
 import 'package:oncare/app/app.dart';
 import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/core/logging/app_logger.dart';
+import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
+import 'package:oncare/features/diet/domain/repositories/diet_repository.dart';
+import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/services/locale_provider.dart';
 
@@ -21,6 +24,11 @@ void main() {
         overrides: <Override>[
           appConfigProvider.overrideWithValue(config),
           appLoggerProvider.overrideWithValue(Logger(level: Level.off)),
+          // Diet repo defaults to DioDietRepository (Stage 9) which
+          // needs a real dio+db. Swap to the in-memory mock here.
+          dietRepositoryProvider.overrideWithValue(
+            const MockDietRepository() as DietRepository,
+          ),
           if (locale != null) localeProvider.overrideWith((ref) => locale),
         ],
         child: const OncareApp(),

--- a/frontend/flutter/tool/fetch_drift_wasm.sh
+++ b/frontend/flutter/tool/fetch_drift_wasm.sh
@@ -21,18 +21,24 @@ if [[ -z "$DRIFT_VERSION" ]]; then
   exit 1
 fi
 
-# Pinned sqlite3 WASM build. Bump when drift's WASM ABI changes
-# (i.e. if the next `drift_worker.js` version refuses to load this
-# WASM, pick a newer sqlite3-X.Y.Z release).
-SQLITE3_WASM_TAG="${SQLITE3_WASM_TAG:-sqlite3-3.3.1}"
+# The WASM ABI is tied to the Dart `sqlite3` package version — the
+# release tag uses the same X.Y.Z. drift_worker.js (from the drift
+# release) and sqlite3.wasm (from the sqlite3.dart release) must
+# share that ABI, otherwise WASM instantiation fails with
+# `function import requires a callable` for `dart.dispatch_xFunc`.
+SQLITE3_VERSION=$(awk '/^  sqlite3:$/{f=1;next} f && /version:/{gsub(/[" ]/,"",$2); print $2; exit}' pubspec.lock)
+if [[ -z "$SQLITE3_VERSION" ]]; then
+  echo "Could not resolve sqlite3 package version from pubspec.lock" >&2
+  exit 1
+fi
 
 echo "Resolved drift version    : $DRIFT_VERSION"
-echo "Pinned sqlite3 WASM tag   : $SQLITE3_WASM_TAG"
+echo "Resolved sqlite3 version  : $SQLITE3_VERSION"
 
 mkdir -p web
 curl --fail --location --silent --show-error \
   -o web/sqlite3.wasm \
-  "https://github.com/simolus3/sqlite3.dart/releases/download/${SQLITE3_WASM_TAG}/sqlite3.wasm"
+  "https://github.com/simolus3/sqlite3.dart/releases/download/sqlite3-${SQLITE3_VERSION}/sqlite3.wasm"
 curl --fail --location --silent --show-error \
   -o web/drift_worker.js \
   "https://github.com/simolus3/drift/releases/download/drift-${DRIFT_VERSION}/drift_worker.js"

--- a/frontend/flutter/tool/fetch_drift_wasm.sh
+++ b/frontend/flutter/tool/fetch_drift_wasm.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Fetch the sqlite3 WASM module + drift_worker.js into web/ for
+# `flutter run -d chrome` and `flutter build web`.
+#
+# Two upstream sources:
+# - `drift_worker.js` is published per-release on
+#   https://github.com/simolus3/drift (tag `drift-X.Y.Z`).
+# - `sqlite3.wasm` is published on
+#   https://github.com/simolus3/sqlite3.dart (tag `sqlite3-X.Y.Z`).
+#   Its X.Y.Z is the sqlite3 C library version, NOT the Dart
+#   package version — pin a known-good build here.
+#
+# CI does the same thing inline in .github/workflows/deploy-web.yml.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+DRIFT_VERSION=$(awk '/^  drift:$/{f=1;next} f && /version:/{gsub(/[" ]/,"",$2); print $2; exit}' pubspec.lock)
+if [[ -z "$DRIFT_VERSION" ]]; then
+  echo "Could not resolve drift version from pubspec.lock" >&2
+  exit 1
+fi
+
+# Pinned sqlite3 WASM build. Bump when drift's WASM ABI changes
+# (i.e. if the next `drift_worker.js` version refuses to load this
+# WASM, pick a newer sqlite3-X.Y.Z release).
+SQLITE3_WASM_TAG="${SQLITE3_WASM_TAG:-sqlite3-3.3.1}"
+
+echo "Resolved drift version    : $DRIFT_VERSION"
+echo "Pinned sqlite3 WASM tag   : $SQLITE3_WASM_TAG"
+
+mkdir -p web
+curl --fail --location --silent --show-error \
+  -o web/sqlite3.wasm \
+  "https://github.com/simolus3/sqlite3.dart/releases/download/${SQLITE3_WASM_TAG}/sqlite3.wasm"
+curl --fail --location --silent --show-error \
+  -o web/drift_worker.js \
+  "https://github.com/simolus3/drift/releases/download/drift-${DRIFT_VERSION}/drift_worker.js"
+
+echo "Downloaded:"
+ls -l web/sqlite3.wasm web/drift_worker.js


### PR DESCRIPTION
## Summary

Flutter 마지막 마일스톤 — **dio 위의 `LocalApiInterceptor` 가 drift(sqlite)에서 데이터를 응답하는 "로컬 백엔드"** 를 붙여, 실 서버 없이도 모든 화면이 REST 응답으로 동작합니다. 끝에 dart format / 웹 빌드용 drift WASM 번들 fix 까지 포함. `oncare-flutter` 의 **남은 16개 커밋 전체** 를 동일 메시지·동일 트리로 재현했습니다 (stage 9 + 마무리 패스).

### Backend docs (선행)
- `API_CATALOG.md` / `DUMMY_BACKEND.md` 옵션 정리
- README 에서 두 문서 링크

### Stage 9 — Local backend (phase 9.1 – 9.10)
- **9.1 schema v2** — drift 신규 5개 테이블 (diet / vitals / exercise / schedule / notification)
- **9.2 seed** — 첫 실행 시 React 원본 mock 데이터를 drift 로 시드
- **9.3 interceptor** — `LocalApiInterceptor` 스켈레톤 + camelCase ↔ snake_case 매퍼
- **9.4 diet** — `GET /diet/days/today` + `DioDietRepository`
- **9.5 vitals** — `POST /vitals/{kind}` + `GET .../latest`, `QuickInput` 와이어링
- **9.6 exercise** — `GET /exercise/weeks/current` (주간 집계)
- **9.7 schedule + noti** — `/schedule/events`, `/notifications`
- **9.8 dashboard** — `GET /dashboard/summary` (diet + exercise + vital + schedule 집계)
- **9.9 misc** — AI Coach / `users.me` / MyHealth / Places 도 LocalApiInterceptor 경로로
- **9.10 docs + smoke** — stage 9 결정 로그 + e2e 스모크 테스트
- **end of stage 9** — `v0.3.0+3` 로 마킹

### 마무리
- `style: dart format` (CI verify gate 통과용)
- `fix(web)`: GitHub Pages 빌드용 drift WASM 번들 (`sqlite3.wasm` + `drift_worker.js`)
- `fix(web)`: `sqlite3` dart 패키지 버전과 wasm 매칭 + dio `4xx/5xx → DioException` 변환

16 commits, 68 files, +6942 / -180.

## Test plan

- [x] `cd frontend/flutter && flutter pub get`
- [x] `dart run build_runner build --delete-conflicting-outputs` (drift schema v2 / freezed)
- [x] `flutter analyze` clean
- [x] `flutter test` 전체 통과
- [x] `flutter test integration_test` — e2e 스모크 통과
- [x] `dart format --set-exit-if-changed .` 차이 없음
- [x] (선택) `flutter run -d chrome` → 첫 실행 시 mock 데이터 seed 후 모든 화면이 LocalApiInterceptor 응답으로 동작하는지 확인
- [x] (선택) `flutter build web --release --base-href "/oncare-flutter/"` 후 `build/web/sqlite3.wasm` / `drift_worker.js` 존재 확인

## Notes
- stage 8 (#9) 머지 이후 main 위에서 작업.
- `pubspec.yaml` 버전은 **0.3.0+3** 로 변경됩니다 (end-of-stage 9 커밋에 포함).
- 이 PR이 머지되면 `frontend/flutter/` 트리가 `oncare-flutter` 원본의 `0696cea` 와 동일해집니다 (작업 완료).

---

Closes #45