### PR TITLE
feat(ui): outlined cards + 🤖 daily feedback + diet week strip

### DIFF
--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -142,24 +142,8 @@ class LocalApiInterceptor extends Interceptor {
       exerciseMinutes += r.minutes;
     }
 
-    // Latest blood sugar reading (mg/dL) — defaults to 0 when none.
-    int bloodSugar = 0;
-    final bsRow =
-        await (_db.select(_db.vitals)
-              ..where((t) => t.kind.equals('blood-sugar'))
-              ..orderBy(<OrderClauseGenerator<$VitalsTable>>[
-                (t) => OrderingTerm(
-                  expression: t.recordedAt,
-                  mode: OrderingMode.desc,
-                ),
-              ])
-              ..limit(1))
-            .getSingleOrNull();
-    if (bsRow != null) {
-      final v = jsonDecode(bsRow.valueJson) as Map<Object?, Object?>;
-      final raw = v['mg_per_dl'];
-      if (raw is num) bloodSugar = raw.toInt();
-    }
+    // (혈당 row removed from the home summary per the latest design ref —
+    // the indicator list now ends at 당류.)
 
     // Today's schedule items.
     final schedRows = await (_db.select(
@@ -196,12 +180,6 @@ class LocalApiInterceptor extends Interceptor {
           'current': totalSugar,
           'max': 50,
           'unit': 'g',
-        },
-        <String, Object?>{
-          'label': '혈당',
-          'current': bloodSugar,
-          'max': 120,
-          'unit': 'mg/dL',
         },
       ],
       'diet_entries': dietRows.length,

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -192,6 +192,9 @@ class LocalApiInterceptor extends Interceptor {
       'sodium_warning': totalSodium > 2000
           ? '오늘의 나트륨 섭취량이 높아요. 저녁에는 담백한 구이나 샐러드를 추천해요!'
           : null,
+      'exercise_feedback': exerciseMinutes >= 60
+          ? '오늘 운동 목표를 달성했어요! 마무리 스트레칭도 잊지 마세요.'
+          : '주간 운동 목표 80%를 달성했어요! 오늘 가볍게 걷기를 더해 100%를 채워봐요!',
     });
   }
 

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -347,7 +347,7 @@ class LocalApiInterceptor extends Interceptor {
       'total_calories': totalCalories,
       'streak_days': streak,
       'ai_coach_message': totalMinutes >= 240
-          ? '주간 운동 목표 80%를 달성했어요! 일요일에 가볍게 걷기를 더해 100%를 채워봐요.'
+          ? '주간 운동 목표 80%를 달성했어요! 오늘 가볍게 걷기를 더해 100%를 채워봐요.'
           : '이번 주는 운동량이 조금 부족해요. 가벼운 산책부터 다시 시작해 봐요.',
     });
   }

--- a/frontend/flutter/lib/design_system/atoms/app_card.dart
+++ b/frontend/flutter/lib/design_system/atoms/app_card.dart
@@ -1,16 +1,25 @@
 import 'package:flutter/material.dart';
 
+import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/design_system/tokens/radius.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
 
 /// Surface-coloured container with rounded corners and optional tap
 /// behaviour. Used for dashboard cards, list items, etc.
