### PR TITLE
feat(ui): unify FAB style + match dashboard robot icon

### DIFF
--- a/frontend/flutter/lib/features/dashboard/presentation/pages/dashboard_page.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/pages/dashboard_page.dart
@@ -61,15 +61,15 @@ class DashboardPage extends ConsumerWidget {
           ),
         ],
       ),
-      floatingActionButton: FloatingActionButton.extended(
+      floatingActionButton: FloatingActionButton(
         backgroundColor: AppColors.primary,
         foregroundColor: AppColors.primaryForeground,
-        icon: const Icon(Icons.smart_toy_outlined),
-        label: const Text('AI 코치'),
+        tooltip: 'AI 코치',
         onPressed: () => showRightSlidePanel<void>(
           context,
           content: const AiCoachPanelBody(),
         ),
+        child: const Icon(Icons.smart_toy_outlined),
       ),
     );
   }

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -185,11 +185,15 @@ class _DailyFeedbackCard extends StatelessWidget {
             width: 36,
             height: 36,
             decoration: BoxDecoration(
-              color: AppColors.primary.withValues(alpha: 0.12),
+              color: AppColors.primary.withValues(alpha: 0.18),
               borderRadius: const BorderRadius.all(AppRadius.lg),
             ),
             alignment: Alignment.center,
-            child: const Text('🤖', style: TextStyle(fontSize: 20)),
+            child: const Icon(
+              Icons.smart_toy_outlined,
+              color: AppColors.primary,
+              size: 20,
+            ),
           ),
           const SizedBox(width: AppSpacing.md),
           Expanded(

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -117,6 +117,7 @@ class _DietRecordPageState extends ConsumerState<DietRecordPage> {
       floatingActionButton: FloatingActionButton(
         backgroundColor: AppColors.primary,
         foregroundColor: AppColors.primaryForeground,
+        tooltip: '식단 추가',
         onPressed: _openDietAddFlow,
         child: const Icon(Icons.add),
       ),

--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -42,41 +42,29 @@ class _ExercisePageState extends ConsumerState<ExercisePage> {
             child: Center(
               child: ConstrainedBox(
                 constraints: const BoxConstraints(maxWidth: 672),
-                child: Stack(
+                child: Column(
                   children: <Widget>[
-                    Column(
-                      children: <Widget>[
-                        Padding(
-                          padding: const EdgeInsets.fromLTRB(
-                            AppSpacing.lg,
-                            AppSpacing.md,
-                            AppSpacing.lg,
-                            AppSpacing.sm,
-                          ),
-                          child: ExerciseTabSwitcher(
-                            activeIndex: _activeIndex,
-                            onChange: (i) => setState(() => _activeIndex = i),
-                          ),
-                        ),
-                        Expanded(
-                          child: IndexedStack(
-                            index: _activeIndex,
-                            children: const <Widget>[
-                              WorkoutRecordTab(),
-                              GymTab(),
-                            ],
-                          ),
-                        ),
-                      ],
-                    ),
-                    if (_activeIndex == 0)
-                      Positioned(
-                        right: AppSpacing.lg,
-                        bottom: AppSpacing.lg,
-                        child: _AddSessionFab(
-                          onPressed: () => showAddSessionSheet(context),
-                        ),
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(
+                        AppSpacing.lg,
+                        AppSpacing.md,
+                        AppSpacing.lg,
+                        AppSpacing.sm,
                       ),
+                      child: ExerciseTabSwitcher(
+                        activeIndex: _activeIndex,
+                        onChange: (i) => setState(() => _activeIndex = i),
+                      ),
+                    ),
+                    Expanded(
+                      child: IndexedStack(
+                        index: _activeIndex,
+                        children: const <Widget>[
+                          WorkoutRecordTab(),
+                          GymTab(),
+                        ],
+                      ),
+                    ),
                   ],
                 ),
               ),
@@ -84,29 +72,15 @@ class _ExercisePageState extends ConsumerState<ExercisePage> {
           ),
         ],
       ),
-    );
-  }
-}
-
-class _AddSessionFab extends StatelessWidget {
-  const _AddSessionFab({required this.onPressed});
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return Material(
-      color: AppColors.primary,
-      shape: const CircleBorder(),
-      elevation: 4,
-      child: InkWell(
-        customBorder: const CircleBorder(),
-        onTap: onPressed,
-        child: const SizedBox(
-          width: 56,
-          height: 56,
-          child: Icon(Icons.add, size: 28, color: Colors.white),
-        ),
-      ),
+      floatingActionButton: _activeIndex == 0
+          ? FloatingActionButton(
+              backgroundColor: AppColors.primary,
+              foregroundColor: AppColors.primaryForeground,
+              tooltip: '운동 기록 추가',
+              onPressed: () => showAddSessionSheet(context),
+              child: const Icon(Icons.add),
+            )
+          : null,
     );
   }
 }


