### PR TITLE
fix(deploy): Flutter project path in GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,18 +34,18 @@ jobs:
         run: flutter --version
 
       - name: Install Flutter dependencies
-        working-directory: frontend
+        working-directory: frontend/flutter
         run: flutter pub get
 
       - name: Build Flutter web
-        working-directory: frontend
+        working-directory: frontend/flutter
         run: flutter build web --release --base-href "/sudo-capstone-project/frontend/"
 
       - name: Prepare GitHub Pages files
         run: |
           mkdir -p public/frontend
           cp index.html public/index.html
-          cp -R frontend/build/web/* public/frontend/
+          cp -R frontend/flutter/build/web/* public/frontend/
           touch public/.nojekyll
 
       - name: Configure GitHub Pages


### PR DESCRIPTION
## Summary
- Flutter project lives at `frontend/flutter/`, not `frontend/`. The previous deploy workflow ran `flutter pub get` from `frontend/`, which has no `pubspec.yaml`, so the last run on `main` failed with "Expected to find project root in current working directory."
- Update `working-directory` for `pub get` and `build web` steps, plus the artifact copy path in the "Prepare GitHub Pages files" step.

## Test plan
- [x] After merge, the `Deploy GitHub Pages` workflow on `main` completes successfully.
- [x] Published site serves both the static intro page and the Flutter web app at `/sudo-capstone-project/frontend/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment configuration to streamline the release process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CSE-Sudo-26/sudo-capstone-project/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->