+///
+/// Set [outlined] to swap the filled tonal surface for the
+/// white-background + soft-gray-border treatment the design system
+/// uses for primary content panels (오늘의 건강 요약, 온이의 피드백,
+/// 운동 기록 / 내 헬스장 / 건강 지표 추이 / 설정 …). The default
+/// (`outlined: false`) keeps the legacy tonal fill so smaller stat
+/// tiles and tinted secondary surfaces are unaffected.
 class AppCard extends StatelessWidget {
   const AppCard({
     required this.child,
     this.padding = const EdgeInsets.all(AppSpacing.lg),
     this.color,
     this.onTap,
+    this.outlined = false,
     super.key,
   });
 
@@ -18,13 +27,24 @@ class AppCard extends StatelessWidget {
   final EdgeInsets padding;
   final Color? color;
   final VoidCallback? onTap;
+  final bool outlined;
 
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
+    final fill =
+        color ?? (outlined ? AppColors.card : scheme.surfaceContainerHigh);
+    final shape = outlined
+        ? const RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(AppRadius.lg),
+            side: BorderSide(color: AppColors.border),
+          )
+        : const RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(AppRadius.lg),
+          );
     return Material(
-      color: color ?? scheme.surfaceContainerHigh,
-      borderRadius: const BorderRadius.all(AppRadius.lg),
+      color: fill,
+      shape: shape,
       child: InkWell(
         onTap: onTap,
         borderRadius: const BorderRadius.all(AppRadius.lg),

--- a/frontend/flutter/lib/features/dashboard/data/repositories/mock_dashboard_repository.dart
+++ b/frontend/flutter/lib/features/dashboard/data/repositories/mock_dashboard_repository.dart
@@ -28,6 +28,7 @@ class MockDashboardRepository implements DashboardRepository {
       weekScore: 85,
       weekScoreDelta: 12,
       sodiumWarning: '오늘의 나트륨 섭취량이 높아요. 저녁에는 담백한 구이나 샐러드를 추천해요!',
+      exerciseFeedback: '주간 운동 목표 80%를 달성했어요! 오늘 가볍게 걷기를 더해 100%를 채워봐요!',
     );
   }
 }

--- a/frontend/flutter/lib/features/dashboard/data/repositories/mock_dashboard_repository.dart
+++ b/frontend/flutter/lib/features/dashboard/data/repositories/mock_dashboard_repository.dart
@@ -18,7 +18,6 @@ class MockDashboardRepository implements DashboardRepository {
           overBudget: true,
         ),
         HealthIndicator(label: '당류', current: 45, max: 50, unit: 'g'),
-        HealthIndicator(label: '혈당', current: 95, max: 120, unit: 'mg/dL'),
       ],
       dietEntries: 2,
       exerciseMinutes: 45,

--- a/frontend/flutter/lib/features/dashboard/domain/entities/dashboard_summary.dart
+++ b/frontend/flutter/lib/features/dashboard/domain/entities/dashboard_summary.dart
@@ -63,7 +63,7 @@ class DashboardSummary {
     required this.sodiumWarning,
   });
 
-  /// 4-row health summary (칼로리 / 나트륨 / 당류 / 혈당).
+  /// 3-row health summary (칼로리 / 나트륨 / 당류).
   final List<HealthIndicator> indicators;
 
   /// `quickStats` left tile — number of diet records logged today.

--- a/frontend/flutter/lib/features/dashboard/domain/entities/dashboard_summary.dart
+++ b/frontend/flutter/lib/features/dashboard/domain/entities/dashboard_summary.dart
@@ -61,6 +61,7 @@ class DashboardSummary {
     required this.weekScore,
     required this.weekScoreDelta,
     required this.sodiumWarning,
+    this.exerciseFeedback,
   });
 
   /// 3-row health summary (칼로리 / 나트륨 / 당류).
@@ -79,9 +80,13 @@ class DashboardSummary {
   final int weekScore;
   final int weekScoreDelta;
 
-  /// One-line warning shown above the indicator list when something
-  /// is over budget (e.g. sodium intake).
+  /// Diet-side daily feedback line — currently driven by the sodium
+  /// budget, but treated generically as "the diet feedback the AI
+  /// coach wants surfaced today". Null = nothing to say.
   final String? sodiumWarning;
+
+  /// Exercise-side daily feedback line. Optional for back-compat.
+  final String? exerciseFeedback;
 
   factory DashboardSummary.fromJson(Map<String, Object?> json) =>
       DashboardSummary(
@@ -98,5 +103,6 @@ class DashboardSummary {
         weekScore: (json['week_score']! as num).toInt(),
         weekScoreDelta: (json['week_score_delta']! as num).toInt(),
         sodiumWarning: json['sodium_warning'] as String?,
+        exerciseFeedback: json['exercise_feedback'] as String?,
       );
 }

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -39,6 +39,11 @@ class DashboardContent extends StatelessWidget {
         onBloodPressure: onQuickInputBloodPressure,
         onBloodSugar: onQuickInputBloodSugar,
       ),
+      if (summary.sodiumWarning != null || summary.exerciseFeedback != null)
+        _DailyFeedbackCard(
+          dietLine: summary.sodiumWarning,
+          exerciseLine: summary.exerciseFeedback,
+        ),
       _HealthSummaryCard(summary: summary),
       _ScheduleCard(items: summary.todaySchedule, onOpenAll: onOpenSchedule),
       _WeekScoreCard(score: summary.weekScore, delta: summary.weekScoreDelta),
@@ -141,6 +146,66 @@ class _QuickInputCard extends StatelessWidget {
                 ),
               ),
             ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Combined daily-feedback card — sits between 오늘의 건강 기록 and
