### PR TITLE
chore(backend): Alembic 마이그레이션 · 설정/시크릿 격리 · 테스트+CI

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,60 @@
+name: Backend CI
+
+on:
+  push:
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-ci.yml"
+  pull_request:
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-ci.yml"
+
+jobs:
+  test:
+    name: Alembic + Pytest (Postgres/pgvector)
+    runs-on: ubuntu-latest
+
+    services:
+      db:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: oncare
+          POSTGRES_PASSWORD: oncare
+          POSTGRES_DB: oncare
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U oncare"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      ENV: dev
+      DATABASE_URL: postgresql+psycopg://oncare:oncare@localhost:5432/oncare
+      # AI 키는 필요 없음(테스트는 인식/코치 호출을 하지 않음)
+      SEED_DEMO_DATA: "true"
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run migrations (validates baseline)
+        run: alembic upgrade head
+
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 .env
 .venv/
 
+# Python
+__pycache__/
+*.py[cod]
+
 # OS / editor cruft
 .DS_Store
 *.swp

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,12 @@
 # cp .env.example .env 후 값 채우기
+# 환경: dev | staging | prod   (prod 는 아래 JWT_SECRET 기본값이면 기동이 차단됨)
+ENV=dev
+
 DATABASE_URL=postgresql+psycopg://oncare:oncare@localhost:5432/oncare
+# 앱 기동 시 create_all() 로 테이블 생성(개발 편의). 운영은 Alembic 사용 → false 권장.
+AUTO_CREATE_TABLES=true
+
+# 운영에서는 반드시 교체:  openssl rand -hex 32
 JWT_SECRET=CHANGE_ME_run_openssl_rand_hex_32
 JWT_ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=1440

--- a/backend/README.md
+++ b/backend/README.md
@@ -25,6 +25,19 @@ docker compose up --build
 ```
 → http://localhost:8000/docs  (경로는 모두 /v1/...)
 
+## DB 마이그레이션 (Alembic)
+스키마는 **Alembic 마이그레이션**으로 관리합니다(베이스라인: `migrations/versions/0001_baseline.py`, 9테이블 + pgvector).
+DB URL 은 `.env` 의 `DATABASE_URL` 을 그대로 사용합니다(`migrations/env.py` 가 app 설정에서 읽음).
+
+```bash
+cd backend
+alembic upgrade head          # 최신 스키마로 반영 (운영/CI 는 이 명령으로 스키마 생성)
+alembic revision --autogenerate -m "설명"   # 모델 변경 후 새 마이그레이션 생성
+alembic downgrade -1          # 한 단계 롤백
+```
+> 개발 편의를 위해 앱 기동 시 `create_all()` 로도 테이블을 만들지만(멱등), **운영은 `alembic upgrade head`** 를 정답으로 삼습니다.
+> (운영에서 `create_all` 을 끄려면 `AUTO_CREATE_TABLES=false` — 설정 항목은 이후 커밋에서 추가)
+
 ## 프론트 연동 (실서버 전환)
 프론트에서:
 ```bash

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,42 @@
+# Alembic 설정 — On-Care 백엔드
+# DB URL 은 여기 하드코딩하지 않고 migrations/env.py 에서 app 설정(.env 의 DATABASE_URL)을 읽습니다.
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+# 리비전 파일명: 0001_slug 형태
+file_template = %%(rev)s_%%(slug)s
+timezone = UTC
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -2,11 +2,19 @@
 from __future__ import annotations
 
 from functools import lru_cache
+
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# 개발 기본 시크릿(운영에서 그대로 쓰면 기동 차단)
+DEFAULT_JWT_SECRET = "CHANGE_ME_dev_only_secret_key_please_replace_in_prod"
 
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+
+    # --- 환경 ---
+    env: str = "dev"  # dev | staging | prod
 
     # --- API ---
     api_v1_prefix: str = "/v1"
@@ -14,9 +22,11 @@ class Settings(BaseSettings):
 
     # --- Database ---
     database_url: str = "postgresql+psycopg://oncare:oncare@localhost:5432/oncare"
+    # 앱 기동 시 create_all() 로 테이블 생성 여부(개발 편의). 운영은 Alembic 을 정답으로 → false 권장.
+    auto_create_tables: bool = True
 
     # --- JWT ---
-    jwt_secret: str = "CHANGE_ME_dev_only_secret_key_please_replace_in_prod"
+    jwt_secret: str = DEFAULT_JWT_SECRET
     jwt_algorithm: str = "HS256"
     access_token_expire_minutes: int = 60 * 24
 
