### PR TITLE
chore(repo): add CodeRabbit configuration for automated code reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,99 @@
+# CodeRabbit configuration — On-Care capstone project
+# Docs: https://docs.coderabbit.ai/configure-coderabbit
+#
+# 본 설정은 한국어 리뷰 + 캡스톤 학부 팀 친화적 톤을 기본값으로 한다.
+# 필요 시 항목별로 자유롭게 조정하되, path_filters · path_instructions 는
+# 프로젝트 구조 변경 시 함께 갱신할 것.
+
+language: ko-KR
+
+tone_instructions: >-
+  친근하고 명확한 한국어로 리뷰. 캡스톤 학부 팀이 이해할 수 있도록
+  과도하게 학술적이거나 장황한 표현은 피한다. 잘못된 점만 지적하기보다
+  *왜* 그렇게 바꿔야 하는지 한두 줄로 근거를 함께 제시한다.
+
+early_access: false
+
+reviews:
+  # chill = 덜 공격적 / assertive = 더 엄격
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_in_walkthrough: false
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: false
+    base_branches:
+      - main
+
+  # 리뷰에서 제외할 경로 (자동 생성 · 빌드 산출물 · 플랫폼 디렉토리 · 의존성)
+  path_filters:
+    # Flutter 자동 생성 코드
+    - "!**/*.g.dart"
+    - "!**/*.freezed.dart"
+    - "!frontend/flutter/lib/gen/**"
+    - "!frontend/flutter/lib/l10n/app_localizations*.dart"
+    # Flutter 플랫폼 디렉토리 (직접 수정하지 않음)
+    - "!frontend/flutter/ios/**"
+    - "!frontend/flutter/android/**"
+    - "!frontend/flutter/macos/**"
+    - "!frontend/flutter/windows/**"
+    - "!frontend/flutter/linux/**"
+    - "!frontend/flutter/web/**"
+    # 빌드 산출물 / 의존성
+    - "!**/build/**"
+    - "!**/.dart_tool/**"
+    - "!**/node_modules/**"
+    - "!**/.venv/**"
+    - "!**/*.lock"
+    - "!**/pubspec.lock"
+    # Golden 테스트 스냅샷 (바이너리)
+    - "!**/test/golden/**"
+    # 에디터 설정
+    - "!**/.idea/**"
+    - "!**/.vscode/**"
+
+  # 경로별 리뷰 가이드 — 해당 디렉토리 변경 시 우선 점검할 항목
+  path_instructions:
+    - path: "frontend/flutter/lib/features/**"
+      instructions: >-
+        Flutter feature 모듈. Riverpod 상태 관리, go_router 라우팅,
+        domain/data/presentation 레이어 분리 컨벤션을 따르는지 확인.
+        feature 간 직접 의존이 아닌 shared/ 또는 design_system/ 를
+        통한 간접 의존을 권장.
+
+    - path: "frontend/flutter/lib/design_system/**"
+      instructions: >-
+        디자인 시스템 (tokens / atoms / molecules / charts).
+        새 토큰 추가 시 기존 토큰과 의미가 겹치지 않는지, atoms 는
+        부작용(side effect) 없이 props 만으로 렌더되는지 확인.
+
+    - path: "frontend/flutter/lib/core/network/**"
+      instructions: >-
+        Dio interceptor + LocalApiInterceptor 영역. mock 응답 추가 시
+        실제 백엔드 스키마와 일치하는지, USE_MOCK_API 플래그로 전환
+        가능한 구조를 유지하는지 확인.
+
+    - path: "frontend/flutter/test/**"
+      instructions: >-
+        Flutter 테스트. 단위·위젯·golden·integration 테스트가
+        적절한 깊이로 작성되었는지, mock 데이터가 실제 entity 스키마와
+        일치하는지 확인.
+
+    - path: "docs/**"
+      instructions: >-
+        프로젝트 문서. 마크다운 렌더링·헤딩 계층·placeholder 표기 일관성
+        위주로 검토. README 갱신이 필요한 변경인지도 확인.
+
+    - path: ".github/**"
+      instructions: >-
+        GitHub 워크플로우·템플릿. 시크릿 노출·과도한 권한 부여·외부
+        action 의 핀(pin) 누락이 없는지 우선 점검.
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
## Summary

* PR 에 이미 자동 실행되고 있는 CodeRabbit 봇의 동작을 **한국어 리뷰 + 캡스톤 학부 팀 친화적 톤** + 프로젝트 구조에 맞는 path filter / path instructions 로 커스터마이즈
* Flutter 자동 생성 코드 / 플랫폼 디렉토리 / 빌드 산출물 / golden 스냅샷을 리뷰 대상에서 제외해 **노이즈 제거**
* `features/` · `design_system/` · `core/network/` · `test/` · `docs/` · `.github/` 별 우선 점검 항목을 제시해 **리뷰 시그널 향상**

---

## Changes

### 📝 Docs

* `.coderabbit.yaml` 신규
  - `language: ko-KR`
  - `tone_instructions` — 친근·명확·근거 제시 톤 (학부 캡스톤 친화적)
  - `reviews.profile: chill` + `auto_review` on main (draft 제외)
  - `path_filters` — `*.g.dart` · `*.freezed.dart` · `lib/gen/` · `lib/l10n/app_localizations*` · 플랫폼 디렉토리 · `build/` · `.dart_tool/` · `node_modules/` · `.venv/` · `*.lock` · golden 스냅샷 · `.idea/` · `.vscode/` 제외
  - `path_instructions` — 6개 디렉토리별 우선 점검 항목 (Riverpod 컨벤션 · 디자인 토큰 의미 중복 · LocalApiInterceptor 스키마 일치 · 시크릿 노출 등)

---

## Commits

1. `$(git rev-parse --short HEAD)` chore(repo): add CodeRabbit configuration for automated reviews

---

## Notes

* 파일명은 CodeRabbit 이 자동 인식하는 표준 `.coderabbit.yaml` (leading dot)
* 이미 CodeRabbit 봇은 PR 체크에 등장 (예: PR #58 의 \"CodeRabbit / SUCCESS\") — 본 PR 머지 후 다음 PR 부터 새 설정이 자동 적용됨
* `tone_instructions` 와 `path_instructions` 는 운영해 보면서 결과를 보고 후속 PR 로 조정해도 됨

---

## Test Plan

* [x] YAML 문법 검증 (들여쓰기 · 리스트 표기 · 따옴표)
* [x] 경로 필터 패턴이 실제 디렉토리와 일치하는지 확인
* [x] Merge 충돌 없음

### Manual Test Steps

1. 머지 후 임의의 후속 PR 생성 → CodeRabbit 리뷰가 **한국어로** 작성되는지 확인
2. 동일 PR 에서 `*.g.dart` · `ios/` · `build/` 변경이 포함되어 있어도 리뷰 대상에서 제외되는지 확인
3. `frontend/flutter/lib/features/` 또는 `design_system/` 변경 PR 에서 path_instructions 가이드가 리뷰 코멘트에 반영되는지 확인

---

## Related Issues

Closes #73

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검 (경로 패턴 정확성)
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인 (메타 설정 파일, 앱 코드 영향 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 코드 리뷰 자동화 및 협업 도구 설정을 추가하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->