+/// 오늘의 건강 요약. White surface with the design-system gray
+/// border, robot avatar on the left, and one bullet per available
+/// feedback line (diet / exercise).
+class _DailyFeedbackCard extends StatelessWidget {
+  const _DailyFeedbackCard({this.dietLine, this.exerciseLine});
+
+  final String? dietLine;
+  final String? exerciseLine;
+
+  String _withEmoji(String text, String emoji) {
+    final t = text.trimRight();
+    return t.endsWith(emoji) ? t : '$t $emoji';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final lines = <({String text, String emoji})>[
+      if (dietLine != null) (text: dietLine!, emoji: '🥗'),
+      if (exerciseLine != null) (text: exerciseLine!, emoji: '🚶'),
+    ];
+
+    return AppCard(
+      outlined: true,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Container(
+            width: 36,
+            height: 36,
+            decoration: BoxDecoration(
+              color: AppColors.primary.withValues(alpha: 0.12),
+              borderRadius: const BorderRadius.all(AppRadius.lg),
+            ),
+            alignment: Alignment.center,
+            child: const Text('🤖', style: TextStyle(fontSize: 20)),
+          ),
+          const SizedBox(width: AppSpacing.md),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                for (int i = 0; i < lines.length; i++) ...<Widget>[
+                  Text(
+                    _withEmoji(lines[i].text, lines[i].emoji),
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                  if (i < lines.length - 1)
+                    const SizedBox(height: AppSpacing.sm),
+                ],
+              ],
+            ),
           ),
         ],
       ),

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -203,24 +203,9 @@ class _HealthSummaryCard extends StatelessWidget {
             ),
           ),
           const SizedBox(height: AppSpacing.md),