### PR DESCRIPTION
## Summary

- **FAB 일관성** — 홈/식단/운동 세 페이지의 `+` 플로팅 버튼을 동일 크기(56dp 원형) · 동일 위치(Scaffold 기본 슬롯) · 동일 스타일로 통일했습니다. 홈의 "AI 코치" 텍스트 라벨은 제거하고 로봇 아이콘만 남겼습니다.
- **로봇 아이콘 일관성** — 홈 일일 피드백 카드("오늘의 나트륨 섭취량이…")의 로봇 아바타를 다른 "온이의 피드백" 카드와 동일한 `Icons.smart_toy_outlined`(primary tint 0.18)로 정렬했습니다. 기존에는 🤖 이모지에 0.12 tint라서 다른 카드와 시각적으로 달랐습니다.

## Changes

**FAB 통일 (commit 1 — `920e664`)**
- `lib/features/dashboard/presentation/pages/dashboard_page.dart` — `FloatingActionButton.extended` → `FloatingActionButton` (라벨 제거, 아이콘만, tooltip="AI 코치")
- `lib/features/exercise/presentation/pages/exercise_page.dart` — body 내부 `Positioned(_AddSessionFab)`를 `Scaffold.floatingActionButton` 슬롯으로 이동. 헬스장 탭(`_activeIndex == 1`)에서는 숨김 처리. 더 이상 쓰지 않는 `_AddSessionFab` 클래스 제거.
- `lib/features/diet/presentation/pages/diet_record_page.dart` — tooltip="식단 추가" 추가로 패리티 맞춤.

**아이콘 통일 (commit 2 — `c6f64c2`)**
- `lib/features/dashboard/presentation/widgets/dashboard_content.dart` — `_DailyFeedbackCard`의 🤖 이모지 + alpha 0.12 → `Icons.smart_toy_outlined` + alpha 0.18 (`AiCoachCard`와 동일).

## Notes

- 운동 FAB의 기존 `Positioned` 방식은 가로가 넓은 화면에서 max-672 ConstrainedBox 가장자리에 붙어서 화면 우측 가장자리와 어긋났습니다. Scaffold 슬롯으로 옮기면서 다른 두 페이지와 정확히 같은 위치(우측 하단, Material 기본 오프셋)에 정렬됩니다.
- `flutter analyze` clean(사전 존재 `package_api_docs` 경고 외 변경 없음).
- PR #19 머지 이후 누락된 변경분을 분리해서 다시 올립니다.

## Test plan

- [x] 홈/식단/운동 세 화면을 오가며 `+` 버튼이 동일 크기·위치·원형으로 보이는지 확인
- [x] 홈 `+` 버튼이 라벨 없이 로봇 아이콘만 표시되는지 확인
- [x] 홈 "오늘의 나트륨 섭취량이…" 카드의 로봇 아바타가 다른 "온이의 피드백" 카드 아바타와 동일한지 확인
- [x] 운동 탭에서 헬스장 탭으로 전환 시 FAB이 사라지는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * "AI 코치" button now displays with compact icon and tooltip for clarity
  * Added tooltip to diet recording action button
  * Robot avatar redesigned with enhanced icon graphics
  * Exercise page layout refined with repositioned action button

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CSE-Sudo-26/sudo-capstone-project/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->