### PR TITLE
chore(deploy): download drift WASM in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,10 @@ jobs:
         working-directory: frontend/flutter
         run: flutter pub get
 
+      - name: Download drift WASM (sqlite3.wasm + drift_worker.js)
+        working-directory: frontend/flutter
+        run: bash tool/fetch_drift_wasm.sh
+
       - name: Build Flutter web
         working-directory: frontend/flutter
         run: flutter build web --release --base-href "/frontend/"


### PR DESCRIPTION
## Summary
- After the base-href fix, the Flutter app boots on the live site but immediately fails because `sqlite3.wasm` and `drift_worker.js` return 404 (no UI progresses past the empty body, hence \"infinite loading\").
- Root cause: those files are gitignored in [frontend/flutter/.gitignore](frontend/flutter/.gitignore:1) (they must match `pubspec.lock`'s drift version), and the deploy workflow never ran the existing [tool/fetch_drift_wasm.sh](frontend/flutter/tool/fetch_drift_wasm.sh) before `flutter build web`. The reference workflow at [frontend/flutter/.github/workflows/deploy-web.yml:38](frontend/flutter/.github/workflows/deploy-web.yml:38) shows the intended pattern.
- Fix: add the download step before `flutter build web` in our deploy workflow.

## Test plan
- [x] Workflow on `main` succeeds.
- [x] `https://ewhasudo.zapto.org/frontend/sqlite3.wasm` → 200
- [x] `https://ewhasudo.zapto.org/frontend/drift_worker.js` → 200
- [x] `https://ewhasudo.zapto.org/frontend/` renders the oncare dashboard (no more blank page).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build pipeline to fetch required dependencies during the deployment process, improving build efficiency and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CSE-Sudo-26/sudo-capstone-project/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->