@@ -45,6 +55,20 @@ class Settings(BaseSettings):
     # --- 기타 ---
     cors_allow_origins: str = "*"
     seed_demo_data: bool = True
+
+    @property
+    def is_prod(self) -> bool:
+        return self.env.strip().lower() in ("prod", "production")
+
+    @model_validator(mode="after")
+    def _guard_prod_secrets(self) -> "Settings":
+        """운영 환경에서 안전하지 않은 기본값을 쓰면 기동을 막는다(fail-fast)."""
+        if self.is_prod:
+            if not self.jwt_secret or self.jwt_secret == DEFAULT_JWT_SECRET:
+                raise ValueError(
+                    "운영(env=prod)에서는 JWT_SECRET 을 안전한 값으로 반드시 설정해야 합니다."
+                )
+        return self
 
 
 @lru_cache

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -18,13 +18,18 @@ DEMO_USER_ID = "user-demo"
 
 
 def init_db() -> None:
+    settings = get_settings()
+
     with engine.connect() as conn:
         conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
         conn.commit()
 
-    Base.metadata.create_all(bind=engine)
+    # 개발 편의: create_all(멱등). 운영은 Alembic(`alembic upgrade head`)을 정답으로 삼고
+    # AUTO_CREATE_TABLES=false 로 꺼둔다.
+    if settings.auto_create_tables:
+        Base.metadata.create_all(bind=engine)
 
