### PR TITLE
feat(auth): 인증 강화 (refresh 토큰 · 토큰 타입 검증 · 데모폴백 운영 격리)

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -22,6 +22,7 @@ from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core.config import get_settings
 from app.core.security import decode_access_token
 from app.db.init_db import DEMO_USER_ID
 from app.db.session import get_db
@@ -39,22 +40,31 @@ def get_current_user(
     request: Request,
     db: Annotated[Session, Depends(get_db)],
 ) -> User:
-    """토큰이 유효하면 그 사용자, 아니면 데모 사용자로 폴백."""
+    """토큰이 유효하면 그 사용자. 없거나 무효하면:
+    - 개발/스테이징(demo_fallback_enabled): 데모 사용자로 폴백
+    - 운영(prod): 401 (폴백 비활성)
+    """
     token = _extract_bearer(request)
-    user_id = DEMO_USER_ID
     if token:
         try:
             user_id = decode_access_token(token)
+            user = db.scalar(select(User).where(User.id == user_id))
+            if user is not None:
+                return user
         except jwt.InvalidTokenError:
-            user_id = DEMO_USER_ID
+            pass
 
-    user = db.scalar(select(User).where(User.id == user_id))
-    if user is None:
-        # 토큰의 사용자가 없으면 데모로 한 번 더 폴백
-        user = db.scalar(select(User).where(User.id == DEMO_USER_ID))
-    if user is None:
-        raise HTTPException(status_code=500, detail="데모 사용자가 시드되지 않았습니다.")
-    return user
+    if get_settings().demo_fallback_enabled:
+        demo = db.scalar(select(User).where(User.id == DEMO_USER_ID))
+        if demo is None:
+            raise HTTPException(status_code=500, detail="데모 사용자가 시드되지 않았습니다.")
+        return demo
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="인증이 필요합니다.",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
 
 
 def require_auth(

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -13,17 +13,21 @@ from __future__ import annotations
 import uuid
 from typing import Annotated
 
+import jwt
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.deps import CurrentUser
-from app.core.security import create_access_token, hash_password, verify_password
+from app.core.security import (
+    create_access_token, create_refresh_token, decode_refresh_token,
+    hash_password, verify_password,
+)
 from app.db.session import get_db
 from app.models.models import HealthProfile, User
 from app.schemas.user import (
-    HealthProfileBrief, RiskInfo, SettingItem, Token, UserHealth, UserMe, UserRegister,
+    HealthProfileBrief, RefreshRequest, RiskInfo, SettingItem, Token, UserHealth, UserMe, UserRegister,
 )
 from app.services.health_service import DEMO_SETTINGS, build_indicators_for_user
 
@@ -95,4 +99,24 @@ def login(
     user = db.scalar(select(User).where(User.email == form.username))
     if not user or not verify_password(form.password, user.hashed_password):
         raise HTTPException(status_code=401, detail="이메일 또는 비밀번호가 올바르지 않습니다.")
-    return Token(access_token=create_access_token(user.id))
+    return Token(
+        access_token=create_access_token(user.id),
+        refresh_token=create_refresh_token(user.id),
+    )
+
+
+@router.post("/auth/refresh", response_model=Token)
+def refresh(payload: RefreshRequest, db: Annotated[Session, Depends(get_db)]) -> Token:
+    """refresh 토큰으로 새 access(+refresh) 토큰 발급(회전)."""
+    invalid = HTTPException(status_code=401, detail="유효하지 않은 refresh 토큰입니다.")
+    try:
+        user_id = decode_refresh_token(payload.refresh_token)
+    except jwt.InvalidTokenError:
+        raise invalid
+    user = db.scalar(select(User).where(User.id == user_id))
+    if user is None or not user.is_active:
+        raise invalid
+    return Token(
+        access_token=create_access_token(user.id),
+        refresh_token=create_refresh_token(user.id),
+    )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -29,6 +29,9 @@ class Settings(BaseSettings):
     jwt_secret: str = DEFAULT_JWT_SECRET
     jwt_algorithm: str = "HS256"
     access_token_expire_minutes: int = 60 * 24
+    refresh_token_expire_days: int = 30
+    # 토큰 없이 접근 시 데모 사용자로 폴백(개발 편의). 운영(prod)에서는 항상 비활성.
+    allow_demo_fallback: bool = True
 
     # --- AI 엔진 (이후 STEP 에서 사용) ---
     recognizer: str = "gemini"
@@ -59,6 +62,11 @@ class Settings(BaseSettings):
     @property
     def is_prod(self) -> bool:
         return self.env.strip().lower() in ("prod", "production")
+
+    @property
+    def demo_fallback_enabled(self) -> bool:
+        """데모 사용자 폴백 허용 여부 — 운영에서는 설정과 무관하게 항상 비활성."""
+        return self.allow_demo_fallback and not self.is_prod
 
     @model_validator(mode="after")
     def _guard_prod_secrets(self) -> "Settings":

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -23,18 +23,35 @@ def verify_password(plain: str, hashed: str) -> bool:
     return _password_hash.verify(plain, hashed)
 
 
-def create_access_token(subject: str) -> str:
+def _encode(subject: str, token_type: str, ttl: timedelta) -> str:
     now = datetime.now(timezone.utc)
-    payload = {
-        "sub": subject,
-        "iat": now,
-        "exp": now + timedelta(minutes=settings.access_token_expire_minutes),
-    }
+    payload = {"sub": subject, "type": token_type, "iat": now, "exp": now + ttl}
     return jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+
+
+def create_access_token(subject: str) -> str:
+    return _encode(subject, "access", timedelta(minutes=settings.access_token_expire_minutes))
+
+
+def create_refresh_token(subject: str) -> str:
+    return _encode(subject, "refresh", timedelta(days=settings.refresh_token_expire_days))
 
 
 def decode_access_token(token: str) -> str:
     payload = jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
+    # refresh 토큰을 액세스로 오용하는 것을 차단 (구버전 토큰은 type 이 없어 허용)
+    if payload.get("type") == "refresh":
+        raise jwt.InvalidTokenError("refresh 토큰은 액세스로 사용할 수 없습니다.")
+    sub = payload.get("sub")
+    if sub is None:
+        raise jwt.InvalidTokenError("sub 없음")
+    return str(sub)
+
+
+def decode_refresh_token(token: str) -> str:
+    payload = jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
+    if payload.get("type") != "refresh":
+        raise jwt.InvalidTokenError("refresh 토큰이 아닙니다.")
     sub = payload.get("sub")
     if sub is None:
         raise jwt.InvalidTokenError("sub 없음")

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -66,7 +66,12 @@ class UserHealth(BaseModel):
 # ---- 인증(로그인) ----
 class Token(BaseModel):
     access_token: str
+    refresh_token: str = ""
     token_type: str = "bearer"
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
 
 
 class UserRegister(BaseModel):

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -39,3 +39,23 @@ def test_duplicate_register_conflicts_409(client):
     assert r1.status_code == 201
     r2 = client.post("/v1/auth/register", json={"email": email, "password": "pw!", "name": "a"})
     assert r2.status_code == 409
+
+
+def test_refresh_token_flow(client):
+    email = f"ref-{uuid4().hex[:8]}@oncare.com"
+    client.post("/v1/auth/register", json={"email": email, "password": "pw!", "name": "r"})
+    login = client.post("/v1/auth/login", data={"username": email, "password": "pw!"})
+    assert login.status_code == 200
+    refresh_token = login.json()["refresh_token"]
+    assert refresh_token
+
+    # refresh 로 새 access 발급 → /users/me 동작
+    r = client.post("/v1/auth/refresh", json={"refresh_token": refresh_token})
+    assert r.status_code == 200, r.text
+    new_access = r.json()["access_token"]
+    me = client.get("/v1/users/me", headers={"Authorization": f"Bearer {new_access}"})
+    assert me.status_code == 200
+
+    # 잘못된 refresh → 401
+    bad = client.post("/v1/auth/refresh", json={"refresh_token": "not-a-token"})
+    assert bad.status_code == 401

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -24,3 +24,13 @@ def test_prod_blocks_default_secret():
 def test_prod_ok_with_real_secret():
     s = Settings(_env_file=None, env="prod", jwt_secret="a-strong-random-secret-value")
     assert s.is_prod is True
+
+
+def test_demo_fallback_gated_by_env():
+    # 개발: 기본 허용
+    assert Settings(_env_file=None).demo_fallback_enabled is True
+    # 운영: 설정과 무관하게 비활성
+    prod = Settings(_env_file=None, env="prod", jwt_secret="strong", allow_demo_fallback=True)
+    assert prod.demo_fallback_enabled is False
+    # 명시적으로 끄면 개발에서도 비활성
+    assert Settings(_env_file=None, allow_demo_fallback=False).demo_fallback_enabled is False

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -6,7 +6,9 @@ import pytest
 
 from app.core.security import (
     create_access_token,
+    create_refresh_token,
     decode_access_token,
+    decode_refresh_token,
     hash_password,
     verify_password,
 )
@@ -31,3 +33,20 @@ def test_jwt_roundtrip():
 def test_jwt_invalid_token_raises():
     with pytest.raises(jwt.InvalidTokenError):
         decode_access_token("not-a-valid-token")
+
+
+def test_refresh_token_roundtrip():
+    token = create_refresh_token("user-9")
+    assert decode_refresh_token(token) == "user-9"
+
+
+def test_access_token_rejected_as_refresh():
+    """액세스 토큰을 refresh 로 쓰면 거부."""
+    with pytest.raises(jwt.InvalidTokenError):
+        decode_refresh_token(create_access_token("user-9"))
+
+
+def test_refresh_token_rejected_as_access():
+    """refresh 토큰을 액세스로 쓰면 거부(토큰 혼용 방지)."""
+    with pytest.raises(jwt.InvalidTokenError):
+        decode_access_token(create_refresh_token("user-9"))


### PR DESCRIPTION
Closes #103

## 개요
백엔드 **Phase 1(인증 강화)** 입니다. Phase 0 PR **#98 위에 스택**되어 있습니다(base: `feature/backend-foundation`). `main` 미반영.

## 변경 (커밋 순서)
1. **feat: refresh 토큰 + 토큰 타입 검증 + 폴백 게이팅**
   - 30일 **refresh 토큰** 추가(access와 병행). 두 JWT에 `type` 클레임을 넣어 **refresh를 access로(또는 반대로) 오용하는 것을 차단**.
   - `/auth/login` 이 access+refresh 반환, **`POST /auth/refresh`** 로 회전 발급.
   - `get_current_user` 의 **데모 사용자 폴백을 `demo_fallback_enabled` 로 게이팅** → 운영(prod)에서는 항상 비활성(무토큰/무효토큰 → **401**).
2. **test: refresh·타입 혼용·폴백 게이팅 테스트** — 순수 유닛(refresh 롤트립, access↔refresh 혼용 거부, `demo_fallback_enabled`) + DB(login→refresh→인증 me, 잘못된 refresh 401).

## 검증
- 로컬 순수 유닛 테스트 **11개 통과**. DB 테스트(회원가입·로그인·**refresh 흐름**·오류)는 본 PR의 Backend CI(Postgres/pgvector)에서 실행.
- 하위호환: 기본값은 개발 동작 그대로. Token 응답에 `refresh_token` 필드만 추가(프론트는 무시 가능).

## 참고 / 다음
- 완전한 서버측 로그아웃(토큰 폐기)은 저장소(Redis 등) 도입 후 별도 진행 예정.
- 다음 Phase: 소셜 로그인(Apple/Google/Kakao/Naver) → Vision/RAG 앱 연동·공공 DB 매핑.

리뷰어: @seoyeon0516 @aJISUa
