### PR TITLE
ci(deploy): add GitHub Pages deployment workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,71 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Flutter web and static intro page
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Check Flutter version
+        run: flutter --version
+
+      - name: Install Flutter dependencies
+        working-directory: frontend
+        run: flutter pub get
+
+      - name: Build Flutter web
+        working-directory: frontend
+        run: flutter build web --release --base-href "/sudo-capstone-project/frontend/"
+
+      - name: Prepare GitHub Pages files
+        run: |
+          mkdir -p public/frontend
+          cp index.html public/index.html
+          cp -R frontend/build/web/* public/frontend/
+          touch public/.nojekyll
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- GitHub Pages 배포를 위한 GitHub Actions workflow를 추가했습니다.
- 루트의 `index.html`은 소개 페이지로 배포합니다.
- `frontend` Flutter 프로젝트는 웹 빌드 후 `/frontend/` 경로로 배포합니다.
- Flutter 웹 앱의 asset 경로 문제를 방지하기 위해 `--base-href "/sudo-capstone-project/frontend/"` 옵션을 적용했습니다.

## Deployment URLs

- 소개 페이지: `https://cse-sudo-26.github.io/sudo-capstone-project/`
- Flutter 앱: `https://cse-sudo-26.github.io/sudo-capstone-project/frontend/`

## Notes

- GitHub Pages 설정에서 Source를 `GitHub Actions`로 변경해야 합니다.
- 우선 기본 `github.io` 주소 배포를 확인하기 위해 CNAME 복사는 제외했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated deployment of the web application to GitHub Pages on updates to the main branch, ensuring faster and more reliable release cycles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CSE-Sudo-26/sudo-capstone-project/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Closes #46