-    if get_settings().seed_demo_data:
+    if settings.seed_demo_data:
         _seed_demo_user()
         _seed_demo_places()
         _seed_demo_notifications()

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,0 +1,63 @@
+"""Alembic 환경 설정.
+
+DB URL 과 메타데이터를 app 코드에서 가져와, 마이그레이션과 앱이
+같은 스키마 정의를 공유하게 합니다. (URL 은 .env 의 DATABASE_URL)
+"""
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from app.core.config import get_settings
+from app.db.session import Base
+
+# app 모델을 import 해야 Base.metadata 에 테이블이 등록된다.
+from app.models import models  # noqa: F401
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# 실행 시점의 실제 DB URL 주입 (하드코딩 방지)
+config.set_main_option("sqlalchemy.url", get_settings().database_url)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """오프라인(--sql) 모드: DB 연결 없이 SQL 생성."""
+    context.configure(
+        url=config.get_main_option("sqlalchemy.url"),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """온라인 모드: 실제 DB 에 연결해 마이그레이션."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+        )
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/migrations/script.py.mako
+++ b/backend/migrations/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+revision: str = ${repr(up_revision)}
+down_revision: str | Sequence[str] | None = ${repr(down_revision)}
+branch_labels: str | Sequence[str] | None = ${repr(branch_labels)}
+depends_on: str | Sequence[str] | None = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/backend/migrations/versions/0001_baseline.py
+++ b/backend/migrations/versions/0001_baseline.py
@@ -1,0 +1,175 @@
+"""baseline schema (9 tables + pgvector)
+
+현재 ORM 모델(app/models/models.py)과 1:1 대응하는 최초 베이스라인.
+기존에는 Base.metadata.create_all() 로 생성하던 스키마를 마이그레이션으로 고정한다.
+
+Revision ID: 0001_baseline
+Revises:
+Create Date: 2026-07-03
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from pgvector.sqlalchemy import Vector
+
+revision: str = "0001_baseline"
+down_revision: str | Sequence[str] | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# 임베딩 차원(현재 기본값). 차원 변경은 별도 마이그레이션 + 재임베딩으로 처리.
+EMBED_DIM = 1536
+_now = sa.text("now()")
+_user_fk = lambda: sa.ForeignKey("users.id", ondelete="CASCADE")  # noqa: E731
+
+
+def upgrade() -> None:
+    # RAG 임베딩 검색용 확장 (coach_documents.embedding 이전에 필요)
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+
+    op.create_table(
+        "users",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column("email", sa.String(255), nullable=False),
+        sa.Column("name", sa.String(100), nullable=False, server_default=""),
+        sa.Column("hashed_password", sa.String(255), nullable=False, server_default=""),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=_now),
+    )
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+
+    op.create_table(
+        "health_profiles",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("user_id", sa.String(64), _user_fk(), nullable=False, unique=True),
+        sa.Column("risk_title", sa.String(200), nullable=False, server_default=""),
+        sa.Column("risk_body", sa.Text(), nullable=False, server_default=""),
+        sa.Column("risk_level", sa.String(20), nullable=False, server_default="low"),
+        sa.Column("conditions", sa.Text(), nullable=False, server_default=""),
+        sa.Column("goals", sa.Text(), nullable=False, server_default=""),
+        sa.Column("activity_points", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("activity_rank", sa.Integer(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=_now),
+    )
+
+    op.create_table(
+        "diet_entries",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column("user_id", sa.String(64), _user_fk(), nullable=False),
+        sa.Column("date", sa.String(10), nullable=False),
+        sa.Column("meal_type", sa.String(20), nullable=False),
+        sa.Column("time_label", sa.String(10), nullable=False, server_default=""),
+        sa.Column("foods_json", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("total_calories", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("sodium_mg", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("sugar_g", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("engine", sa.String(20), nullable=False, server_default=""),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=_now),
+    )
+    op.create_index("ix_diet_entries_user_id", "diet_entries", ["user_id"])
+    op.create_index("ix_diet_entries_date", "diet_entries", ["date"])
+
+    op.create_table(
+        "exercise_sessions",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column("user_id", sa.String(64), _user_fk(), nullable=False),
+        sa.Column("week_start", sa.String(10), nullable=False),
+        sa.Column("day_label", sa.String(4), nullable=False),
+        sa.Column("type", sa.String(20), nullable=False),
+        sa.Column("minutes", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("calories", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=_now),
+    )
+    op.create_index("ix_exercise_sessions_user_id", "exercise_sessions", ["user_id"])
+    op.create_index("ix_exercise_sessions_week_start", "exercise_sessions", ["week_start"])
+
+    op.create_table(
+        "vitals",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column("user_id", sa.String(64), _user_fk(), nullable=False),
+        sa.Column("kind", sa.String(20), nullable=False),
+        sa.Column("value_json", sa.Text(), nullable=False, server_default="{}"),
+        sa.Column("recorded_at", sa.DateTime(timezone=True), nullable=False, server_default=_now),
+    )
+    op.create_index("ix_vitals_user_id", "vitals", ["user_id"])
+    op.create_index("ix_vitals_kind", "vitals", ["kind"])
+
+    op.create_table(
+        "schedule_events",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column("user_id", sa.String(64), _user_fk(), nullable=False),
+        sa.Column("date", sa.String(10), nullable=False),
+        sa.Column("time", sa.String(10), nullable=False, server_default=""),
+        sa.Column("title", sa.String(200), nullable=False),
+        sa.Column("category", sa.String(20), nullable=False),
+        sa.Column("emoji", sa.String(10), nullable=False, server_default=""),
+        sa.Column("color_hex", sa.String(10), nullable=False, server_default="#E0F2F7"),
+    )
+    op.create_index("ix_schedule_events_user_id", "schedule_events", ["user_id"])
+    op.create_index("ix_schedule_events_date", "schedule_events", ["date"])
+
+    op.create_table(
+        "notifications",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column("user_id", sa.String(64), _user_fk(), nullable=False),
+        sa.Column("title", sa.String(200), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False, server_default=""),
+        sa.Column("category", sa.String(20), nullable=False),
+        sa.Column("read", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=_now),
+    )
+    op.create_index("ix_notifications_user_id", "notifications", ["user_id"])
+
+    op.create_table(
+        "coach_documents",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        # 공공 문서는 NULL(전체 공유), 개인 문서는 특정 user_id
+        sa.Column("user_id", sa.String(64), _user_fk(), nullable=True),
+        sa.Column("source", sa.String(50), nullable=False, server_default=""),
+        sa.Column("domain", sa.String(20), nullable=False, server_default="general"),
+        sa.Column("title", sa.String(300), nullable=False, server_default=""),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("embedding", Vector(EMBED_DIM), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=_now),
+    )
+    op.create_index("ix_coach_documents_user_id", "coach_documents", ["user_id"])
+    op.create_index("ix_coach_documents_domain", "coach_documents", ["domain"])
+
+    op.create_table(
+        "places",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column("name", sa.String(200), nullable=False),
+        sa.Column("category", sa.String(30), nullable=False),
+        sa.Column("address", sa.String(300), nullable=False, server_default=""),
+        sa.Column("lat", sa.Float(), nullable=True),
+        sa.Column("lng", sa.Float(), nullable=True),
+        sa.Column("kakao_place_id", sa.String(50), nullable=False, server_default=""),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("places")
+    op.drop_index("ix_coach_documents_domain", table_name="coach_documents")
+    op.drop_index("ix_coach_documents_user_id", table_name="coach_documents")
+    op.drop_table("coach_documents")
+    op.drop_index("ix_notifications_user_id", table_name="notifications")
+    op.drop_table("notifications")
+    op.drop_index("ix_schedule_events_date", table_name="schedule_events")
+    op.drop_index("ix_schedule_events_user_id", table_name="schedule_events")
+    op.drop_table("schedule_events")
+    op.drop_index("ix_vitals_kind", table_name="vitals")
+    op.drop_index("ix_vitals_user_id", table_name="vitals")
+    op.drop_table("vitals")
+    op.drop_index("ix_exercise_sessions_week_start", table_name="exercise_sessions")
+    op.drop_index("ix_exercise_sessions_user_id", table_name="exercise_sessions")
+    op.drop_table("exercise_sessions")
+    op.drop_index("ix_diet_entries_date", table_name="diet_entries")
+    op.drop_index("ix_diet_entries_user_id", table_name="diet_entries")
+    op.drop_table("diet_entries")
+    op.drop_table("health_profiles")
+    op.drop_index("ix_users_email", table_name="users")
+    op.drop_table("users")
+    # vector 확장은 다른 객체가 쓸 수 있어 남겨둔다.

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+pythonpath = .
+addopts = -q

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,4 @@
+# 테스트 전용 의존성 (운영 이미지에는 불필요)
+-r requirements.txt
+pytest>=8.0
+httpx>=0.27

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 fastapi>=0.110
 uvicorn[standard]>=0.27
 sqlalchemy>=2.0
+alembic>=1.13
 psycopg[binary]>=3.1
 pgvector>=0.2.5
 pwdlib[bcrypt]>=0.2

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,40 @@
+"""pytest 공통 설정.
+
+- 순수 유닛 테스트(test_config, test_security)는 DB 없이 실행됩니다.
+- DB/엔드포인트 테스트는 `client` 픽스처를 쓰며, DB 연결이 안 되면 자동 skip 됩니다
+  (로컬은 skip, CI 의 Postgres(pgvector) 서비스에서 실행).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+from sqlalchemy import create_engine, text
+
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL", "postgresql+psycopg://oncare:oncare@localhost:5432/oncare"
+)
+
+
+def _db_available() -> bool:
+    try:
+        engine = create_engine(DATABASE_URL, pool_pre_ping=True)
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        engine.dispose()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.fixture(scope="session")
+def client():
+    """FastAPI TestClient. DB 가 없으면 skip."""
+    if not _db_available():
+        pytest.skip("DB 연결 불가 — CI(Postgres 서비스)에서 실행됩니다.")
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+
+    with TestClient(app) as c:  # lifespan → init_db (vector extension / create_all / seed)
+        yield c

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,41 @@
+"""인증(회원가입 · 로그인 · 토큰) — DB 필요(로컬 skip, CI 실행)."""
+from __future__ import annotations
+
+from uuid import uuid4
+
+
+def test_register_login_and_me(client):
+    email = f"tester-{uuid4().hex[:8]}@oncare.com"
+    password = "pw-12345!"
+
+    r = client.post(
+        "/v1/auth/register",
+        json={"email": email, "password": password, "name": "테스터"},
+    )
+    assert r.status_code == 201, r.text
+    user_id = r.json()["id"]
+
+    r2 = client.post("/v1/auth/login", data={"username": email, "password": password})
+    assert r2.status_code == 200, r2.text
+    token = r2.json()["access_token"]
+    assert token
+
+    # 발급 토큰으로 인증된 /users/me 는 가입한 사용자를 반환해야 한다
+    r3 = client.get("/v1/users/me", headers={"Authorization": f"Bearer {token}"})
+    assert r3.status_code == 200
+    assert r3.json()["id"] == user_id
+
+
+def test_login_wrong_password_401(client):
+    email = f"tester-{uuid4().hex[:8]}@oncare.com"
+    client.post("/v1/auth/register", json={"email": email, "password": "correct-pw!", "name": "x"})
+    r = client.post("/v1/auth/login", data={"username": email, "password": "wrong-pw"})
+    assert r.status_code == 401
+
+
+def test_duplicate_register_conflicts_409(client):
+    email = f"dup-{uuid4().hex[:8]}@oncare.com"
+    r1 = client.post("/v1/auth/register", json={"email": email, "password": "pw!", "name": "a"})
+    assert r1.status_code == 201
+    r2 = client.post("/v1/auth/register", json={"email": email, "password": "pw!", "name": "a"})
+    assert r2.status_code == 409

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,26 @@
+"""설정(Settings) 검증 — DB 불필요."""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.core.config import DEFAULT_JWT_SECRET, Settings
+
+
+def test_dev_defaults():
+    s = Settings(_env_file=None)
+    assert s.env == "dev"
+    assert s.is_prod is False
+    assert s.auto_create_tables is True
+    assert s.api_v1_prefix == "/v1"
+
+
+def test_prod_blocks_default_secret():
+    """운영에서 기본 JWT_SECRET 을 쓰면 기동이 막혀야 한다(fail-fast)."""
+    with pytest.raises(ValidationError):
+        Settings(_env_file=None, env="prod", jwt_secret=DEFAULT_JWT_SECRET)
+
+
+def test_prod_ok_with_real_secret():
+    s = Settings(_env_file=None, env="prod", jwt_secret="a-strong-random-secret-value")
+    assert s.is_prod is True

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,0 +1,33 @@
+"""보안 유틸(비밀번호 해싱 · JWT) 검증 — DB 불필요."""
+from __future__ import annotations
+
+import jwt
+import pytest
+
+from app.core.security import (
+    create_access_token,
+    decode_access_token,
+    hash_password,
+    verify_password,
+)
+
+
+def test_password_hash_roundtrip():
+    hashed = hash_password("s3cret!")
+    assert hashed and hashed != "s3cret!"
+    assert verify_password("s3cret!", hashed) is True
+    assert verify_password("wrong-password", hashed) is False
+
+
+def test_verify_empty_hash_is_false():
+    assert verify_password("anything", "") is False
+
+
+def test_jwt_roundtrip():
+    token = create_access_token("user-123")
+    assert decode_access_token(token) == "user-123"
+
+
+def test_jwt_invalid_token_raises():
+    with pytest.raises(jwt.InvalidTokenError):
+        decode_access_token("not-a-valid-token")

--- a/backend/tests/test_system.py
+++ b/backend/tests/test_system.py
@@ -1,0 +1,20 @@
+"""시스템 엔드포인트 스모크 — DB 필요(로컬 skip, CI 실행)."""
+from __future__ import annotations
+
+
+def test_ping(client):
+    r = client.get("/v1/ping")
+    assert r.status_code == 200
+
+
+def test_healthz(client):
+    r = client.get("/v1/healthz")
+    assert r.status_code == 200
+
+
+def test_version(client):
+    r = client.get("/v1/version")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["api_version"] == "v1"
+    assert "app_version" in body


### PR DESCRIPTION
Closes #102

## 개요
백엔드 MVP → 실서비스 전환의 **Phase 0(기반)** 3가지를 순서대로 구현했습니다.
> Base 브랜치는 `feature/backend-rework` 입니다 — **아직 `main`에는 올리지 않습니다.**

## 변경 (커밋 순서)
1. **feat: Alembic 마이그레이션 도입** — `create_all` 의존 → 버전관리 마이그레이션. 베이스라인 `0001`이 9테이블 + `pgvector` 확장을 생성(`app/models/models.py`와 1:1). `migrations/env.py`가 앱 설정에서 `DATABASE_URL`을 읽어 스키마 소스를 단일화. README에 `alembic upgrade head` 운영 경로 문서화.
2. **chore: 설정/시크릿 하드닝** — `ENV`(dev/staging/prod)·`AUTO_CREATE_TABLES` 추가, **운영에서 기본 `JWT_SECRET`이면 기동 차단(fail-fast)**. `init_db`의 `create_all`을 설정으로 게이팅(운영은 Alembic). `.env.example` 갱신. 기본값은 dev 동작 그대로(하위호환).
3. **test: pytest 하네스 + 백엔드 CI** — 순수 유닛(설정·해싱·JWT)은 어디서나 실행, DB/엔드포인트(시스템·인증)는 DB 없으면 자동 skip. CI가 pgvector Postgres 서비스에서 `alembic upgrade head`(베이스라인 검증) → `pytest`.

## 검증
- 로컬: 순수 유닛 테스트 **7개 통과**, DB 테스트 6개 clean skip.
- 마이그레이션·DB 테스트는 본 PR의 **Backend CI**(Postgres/pgvector)에서 실행됩니다.

## 다음 Phase (별도 PR)
인증 강화(refresh·데모폴백 격리)·소셜 로그인 → Vision/RAG 앱 연동·공공 식품영양성분 DB 매핑 → 보안/개인정보·배포.

리뷰어: @seoyeon0516 @aJISUa
