### PR TITLE
feat(ui): diet add flow shell + FAB consistency + AI coach cleanup

### DIFF
--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -455,11 +455,6 @@ class LocalApiInterceptor extends Interceptor {
           'title': '수분 보충',
           'body': '오늘 평소보다 활동량이 많았어요. 물 한 컵 더 마셔봐요.',
         },
-        <String, Object?>{
-          'tag': 'sleep',
-          'title': '취침 1시간 전 화면 줄이기',
-          'body': '깊은 수면 비율이 낮은 패턴이 보입니다. 자극을 줄여보세요.',
-        },
       ],
     });
   }

--- a/frontend/flutter/lib/features/ai_coach/data/repositories/mock_ai_coach_repository.dart
+++ b/frontend/flutter/lib/features/ai_coach/data/repositories/mock_ai_coach_repository.dart
@@ -25,11 +25,6 @@ class MockAiCoachRepository implements AiCoachRepository {
           title: '수분 보충',
           body: '오늘 평소보다 활동량이 많았어요. 물 한 컵 더 마셔봐요.',
         ),
-        AiSuggestion(
-          tag: AiSuggestionTag.sleep,
-          title: '취침 1시간 전 화면 줄이기',
-          body: '깊은 수면 비율이 낮은 패턴이 보입니다. 자극을 줄여보세요.',
-        ),
       ],
     );
   }

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_add_analyzing_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_add_analyzing_page.dart
@@ -1,0 +1,218 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/design_system/tokens/radius.dart';
+import 'package:oncare/design_system/tokens/spacing.dart';
+
+/// Fake "AI 분석 중" screen shown after the shutter is pressed.
+/// Steps cycle every ~900ms and the screen auto-completes after ~2.8s,
+/// popping `true` so the camera page knows the capture flow finished.
+/// The actual YOLO / Gemini Vision pipeline is not wired up yet — this
+/// is a UX placeholder so the diet add flow feels live in demos.
+class DietAddAnalyzingPage extends StatefulWidget {
+  const DietAddAnalyzingPage({super.key});
+
+  @override
+  State<DietAddAnalyzingPage> createState() => _DietAddAnalyzingPageState();
+}
+
+class _DietAddAnalyzingPageState extends State<DietAddAnalyzingPage> {
+  static const List<_Step> _steps = <_Step>[
+    _Step(icon: Icons.center_focus_strong, label: '음식을 인식하고 있어요'),
+    _Step(icon: Icons.calculate_outlined, label: '영양 정보를 계산하고 있어요'),
+    _Step(icon: Icons.fact_check_outlined, label: '결과를 정리하고 있어요'),
+  ];
+
+  int _stepIndex = 0;
+  Timer? _stepTimer;
+  Timer? _doneTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _stepTimer = Timer.periodic(const Duration(milliseconds: 900), (Timer t) {
+      if (!mounted) return;
+      if (_stepIndex >= _steps.length - 1) {
+        t.cancel();
+        return;
+      }
+      setState(() => _stepIndex++);
+    });
+    _doneTimer = Timer(const Duration(milliseconds: 2800), () {
+      if (!mounted) return;
+      Navigator.of(context).pop(true);
+    });
+  }
+
+  @override
+  void dispose() {
+    _stepTimer?.cancel();
+    _doneTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        child: Stack(
+          children: <Widget>[
+            Align(
+              alignment: Alignment.topLeft,
+              child: Padding(
+                padding: const EdgeInsets.all(AppSpacing.sm),
+                child: IconButton(
+                  tooltip: '취소',
+                  onPressed: () => Navigator.of(context).pop(false),
+                  icon: const Icon(Icons.close),
+                ),
+              ),
+            ),
+            Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 360),
+                child: Padding(
+                  padding: const EdgeInsets.all(AppSpacing.lg),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: <Widget>[
+                      const Center(child: _CapturedThumbnail()),
+                      const SizedBox(height: AppSpacing.xl),
+                      const Center(
+                        child: SizedBox(
+                          width: 48,
+                          height: 48,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 4,
+                            color: AppColors.primary,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: AppSpacing.lg),
+                      Text(
+                        'AI가 식단을 분석하고 있어요',
+                        textAlign: TextAlign.center,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: AppSpacing.xs),
+                      Text(
+                        '잠시만 기다려 주세요 · 보통 2~3초 소요됩니다',
+                        textAlign: TextAlign.center,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: AppColors.mutedForeground,
+                        ),
+                      ),
+                      const SizedBox(height: AppSpacing.xl),
+                      for (int i = 0; i < _steps.length; i++)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+                          child: _StepRow(
+                            step: _steps[i],
+                            state: i < _stepIndex
+                                ? _RowState.done
+                                : i == _stepIndex
+                                    ? _RowState.active
+                                    : _RowState.pending,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+enum _RowState { pending, active, done }
+
+class _Step {
+  const _Step({required this.icon, required this.label});
+  final IconData icon;
+  final String label;
+}
+
+class _StepRow extends StatelessWidget {
+  const _StepRow({required this.step, required this.state});
+
+  final _Step step;
+  final _RowState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final leading = switch (state) {
+      _RowState.done => const Icon(
+          Icons.check_circle,
+          color: AppColors.success,
+          size: 22,
+        ),
+      _RowState.active => const SizedBox(
+          width: 22,
+          height: 22,
+          child: CircularProgressIndicator(
+            strokeWidth: 2.4,
+            color: AppColors.primary,
+          ),
+        ),
+      _RowState.pending => Icon(
+          step.icon,
+          color: AppColors.mutedForeground,
+          size: 22,
+        ),
+    };
+    return Row(
+      children: <Widget>[
+        SizedBox(width: 28, height: 28, child: Center(child: leading)),
+        const SizedBox(width: AppSpacing.md),
+        Expanded(
+          child: Text(
+            step.label,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: state == _RowState.pending
+                  ? AppColors.mutedForeground
+                  : AppColors.foreground,
+              fontWeight: state == _RowState.active
+                  ? FontWeight.w600
+                  : FontWeight.w500,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CapturedThumbnail extends StatelessWidget {
+  const _CapturedThumbnail();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 132,
+      height: 132,
+      decoration: BoxDecoration(
+        borderRadius: const BorderRadius.all(AppRadius.lg),
+        gradient: const LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: <Color>[AppColors.accent, AppColors.muted],
+        ),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: const Center(
+        child: Icon(Icons.restaurant, size: 48, color: AppColors.primary),
+      ),
+    );
+  }
+}

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_add_camera_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_add_camera_page.dart
@@ -1,0 +1,271 @@
+import 'package:flutter/material.dart';
+
+import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/diet/presentation/pages/diet_add_analyzing_page.dart';
+
+/// Fake camera capture screen. Renders a viewfinder-style overlay over
+/// a dark gradient placeholder (no real camera preview yet). Tapping the
+/// shutter flashes the screen and pushes the analyzing page. When the
+/// analyzing page returns `true`, this page pops with `true` so the
+/// diet record page can confirm the capture flow finished.
+class DietAddCameraPage extends StatefulWidget {
+  const DietAddCameraPage({super.key});
+
+  @override
+  State<DietAddCameraPage> createState() => _DietAddCameraPageState();
+}
+
+class _DietAddCameraPageState extends State<DietAddCameraPage>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _flashCtrl = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 220),
+  );
+  bool _capturing = false;
+
+  @override
+  void dispose() {
+    _flashCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _onShutter() async {
+    if (_capturing) return;
+    setState(() => _capturing = true);
+    await _flashCtrl.forward(from: 0);
+    if (!mounted) return;
+    final analyzed = await Navigator.of(context).push<bool>(
+      MaterialPageRoute<bool>(
+        builder: (_) => const DietAddAnalyzingPage(),
+        fullscreenDialog: true,
+      ),
+    );
+    if (!mounted) return;
+    if (analyzed == true) {
+      Navigator.of(context).pop(true);
+    } else {
+      // User cancelled analysis — stay on camera so they can retake.
+      _flashCtrl.reverse();
+      setState(() => _capturing = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Stack(
+        children: <Widget>[
+          const Positioned.fill(child: _FauxCameraPreview()),
+          const Center(child: _ViewfinderFrame()),
+          SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(AppSpacing.lg),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  _RoundIconButton(
+                    icon: Icons.close,
+                    onTap: () => Navigator.of(context).pop(false),
+                  ),
+                  const Spacer(),
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.md,
+                      vertical: AppSpacing.xs,
+                    ),
+                    decoration: BoxDecoration(
+                      color: Colors.black.withValues(alpha: 0.5),
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                    child: const Text(
+                      '식단 사진 촬영',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                  const Spacer(),
+                  const SizedBox(width: 40),
+                ],
+              ),
+            ),
+          ),
+          Align(
+            alignment: const Alignment(0, 0.6),
+            child: Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSpacing.md,
+                vertical: AppSpacing.xs,
+              ),
+              decoration: BoxDecoration(
+                color: Colors.black.withValues(alpha: 0.45),
+                borderRadius: BorderRadius.circular(999),
+              ),
+              child: const Text(
+                '음식이 프레임 안에 들어오도록 맞춰 주세요',
+                style: TextStyle(color: Colors.white, fontSize: 13),
+              ),
+            ),
+          ),
+          SafeArea(
+            child: Align(
+              alignment: Alignment.bottomCenter,
+              child: Padding(
+                padding: const EdgeInsets.only(bottom: AppSpacing.xxl),
+                child: _ShutterButton(
+                  onTap: _onShutter,
+                  enabled: !_capturing,
+                ),
+              ),
+            ),
+          ),
+          IgnorePointer(
+            child: FadeTransition(
+              opacity: Tween<double>(begin: 0, end: 1).animate(
+                CurvedAnimation(parent: _flashCtrl, curve: Curves.easeOut),
+              ),
+              child: Container(color: Colors.white),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FauxCameraPreview extends StatelessWidget {
+  const _FauxCameraPreview();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        gradient: RadialGradient(
+          colors: <Color>[Color(0xFF1F2937), Color(0xFF0B1220)],
+          radius: 1.2,
+        ),
+      ),
+    );
+  }
+}
+
+class _ViewfinderFrame extends StatelessWidget {
+  const _ViewfinderFrame();
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size.shortestSide * 0.72;
+    return SizedBox(
+      width: size,
+      height: size,
+      child: const Stack(
+        children: <Widget>[
+          Align(alignment: Alignment.topLeft, child: _CornerBracket(corner: Alignment.topLeft)),
+          Align(alignment: Alignment.topRight, child: _CornerBracket(corner: Alignment.topRight)),
+          Align(alignment: Alignment.bottomLeft, child: _CornerBracket(corner: Alignment.bottomLeft)),
+          Align(alignment: Alignment.bottomRight, child: _CornerBracket(corner: Alignment.bottomRight)),
+        ],
+      ),
+    );
+  }
+}
+
+class _CornerBracket extends StatelessWidget {
+  const _CornerBracket({required this.corner});
+
+  final Alignment corner;
+
+  @override
+  Widget build(BuildContext context) {
+    const double thickness = 3;
+    const double length = 28;
+    final color = Colors.white.withValues(alpha: 0.9);
+    final isTop = corner.y < 0;
+    final isLeft = corner.x < 0;
+    return SizedBox(
+      width: length,
+      height: length,
+      child: Stack(
+        children: <Widget>[
+          Positioned(
+            top: isTop ? 0 : null,
+            bottom: isTop ? null : 0,
+            left: isLeft ? 0 : null,
+            right: isLeft ? null : 0,
+            child: Container(width: length, height: thickness, color: color),
+          ),
+          Positioned(
+            top: isTop ? 0 : null,
+            bottom: isTop ? null : 0,
+            left: isLeft ? 0 : null,
+            right: isLeft ? null : 0,
+            child: Container(width: thickness, height: length, color: color),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RoundIconButton extends StatelessWidget {
+  const _RoundIconButton({required this.icon, required this.onTap});
+
+  final IconData icon;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.black.withValues(alpha: 0.45),
+      shape: const CircleBorder(),
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: onTap,
+        child: SizedBox(
+          width: 40,
+          height: 40,
+          child: Icon(icon, color: Colors.white, size: 22),
+        ),
+      ),
+    );
+  }
+}
+
+class _ShutterButton extends StatelessWidget {
+  const _ShutterButton({required this.onTap, required this.enabled});
+
+  final VoidCallback onTap;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: enabled ? onTap : null,
+      child: AnimatedOpacity(
+        opacity: enabled ? 1.0 : 0.5,
+        duration: const Duration(milliseconds: 120),
+        child: Container(
+          width: 78,
+          height: 78,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            border: Border.all(color: Colors.white, width: 4),
+          ),
+          child: Center(
+            child: Container(
+              width: 62,
+              height: 62,
+              decoration: const BoxDecoration(
+                shape: BoxShape.circle,
+                color: Colors.white,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -5,6 +5,7 @@ import 'package:oncare/core/errors/app_error.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
+import 'package:oncare/features/diet/presentation/pages/diet_add_camera_page.dart';
 import 'package:oncare/features/diet/presentation/widgets/diet_summary_card.dart';
 import 'package:oncare/features/diet/presentation/widgets/diet_week_strip.dart';
 import 'package:oncare/features/diet/presentation/widgets/meal_card.dart';
@@ -25,6 +26,24 @@ class DietRecordPage extends ConsumerStatefulWidget {
 
 class _DietRecordPageState extends ConsumerState<DietRecordPage> {
   late DateTime _selectedDay = DateTime.now();
+
+  Future<void> _openDietAddFlow() async {
+    final captured = await Navigator.of(context).push<bool>(
+      MaterialPageRoute<bool>(
+        builder: (_) => const DietAddCameraPage(),
+        fullscreenDialog: true,
+      ),
+    );
+    if (!mounted) return;
+    if (captured == true) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('식단 분석을 완료했어요. 결과 확인 화면은 곧 공개됩니다.'),
+          duration: Duration(seconds: 3),
+        ),
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -98,14 +117,7 @@ class _DietRecordPageState extends ConsumerState<DietRecordPage> {
       floatingActionButton: FloatingActionButton(
         backgroundColor: AppColors.primary,
         foregroundColor: AppColors.primaryForeground,
-        onPressed: () {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('식단 추가 — 카메라/수동 입력은 Stage 8.7'),
-              duration: Duration(seconds: 2),
-            ),
-          );
-        },
+        onPressed: _openDietAddFlow,
         child: const Icon(Icons.add),
       ),
     );

--- a/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
@@ -21,17 +21,17 @@ void main() {
     dio.close();
   });
 
-  test('GET /ai-coach/feedback returns greeting + 4 suggestions', () async {
+  test('GET /ai-coach/feedback returns greeting + 3 suggestions', () async {
     final res = await dio.get<Map<String, Object?>>('/ai-coach/feedback');
     expect(res.statusCode, 200);
     expect(res.data!['greeting'], isNotEmpty);
     final suggestions = (res.data!['suggestions']! as List<Object?>)
         .cast<Map<String, Object?>>();
-    expect(suggestions.length, 4);
+    expect(suggestions.length, 3);
     final tags = suggestions.map((s) => s['tag']! as String).toSet();
     expect(
       tags,
-      containsAll(<String>['diet', 'exercise', 'sleep', 'hydration']),
+      containsAll(<String>['diet', 'exercise', 'hydration']),
     );
   });
 


### PR DESCRIPTION
## Summary

- **식단 추가 (UI shell only)** — Diet 페이지 `+` FAB 탭 시 풀스크린 카메라 뷰파인더 → 셔터 → "AI 분석 중" 로딩 화면 (~2.8초, 3단계) → 완료 시 스낵바로 다음 단계 안내. 실제 카메라/YOLOv8/Gemini Vision 연동은 아직 없음 — 데모용 UX 뼈대만 추가.
- **AI 코치 수면 추천 제거** — 홈 AI 코치 패널 mock 데이터에서 "취침 1시간 전 화면 줄이기" 항목 삭제. 식단·운동·수분 3개만 노출.
- **FAB 일관성** — 홈/식단/운동 세 페이지 `+` 버튼을 동일 크기(56dp 원형)·동일 위치(Scaffold 기본 슬롯)·동일 스타일로 통일. 홈의 "AI 코치" 라벨 제거, 아이콘만 노출.
- **로봇 아이콘 일관성** — 홈 일일 피드백 카드의 로봇 아바타(🤖 이모지 + alpha 0.12)를 `Icons.smart_toy_outlined` + alpha 0.18 로 변경해 다른 "온이의 피드백" 카드들과 동일하게 정렬.

## Commits

1. `05b3e5f` Add diet add camera + analyzing loading flow (UI shell)
2. `2a2c704` Remove sleep suggestion from AI Coach mock feedback
3. `5752675` Unify home/diet/exercise FABs as circular icon-only buttons
4. `3bb743c` Match sodium-warning robot icon to 온이의 피드백 style

## Notes

- 카메라 사용자 X 탭 시 식단 페이지로 복귀, 로딩 X 탭 시 카메라로 복귀(재촬영 가능).
- 운동 FAB은 운동 기록 탭(`_activeIndex == 0`)에서만 노출 — 헬스장 탭에서는 숨김.
- `flutter analyze` clean(사전 존재 `package_api_docs` 경고 외 변경 없음).
- 관련 테스트(`dashboard`, `diet`, `exercise`, `ai_coach`, `widget_test`, `local_api_interceptor_aux_test`) 전부 통과.
- `AiSuggestionTag.sleep` enum 값은 유지 — panel/page switch의 exhaustiveness 보존.

## Test plan

- [x] Diet 탭 → `+` 탭 → 카메라 화면 → 셔터 → 로딩 단계 진행 → 자동 복귀 + 스낵바 확인
- [x] 홈/식단/운동 세 화면을 오가며 `+` 버튼이 동일 크기·위치·원형으로 보이는지 확인
- [x] 홈 `+` 버튼이 라벨 없이 로봇 아이콘만 표시되는지 확인
- [x] 홈 "오늘의 나트륨 섭취량이…" 카드의 로봇 아바타가 "온이의 피드백" 카드의 아바타와 동일한지 확인
- [x] 홈 AI 코치 패널에서 수면 카드가 사라졌는지 확인 (식단·운동·수분 3개만)
- [x] 운동 탭에서 헬스장 탭으로 전환 시 FAB이 사라지는지 확인