### PR TITLE
fix(deploy): use /frontend/ base-href to match custom domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build Flutter web
         working-directory: frontend/flutter
-        run: flutter build web --release --base-href "/sudo-capstone-project/frontend/"
+        run: flutter build web --release --base-href "/frontend/"
 
       - name: Prepare GitHub Pages files
         run: |


### PR DESCRIPTION
## Summary
- After the last deploy succeeded, accessing the Flutter site got redirected to `https://ewhasudo.zapto.org/frontend/` and the app failed to load.
- Root cause: `CNAME` sets a custom domain (`ewhasudo.zapto.org`), which strips the `/sudo-capstone-project/` path prefix on redirect. But the build used `--base-href "/sudo-capstone-project/frontend/"`, so the served HTML pointed `<base href>` at a path that 404s on the custom domain (`/sudo-capstone-project/frontend/main.dart.js` → 404; `/frontend/main.dart.js` → 200).
- Fix: build with `--base-href "/frontend/"` so asset paths match the actual serving path under the custom domain.

## Test plan
- [x] After merge, `Deploy GitHub Pages` workflow succeeds on `main`.
- [x] `https://ewhasudo.zapto.org/` serves the static intro page.
- [x] `https://ewhasudo.zapto.org/frontend/` loads the Flutter app with no 404s for `main.dart.js` / `flutter_bootstrap.js` / assets.