### PR TITLE
fix(diagram): resolve legend and result-box overlap in vision pipeline diagram

### DIFF
--- a/docs/diagrams/vision-pipeline.svg
+++ b/docs/diagrams/vision-pipeline.svg
@@ -51,7 +51,7 @@
   <line x1="480" y1="720" x2="480" y2="778" stroke="#2563eb" stroke-width="1.5" marker-end="url(#ar-blue)"/>
   <rect x="454.0" y="741.0" width="52" height="16" fill="#ffffff" opacity="0.95" rx="3"/>
   <text x="480" y="753.0" text-anchor="middle" font-size="11" fill="#2563eb" font-weight="600">최종 출력</text>
-  <g transform="translate(40, 836)">
+  <g transform="translate(40, 860)">
     <line x1="0" y1="6" x2="28" y2="6" stroke="#2563eb" stroke-width="1.5" marker-end="url(#ar-blue)"/>
     <text x="36" y="10" font-size="11" fill="#6b7280">메인 데이터 흐름</text>
     <line x1="160" y1="6" x2="188" y2="6" stroke="#dc2626" stroke-width="1.5" marker-end="url(#ar-warn)"/>


### PR DESCRIPTION
## Summary

* `docs/diagrams/vision-pipeline.svg` 하단 범례가 \"결과:\" 박스와 겹치던 시각 버그 수정
* 범례 그룹 `<g transform>` origin을 y=836 → y=860으로 내려 박스 하단(y=844)과 22px 마진 확보
* viewBox(880) 안에 안전하게 fit (텍스트 descent 포함 약 10px 여유)

---

## Changes

### 🐛 Fixes

* `docs/diagrams/vision-pipeline.svg` — 범례 그룹 origin 24px 하향 이동

---

## Commits

1. `682ac28` fix(diagram): move vision pipeline legend below result box

---

## Notes

* SVG 단일 파일 한 줄 수정. 다른 다이어그램·코드 영향 없음.
* viewBox 자체는 그대로 유지(880). 추후 더 많은 범례 항목이 필요해지면 viewBox 확장 검토 필요.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| 범례 화살표가 "결과:" 박스 내부와 겹침 (legend y=842, box y=780-844) | 범례가 박스 하단 아래로 분리 (legend y=866) |

---

## Test Plan

* [x] SVG가 GitHub에서 정상 렌더링되는지 확인
* [x] 범례 두 항목(메인 데이터 흐름·비음식 반려)이 "결과:" 박스와 겹치지 않는지 확인
* [x] viewBox 경계 안에 모든 요소 표시되는지 확인

### Manual Test Steps

1. GitHub에서 `docs/diagrams/vision-pipeline.svg` 미리보기
2. 다이어그램 하단 \"결과:\" 박스와 범례 영역이 시각적으로 분리되어 있는지 확인

---

## Related Issues

Closes #57

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검 (y 좌표 24px 이동, viewBox 한계 확인)
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인 (다이어그램만 수정, 앱 코드 영향 없음)