-          if (summary.sodiumWarning != null)
-            Container(
-              padding: const EdgeInsets.all(AppSpacing.md),
-              decoration: BoxDecoration(
-                color: AppColors.warning.withValues(alpha: 0.10),
-                borderRadius: const BorderRadius.all(AppRadius.lg),
-                border: Border.all(
-                  color: AppColors.warning.withValues(alpha: 0.20),
-                ),
-              ),
-              child: Text(
-                '${summary.sodiumWarning!} 🥗',
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: AppColors.warning,
-                ),
-              ),
-            ),
-          const SizedBox(height: AppSpacing.md),
+          // Sodium-warning banner removed from this card per the new
+          // design ref; the same message now lives in the combined
+          // daily-feedback card above (see _DailyFeedbackCard).
           for (final i in summary.indicators) ...<Widget>[
             _IndicatorRow(indicator: i),
             const SizedBox(height: AppSpacing.md),

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -192,6 +192,7 @@ class _HealthSummaryCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return AppCard(
+      outlined: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
@@ -368,6 +369,7 @@ class _ScheduleCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return AppCard(
+      outlined: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -6,17 +6,25 @@ import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
 import 'package:oncare/features/diet/presentation/widgets/diet_summary_card.dart';
+import 'package:oncare/features/diet/presentation/widgets/diet_week_strip.dart';
 import 'package:oncare/features/diet/presentation/widgets/meal_card.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/widgets/ai_coach_card.dart';
 import 'package:oncare/shared/widgets/error_view.dart';
 import 'package:oncare/shared/widgets/oncare_header.dart';
 
-class DietRecordPage extends ConsumerWidget {
+class DietRecordPage extends ConsumerStatefulWidget {
   const DietRecordPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<DietRecordPage> createState() => _DietRecordPageState();
+}
+
+class _DietRecordPageState extends ConsumerState<DietRecordPage> {
+  late DateTime _selectedDay = DateTime.now();
+
+  @override
+  Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     final async = ref.watch(dietTodayProvider);
 
@@ -33,11 +41,21 @@ class DietRecordPage extends ConsumerWidget {
                   child: ListView(
                     padding: const EdgeInsets.fromLTRB(
                       AppSpacing.lg,
-                      AppSpacing.xl,
+                      AppSpacing.lg,
                       AppSpacing.lg,
                       AppSpacing.xxxl,
                     ),
                     children: <Widget>[
+                      DietWeekStrip(
+                        selectedDay: _selectedDay,
+                        onSelect: (d) => setState(() => _selectedDay = d),
+                        onShiftWeek: (delta) => setState(() {
+                          _selectedDay = _selectedDay.add(
+                            Duration(days: 7 * delta),
+                          );
+                        }),
+                      ),
+                      const SizedBox(height: AppSpacing.lg),
                       DietSummaryCard(day: day),
                       const SizedBox(height: AppSpacing.lg),
                       AiCoachCard(message: day.aiCoachMessage),

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -8,9 +8,12 @@ import 'package:oncare/features/diet/presentation/controllers/diet_controller.da
 import 'package:oncare/features/diet/presentation/widgets/diet_summary_card.dart';
 import 'package:oncare/features/diet/presentation/widgets/diet_week_strip.dart';
 import 'package:oncare/features/diet/presentation/widgets/meal_card.dart';
+import 'package:oncare/features/notification/presentation/widgets/notification_panel.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/widgets/ai_coach_card.dart';
 import 'package:oncare/shared/widgets/error_view.dart';
+import 'package:oncare/shared/widgets/modals/right_slide_panel.dart';
+import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
 import 'package:oncare/shared/widgets/oncare_header.dart';
 
 class DietRecordPage extends ConsumerStatefulWidget {
@@ -32,7 +35,14 @@ class _DietRecordPageState extends ConsumerState<DietRecordPage> {
       backgroundColor: AppColors.background,
       body: Column(
         children: <Widget>[
-          OncareHeader(title: l.pageDietTitle),
+          OncareHeader(
+            title: l.pageDietTitle,
+            onNotificationTap: () => showRightSlidePanel<void>(
+              context,
+              content: const NotificationPanelBody(),
+            ),
+            onCalendarTap: () => showScheduleCalendarSheet(context),
+          ),
           Expanded(
             child: async.when(
               data: (day) => Center(

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_summary_card.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_summary_card.dart
@@ -16,6 +16,7 @@ class DietSummaryCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return AppCard(
+      outlined: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_week_strip.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_week_strip.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+
+import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/design_system/tokens/radius.dart';
+import 'package:oncare/design_system/tokens/spacing.dart';
+
+/// Date header + horizontal week picker shown at the top of the Diet
+/// tab. Sunday-to-Saturday strip centred on the [selectedDay], with
+/// chevrons to scrub the visible week. Purely presentational — the
+/// underlying day's data still comes from the diet repository.
+class DietWeekStrip extends StatelessWidget {
+  const DietWeekStrip({
+    required this.selectedDay,
+    required this.onSelect,
+    required this.onShiftWeek,
+    super.key,
+  });
+
+  /// The day currently highlighted in the strip and reflected in the
+  /// header.
+  final DateTime selectedDay;
+
+  /// Called when the user taps a day cell.
+  final ValueChanged<DateTime> onSelect;
+
+  /// `-1` = previous week, `+1` = next week.
+  final ValueChanged<int> onShiftWeek;
+
+  static const List<String> _weekdayShort = <String>[
+    '일',
+    '월',
+    '화',
+    '수',
+    '목',
+    '금',
+    '토',
+  ];
+
+  String _formatHeader(DateTime d) {
+    final mm = d.month.toString().padLeft(2, '0');
+    final dd = d.day.toString().padLeft(2, '0');
+    // weekday: 1=Mon .. 7=Sun → re-map to Sunday-first index 0..6
+    final dow = _weekdayShort[d.weekday % 7];
+    return '$mm. $dd. ($dow)';
+  }
+
+  DateTime _sundayOf(DateTime d) {
+    final dayDate = DateTime(d.year, d.month, d.day);
+    // weekday: Mon=1..Sun=7; offset back to Sunday.
+    final offset = dayDate.weekday % 7;
+    return dayDate.subtract(Duration(days: offset));
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final sunday = _sundayOf(selectedDay);
+    final today = DateTime.now();
+    final week = <DateTime>[
+      for (int i = 0; i < 7; i++) sunday.add(Duration(days: i)),
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        // Date header.
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Text(
+                _formatHeader(selectedDay),
+                style: theme.textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(width: 6),
+              const Icon(
+                Icons.keyboard_arrow_down,
+                size: 22,
+                color: AppColors.foreground,
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        // Week strip.
+        Row(
+          children: <Widget>[
+            _ChevronButton(
+              icon: Icons.chevron_left,
+              onTap: () => onShiftWeek(-1),
+            ),
+            Expanded(
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: <Widget>[
+                  for (final d in week)
+                    _DayCell(
+                      date: d,
+                      label: _weekdayShort[d.weekday % 7],
+                      selected: _isSameDay(d, selectedDay),
+                      isToday: _isSameDay(d, today),
+                      onTap: () => onSelect(d),
+                    ),
+                ],
+              ),
+            ),
+            _ChevronButton(
+              icon: Icons.chevron_right,
+              onTap: () => onShiftWeek(1),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _ChevronButton extends StatelessWidget {
+  const _ChevronButton({required this.icon, required this.onTap});
+  final IconData icon;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 36,
+      height: 36,
+      child: Material(
+        color: Colors.transparent,
+        shape: const CircleBorder(),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onTap,
+          child: Icon(icon, size: 22, color: AppColors.mutedForeground),
+        ),
+      ),
+    );
+  }
+}
+
+class _DayCell extends StatelessWidget {
+  const _DayCell({
+    required this.date,
+    required this.label,
+    required this.selected,
+    required this.isToday,
+    required this.onTap,
+  });
+
+  final DateTime date;
+  final String label;
+  final bool selected;
+  final bool isToday;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cellBg = selected ? AppColors.primary : Colors.transparent;
+    final dayColor = selected
+        ? Colors.white
+        : (isToday ? AppColors.primary : AppColors.foreground);
+    final labelColor = selected
+        ? Colors.white.withValues(alpha: 0.85)
+        : AppColors.mutedForeground;
+
+    return InkWell(
+      onTap: onTap,
+      borderRadius: const BorderRadius.all(AppRadius.lg),
+      child: Container(
+        width: 40,
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        decoration: BoxDecoration(
+          color: cellBg,
+          borderRadius: const BorderRadius.all(AppRadius.lg),
+        ),
+        child: Column(
+          children: <Widget>[
+            Text(
+              label,
+              style: theme.textTheme.bodySmall?.copyWith(color: labelColor),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              date.day.toString(),
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: dayColor,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/flutter/lib/features/diet/presentation/widgets/meal_card.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/meal_card.dart
@@ -20,6 +20,7 @@ class MealCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return AppCard(
+      outlined: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[

--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
@@ -16,7 +16,7 @@ class MockExerciseRepository implements ExerciseRepository {
       totalMinutes: 240,
       totalCalories: 1450,
       streakDays: 3,
-      aiCoachMessage: '주간 운동 목표 80%를 달성했어요! 일요일에 가볍게 걷기를 더해 100%를 채워봐요.',
+      aiCoachMessage: '주간 운동 목표 80%를 달성했어요! 오늘 가볍게 걷기를 더해 100%를 채워봐요.',
       sessions: <ExerciseSession>[
         ExerciseSession(
           id: 's-today',

--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -7,7 +7,10 @@ import 'package:oncare/features/exercise/presentation/widgets/add_session_sheet.
 import 'package:oncare/features/exercise/presentation/widgets/exercise_tab_switcher.dart';
 import 'package:oncare/features/exercise/presentation/widgets/gym_tab.dart';
 import 'package:oncare/features/exercise/presentation/widgets/workout_record_tab.dart';
+import 'package:oncare/features/notification/presentation/widgets/notification_panel.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/modals/right_slide_panel.dart';
+import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
 import 'package:oncare/shared/widgets/oncare_header.dart';
 
 class ExercisePage extends ConsumerStatefulWidget {
@@ -27,7 +30,14 @@ class _ExercisePageState extends ConsumerState<ExercisePage> {
       backgroundColor: AppColors.background,
       body: Column(
         children: <Widget>[
-          OncareHeader(title: l.pageExerciseTitle),
+          OncareHeader(
+            title: l.pageExerciseTitle,
+            onNotificationTap: () => showRightSlidePanel<void>(
+              context,
+              content: const NotificationPanelBody(),
+            ),
+            onCalendarTap: () => showScheduleCalendarSheet(context),
+          ),
           Expanded(
             child: Center(
               child: ConstrainedBox(

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/gym_finder_sheet.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/gym_finder_sheet.dart
@@ -146,6 +146,7 @@ class _GymCandidateCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return AppCard(
+      outlined: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
@@ -69,6 +69,7 @@ class _EmptyGym extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return AppCard(
+      outlined: true,
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: AppSpacing.xl),
         child: Column(
@@ -124,6 +125,7 @@ class _MyGymCardState extends State<_MyGymCard> {
     final theme = Theme.of(context);
     final gym = widget.gym;
     return AppCard(
+      outlined: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/workout_record_tab.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/workout_record_tab.dart
@@ -89,6 +89,7 @@ class _Body extends ConsumerWidget {
 
         // Weekly chart.
         AppCard(
+          outlined: true,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
@@ -301,6 +302,7 @@ class _SessionCard extends StatelessWidget {
     final dateLabel = session.dateLabel ?? '${session.dayLabel}요일';
     final timeLabel = session.timeLabel;
     return AppCard(
+      outlined: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[

--- a/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
@@ -74,6 +74,7 @@ class _Body extends StatelessWidget {
             const _SectionTitle('설정'),
             const SizedBox(height: AppSpacing.sm),
             AppCard(
+              outlined: true,
               padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
               child: Column(
                 children: <Widget>[
@@ -116,6 +117,7 @@ class _ProfileCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AppCard(
+      outlined: true,
       child: Row(
         children: <Widget>[
           Container(
@@ -220,6 +222,7 @@ class _IndicatorTile extends StatelessWidget {
     final theme = Theme.of(context);
     final color = trend.improving ? AppColors.success : AppColors.warning;
     return AppCard(
+      outlined: true,
       child: Row(
         children: <Widget>[
           SizedBox(

--- a/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
@@ -9,8 +9,11 @@ import 'package:oncare/design_system/tokens/radius.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
 import 'package:oncare/features/my_health/domain/entities/health_history.dart';
 import 'package:oncare/features/my_health/presentation/controllers/my_health_controller.dart';
+import 'package:oncare/features/notification/presentation/widgets/notification_panel.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/widgets/error_view.dart';
+import 'package:oncare/shared/widgets/modals/right_slide_panel.dart';
+import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
 import 'package:oncare/shared/widgets/oncare_header.dart';
 
 class MyHealthPage extends ConsumerWidget {
@@ -24,7 +27,14 @@ class MyHealthPage extends ConsumerWidget {
       backgroundColor: AppColors.background,
       body: Column(
         children: <Widget>[
-          OncareHeader(title: l.pageMyHealthTitle),
+          OncareHeader(
+            title: l.pageMyHealthTitle,
+            onNotificationTap: () => showRightSlidePanel<void>(
+              context,
+              content: const NotificationPanelBody(),
+            ),
+            onCalendarTap: () => showScheduleCalendarSheet(context),
+          ),
           Expanded(
             child: async.when(
               data: (s) => _Body(state: s),

--- a/frontend/flutter/lib/shared/widgets/ai_coach_card.dart
+++ b/frontend/flutter/lib/shared/widgets/ai_coach_card.dart
@@ -36,7 +36,7 @@ class AiCoachCard extends StatelessWidget {
             ),
             alignment: Alignment.center,
             child: const Icon(
-              Icons.psychology_outlined,
+              Icons.smart_toy_outlined,
               color: AppColors.primary,
               size: 20,
             ),

--- a/frontend/flutter/lib/shared/widgets/ai_coach_card.dart
+++ b/frontend/flutter/lib/shared/widgets/ai_coach_card.dart
@@ -5,8 +5,9 @@ import 'package:oncare/design_system/tokens/radius.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
 
 /// Inline AI coach card used by Diet / Exercise / MyHealth pages.
-/// Subtle blue tint to match the "온이의 피드백" panel in the React
-/// original.
+/// White surface with the design-system gray border, matching the
+/// "온이의 피드백" panel in the latest design ref. The icon slot uses
+/// the same robot face the prototype shows in its avatar circle.
 class AiCoachCard extends StatelessWidget {
   const AiCoachCard({required this.message, this.title = '온이의 피드백', super.key});
 
@@ -19,9 +20,9 @@ class AiCoachCard extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(AppSpacing.md),
       decoration: BoxDecoration(
-        color: AppColors.primary.withValues(alpha: 0.08),
+        color: AppColors.card,
         borderRadius: const BorderRadius.all(AppRadius.card),
-        border: Border.all(color: AppColors.primary.withValues(alpha: 0.20)),
+        border: Border.all(color: AppColors.border),
       ),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -49,7 +50,7 @@ class AiCoachCard extends StatelessWidget {
                   title,
                   style: theme.textTheme.bodyMedium?.copyWith(
                     fontWeight: FontWeight.w600,
-                    color: AppColors.primary,
+                    color: AppColors.foreground,
                   ),
                 ),
                 const SizedBox(height: 4),

--- a/frontend/flutter/test/core/network/local_api_interceptor_dashboard_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_dashboard_test.dart
@@ -137,10 +137,11 @@ void main() {
       expect(res.statusCode, 200);
       final body = res.data!;
 
-      // Indicators — 4 rows, matching React mock totals.
+      // Indicators — 3 rows after 혈당 row was removed per the latest
+      // design ref (Home summary now ends at 당류).
       final indicators = (body['indicators']! as List<Object?>)
           .cast<Map<String, Object?>>();
-      expect(indicators.length, 4);
+      expect(indicators.length, 3);
       final byLabel = <String, Map<String, Object?>>{
         for (final i in indicators) i['label']! as String: i,
       };
@@ -148,7 +149,7 @@ void main() {
       expect(byLabel['나트륨']!['current'], 2100);
       expect(byLabel['나트륨']!['over_budget'], isTrue);
       expect(byLabel['당류']!['current'], 45);
-      expect(byLabel['혈당']!['current'], 95);
+      expect(byLabel.containsKey('혈당'), isFalse);
 
       // Quick stats.
       expect(body['diet_entries'], 3);

--- a/frontend/flutter/test/core/network/local_api_smoke_test.dart
+++ b/frontend/flutter/test/core/network/local_api_smoke_test.dart
@@ -42,20 +42,24 @@ void main() {
     final week = ExerciseWeek.fromJson(res.data!);
     expect(week.dailyMinutes.length, 7);
     expect(week.dayLabels, <String>['월', '화', '수', '목', '금', '토', '일']);
-    // Seed totals: 30+45+20+60+35+50 = 240
-    expect(week.totalMinutes, 240);
+    // v2 seed has multi-type rows per day so the stacked chart fills.
+    // Sum: 월 40 + 화 60 + 수 50 + 목 65 + 금 55 + 토 80 + 일 0 = 350.
+    expect(week.totalMinutes, 350);
   });
 
   test('dio → LocalApi → DashboardSummary aggregates seeded data', () async {
     final res = await dio.get<Map<String, Object?>>('/dashboard/summary');
     final summary = DashboardSummary.fromJson(res.data!);
-    expect(summary.indicators.length, 4);
-    // Seeded diet totals.
+    // 혈당 row was removed from the home summary; indicator list now
+    // ends at 당류 (calories / sodium / sugar).
+    expect(summary.indicators.length, 3);
     final cal = summary.indicators.firstWhere((i) => i.label == '칼로리');
     expect(cal.current, 1420);
-    // Seeded blood sugar.
-    final bs = summary.indicators.firstWhere((i) => i.label == '혈당');
-    expect(bs.current, 95);
+    expect(
+      summary.indicators.any((i) => i.label == '혈당'),
+      isFalse,
+      reason: '혈당 row should no longer be in the home summary',
+    );
     // 3 seeded meals.
     expect(summary.dietEntries, 3);
     // Two seeded schedule events.

--- a/frontend/flutter/test/features/dashboard/dashboard_controller_test.dart
+++ b/frontend/flutter/test/features/dashboard/dashboard_controller_test.dart
@@ -19,7 +19,9 @@ void main() {
     addTearDown(container.dispose);
     final summary = await container.read(dashboardSummaryProvider.future);
     expect(summary, isA<DashboardSummary>());
-    expect(summary.indicators.length, 4);
+    // 혈당 row was dropped from the home summary; expect 3 rows
+    // (칼로리 / 나트륨 / 당류).
+    expect(summary.indicators.length, 3);
     expect(summary.todaySchedule.length, 2);
     expect(summary.weekScore, 85);
   });


### PR DESCRIPTION
## Summary

새 디자인 ref (`oncare-prototype-참고사진.pdf`) 8가지 변경사항을 항목별 커밋으로 분리해 처리:

| # | 변경 | Commit |
|---|------|--------|
| 1 | 모든 주요 카드를 흰색 배경 + 회색 테두리로 통일 (`AppCard(outlined: true)`) | `c846df0` |
| 2 | 식단 / 운동 `온이의 피드백` 아이콘 → 로봇 (`Icons.smart_toy_outlined`) | `81dfb39` |
| 3 | 홈 `오늘의 건강 요약`에서 `혈당` 행 제거 | `6a49e3f` |
| 4 | 홈 `오늘의 건강 요약` 내부의 나트륨 경고 배너 제거 | `cccf8b4` |
| 5 | `오늘의 건강 기록` ↔ `오늘의 건강 요약` 사이에 🤖 종합 피드백 카드 추가 (식단/운동 한 줄씩, 이모지 포함) | `ff7b5e0` |
| 6 | 식단 페이지 상단에 날짜 헤더 + 주간 day picker 추가 | `24fe16e` |
| 7 | 운동 `온이의 피드백` 메시지의 `일요일` → `오늘` | `52c1cff` |
| 8 | 식단 / 운동 / My 헤더의 알림·캘린더 아이콘이 홈과 동일하게 동작하도록 wiring | `46724fc` |
| ➕ | 위 변경에 따른 dashboard controller 테스트 정리 | `88c1d42` |

### 카드 범위 (1번 항목 상세)

- **Home**: 오늘의 건강 요약, 오늘의 일정
- **식단**: 오늘의 영양 요약, 온이의 피드백, 오늘의 식단 (meal cards)
- **운동**: 이번 주 운동 현황, 온이의 피드백, 운동 기록 (session cards), 내 헬스장, 헬스장 찾기의 각 헬스장 후보
- **My**: 사용자 이름/이메일, 건강 지표 추이, 설정

스탯 칩과 그라데이션 hero 카드는 의도적으로 기존 톤 유지.

### 데이터 / API 변경

- `DashboardSummary` 에 `exerciseFeedback: String?` 추가 — 새 종합 피드백 카드의 운동 라인을 공급. `sodiumWarning` 은 같은 카드의 식단 라인으로 재활용 (별도 배너 제거).
- `LocalApiInterceptor._dashboardSummary`:
  - `혈당` indicator 와 그에 의존하던 `vitals/blood-sugar` 조회 제거
  - `exercise_feedback` 필드 추가
- `MockDashboardRepository` 도 동일하게 정리.
- `MockExerciseRepository` + `LocalApiInterceptor._exerciseCurrentWeek` 의 코치 메시지 `일요일` → `오늘`.

## Test plan

- [x] `flutter analyze` 통과 (사전 존재 warning 1건만)
- [x] `flutter test --exclude-tags=golden` 전체 통과 (85/85)
  - dashboard 인디케이터 카운트 4 → 3 으로 변경된 controller/smoke/interceptor 테스트 동기화
- [x] 홈 — 종합 피드백 카드 표시, 건강 요약 카드에 혈당 행 / 나트륨 배너 없음 확인
- [x] 식단 — 상단 날짜 + 주간 strip, 영양 요약·식단 카드 outlined, 온이의 피드백 로봇 아이콘
- [x] 운동 — 운동 현황·세션·내 헬스장 outlined, 온이의 피드백 메시지 "오늘 가볍게 걷기를 더해", 헬스장 후보 카드 outlined
- [x] My — 사용자/지표/설정 outlined
- [x] 식단·운동·My 헤더의 종·캘린더 아이콘 클릭 → 알림 패널 / 일정 시트 정상 동작