### PR TITLE
feat(social): 소셜 로그인 (Kakao/Google/Naver + Apple 스텁)

### DIFF
--- a/backend/app/api/v1/social.py
+++ b/backend/app/api/v1/social.py
@@ -1,0 +1,84 @@
+"""소셜 로그인 라우터.
+
+  POST /auth/social/{provider}  { token }  ->  { access_token, refresh_token }
+
+provider(kakao/google/naver/apple)에서 토큰을 검증해 사용자를 찾거나 만들고,
+우리 서비스의 JWT(access+refresh)를 발급한다.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.security import create_access_token, create_refresh_token
+from app.db.session import get_db
+from app.models.models import SocialAccount, User
+from app.schemas.user import SocialLoginRequest, Token
+from app.services.social.base import SocialAuthError, SocialIdentity
+from app.services.social.factory import get_verifier
+
+router = APIRouter(tags=["auth"])
+
+
+def _find_or_create_user(db: Session, identity: SocialIdentity) -> User:
+    # 1) 이미 연결된 소셜 계정이면 그 사용자
+    account = db.scalar(
+        select(SocialAccount).where(
+            SocialAccount.provider == identity.provider,
+            SocialAccount.provider_user_id == identity.provider_user_id,
+        )
+    )
+    if account is not None:
+        return db.scalar(select(User).where(User.id == account.user_id))
+
+    # 2) 같은 이메일의 기존 사용자에 연결, 없으면 새 사용자 생성
+    user: User | None = None
+    if identity.email:
+        user = db.scalar(select(User).where(User.email == identity.email))
+    if user is None:
+        user = User(
+            id=f"user-{uuid.uuid4().hex[:12]}",
+            email=identity.email or f"{identity.provider}_{identity.provider_user_id}@social.oncare",
+            name=identity.name or identity.provider,
+            hashed_password="",  # 소셜 계정은 비밀번호 없음
+        )
+        db.add(user)
+        db.flush()
+
+    db.add(SocialAccount(
+        user_id=user.id,
+        provider=identity.provider,
+        provider_user_id=identity.provider_user_id,
+    ))
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@router.post("/auth/social/{provider}", response_model=Token)
+async def social_login(
+    provider: str,
+    payload: SocialLoginRequest,
+    db: Annotated[Session, Depends(get_db)],
+) -> Token:
+    try:
+        verifier = get_verifier(provider)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="지원하지 않는 소셜 로그인입니다.")
+
+    try:
+        identity = await verifier.verify(payload.token)
+    except NotImplementedError:
+        raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="아직 지원하지 않는 소셜 로그인입니다.")
+    except SocialAuthError:
+        raise HTTPException(status_code=401, detail="소셜 인증에 실패했습니다.")
+
+    user = _find_or_create_user(db, identity)
+    return Token(
+        access_token=create_access_token(user.id),
+        refresh_token=create_refresh_token(user.id),
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.v1 import (
-    ai_coach, coach_docs, dashboard, diet, exercise, notifications, places, schedule, system, users, vitals,
+    ai_coach, coach_docs, dashboard, diet, exercise, notifications, places, schedule, social, system, users, vitals,
 )
 from app.core.config import get_settings
 from app.db.init_db import init_db
@@ -45,6 +45,7 @@ app.add_middleware(
 # /v1 prefix 로 마운트 (프론트 base URL 이 /v1 을 포함하는 계약)
 app.include_router(system.router, prefix=settings.api_v1_prefix)
 app.include_router(users.router, prefix=settings.api_v1_prefix)
+app.include_router(social.router, prefix=settings.api_v1_prefix)
 app.include_router(dashboard.router, prefix=settings.api_v1_prefix)
 app.include_router(diet.router, prefix=settings.api_v1_prefix)
 app.include_router(exercise.router, prefix=settings.api_v1_prefix)

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -15,7 +15,7 @@ from datetime import datetime
 
 from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
-    Boolean, DateTime, Float, ForeignKey, Integer, String, Text, func,
+    Boolean, DateTime, Float, ForeignKey, Integer, String, Text, UniqueConstraint, func,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -157,6 +157,25 @@ class CoachDocument(Base):
     content: Mapped[str] = mapped_column(Text)
     embedding: Mapped[list[float] | None] = mapped_column(Vector(EMBED_DIM), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class SocialAccount(Base):
+    """소셜 로그인 연결 — 한 사용자에 여러 provider 를 붙일 수 있다.
+
+    (provider, provider_user_id) 는 유일. 소셜 로그인 시 이 조합으로 사용자를 찾고,
+    없으면 (이메일이 같은 기존 사용자에 연결하거나) 새 사용자를 만든다.
+    """
+    __tablename__ = "social_accounts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[str] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), index=True)
+    provider: Mapped[str] = mapped_column(String(20), index=True)  # kakao|google|naver|apple
+    provider_user_id: Mapped[str] = mapped_column(String(128))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("provider", "provider_user_id", name="uq_social_provider_uid"),
+    )
 
 
 class Place(Base):

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -74,6 +74,11 @@ class RefreshRequest(BaseModel):
     refresh_token: str
 
 
+class SocialLoginRequest(BaseModel):
+    # provider 가 준 토큰 (kakao/naver=access_token, google=id_token)
+    token: str
+
+
 class UserRegister(BaseModel):
     email: str
     password: str

--- a/backend/app/services/social/apple.py
+++ b/backend/app/services/social/apple.py
@@ -1,0 +1,16 @@
+"""Apple 로그인 검증 (스텁).
+
+Apple 은 identity_token(JWT) 을 Apple 공개키(JWKS: https://appleid.apple.com/auth/keys)로
+서명 검증하고 aud/iss 를 확인해야 한다. JWKS 캐싱·키 회전 처리가 필요해
+별도 작업으로 구현한다(스텁 유지 — 호출 시 501 로 응답).
+"""
+from __future__ import annotations
+
+from app.services.social.base import SocialIdentity, SocialVerifier
+
+
+class AppleVerifier(SocialVerifier):
+    provider = "apple"
+
+    async def verify(self, token: str) -> SocialIdentity:
+        raise NotImplementedError("Apple 로그인 검증은 이후 구현 예정입니다.")

--- a/backend/app/services/social/base.py
+++ b/backend/app/services/social/base.py
@@ -1,0 +1,28 @@
+"""소셜 로그인 검증 추상화.
+
+각 provider(kakao/google/naver/apple)는 SocialVerifier 를 구현해,
+클라이언트가 넘긴 토큰을 provider 에 확인하고 정규화된 SocialIdentity 를 돌려준다.
+recognizer/embedder 와 동일한 factory 패턴.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class SocialAuthError(Exception):
+    """소셜 토큰 검증 실패(무효 토큰 등)."""
+
+
+@dataclass
+class SocialIdentity:
+    provider: str            # kakao|google|naver|apple
+    provider_user_id: str    # provider 내 고유 사용자 id
+    email: str = ""
+    name: str = ""
+
+
+class SocialVerifier:
+    provider: str = ""
+
+    async def verify(self, token: str) -> SocialIdentity:
+        raise NotImplementedError

--- a/backend/app/services/social/factory.py
+++ b/backend/app/services/social/factory.py
@@ -1,0 +1,22 @@
+"""소셜 provider → Verifier 팩토리."""
+from __future__ import annotations
+
+from app.services.social.apple import AppleVerifier
+from app.services.social.base import SocialVerifier
+from app.services.social.google import GoogleVerifier
+from app.services.social.kakao import KakaoVerifier
+from app.services.social.naver import NaverVerifier
+
+_VERIFIERS: dict[str, type[SocialVerifier]] = {
+    "kakao": KakaoVerifier,
+    "google": GoogleVerifier,
+    "naver": NaverVerifier,
+    "apple": AppleVerifier,
+}
+
+
+def get_verifier(provider: str) -> SocialVerifier:
+    cls = _VERIFIERS.get(provider.lower())
+    if cls is None:
+        raise ValueError(f"지원하지 않는 소셜 provider: {provider}")
+    return cls()

--- a/backend/app/services/social/google.py
+++ b/backend/app/services/social/google.py
@@ -1,0 +1,38 @@
+"""Google 로그인 검증 — id_token 을 tokeninfo 로 확인.
+
+운영 규모에서는 Google JWKS 로컬 검증(google-auth)이 권장되나,
+MVP 단계에서는 tokeninfo 엔드포인트로 검증한다.
+"""
+from __future__ import annotations
+
+import httpx
+
+from app.services.social.base import SocialAuthError, SocialIdentity, SocialVerifier
+
+_TOKENINFO = "https://oauth2.googleapis.com/tokeninfo"
+
+
+class GoogleVerifier(SocialVerifier):
+    provider = "google"
+
+    async def verify(self, token: str) -> SocialIdentity:
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.get(_TOKENINFO, params={"id_token": token})
+        except httpx.HTTPError as exc:
+            raise SocialAuthError(f"google 요청 실패: {exc}") from exc
+
+        if resp.status_code != 200:
+            raise SocialAuthError(f"google 토큰 검증 실패({resp.status_code})")
+
+        data = resp.json()
+        uid = str(data.get("sub") or "")
+        if not uid:
+            raise SocialAuthError("google 사용자 id(sub) 없음")
+
+        return SocialIdentity(
+            provider="google",
+            provider_user_id=uid,
+            email=data.get("email") or "",
+            name=data.get("name") or "",
+        )

--- a/backend/app/services/social/kakao.py
+++ b/backend/app/services/social/kakao.py
@@ -1,0 +1,36 @@
+"""Kakao 로그인 검증 — access_token 으로 사용자 정보 조회."""
+from __future__ import annotations
+
+import httpx
+
+from app.services.social.base import SocialAuthError, SocialIdentity, SocialVerifier
+
+_USERINFO = "https://kapi.kakao.com/v2/user/me"
+
+
+class KakaoVerifier(SocialVerifier):
+    provider = "kakao"
+
+    async def verify(self, token: str) -> SocialIdentity:
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.get(_USERINFO, headers={"Authorization": f"Bearer {token}"})
+        except httpx.HTTPError as exc:
+            raise SocialAuthError(f"kakao 요청 실패: {exc}") from exc
+
+        if resp.status_code != 200:
+            raise SocialAuthError(f"kakao 토큰 검증 실패({resp.status_code})")
+
+        data = resp.json()
+        uid = str(data.get("id") or "")
+        if not uid:
+            raise SocialAuthError("kakao 사용자 id 없음")
+
+        account = data.get("kakao_account") or {}
+        profile = account.get("profile") or {}
+        return SocialIdentity(
+            provider="kakao",
+            provider_user_id=uid,
+            email=account.get("email") or "",
+            name=profile.get("nickname") or "",
+        )

--- a/backend/app/services/social/naver.py
+++ b/backend/app/services/social/naver.py
@@ -1,0 +1,35 @@
+"""Naver 로그인 검증 — access_token 으로 프로필 조회."""
+from __future__ import annotations
+
+import httpx
+
+from app.services.social.base import SocialAuthError, SocialIdentity, SocialVerifier
+
+_USERINFO = "https://openapi.naver.com/v1/nid/me"
+
+
+class NaverVerifier(SocialVerifier):
+    provider = "naver"
+
+    async def verify(self, token: str) -> SocialIdentity:
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.get(_USERINFO, headers={"Authorization": f"Bearer {token}"})
+        except httpx.HTTPError as exc:
+            raise SocialAuthError(f"naver 요청 실패: {exc}") from exc
+
+        if resp.status_code != 200:
+            raise SocialAuthError(f"naver 토큰 검증 실패({resp.status_code})")
+
+        body = resp.json()
+        profile = body.get("response") or {}
+        uid = str(profile.get("id") or "")
+        if not uid:
+            raise SocialAuthError("naver 사용자 id 없음")
+
+        return SocialIdentity(
+            provider="naver",
+            provider_user_id=uid,
+            email=profile.get("email") or "",
+            name=profile.get("name") or profile.get("nickname") or "",
+        )

--- a/backend/migrations/versions/0002_social_accounts.py
+++ b/backend/migrations/versions/0002_social_accounts.py
@@ -1,0 +1,40 @@
+"""social_accounts table (소셜 로그인 연결)
+
+Revision ID: 0002_social_accounts
+Revises: 0001_baseline
+Create Date: 2026-07-03
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0002_social_accounts"
+down_revision: str | Sequence[str] | None = "0001_baseline"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "social_accounts",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "user_id", sa.String(64),
+            sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column("provider", sa.String(20), nullable=False),
+        sa.Column("provider_user_id", sa.String(128), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.UniqueConstraint("provider", "provider_user_id", name="uq_social_provider_uid"),
+    )
+    op.create_index("ix_social_accounts_user_id", "social_accounts", ["user_id"])
+    op.create_index("ix_social_accounts_provider", "social_accounts", ["provider"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_social_accounts_provider", table_name="social_accounts")
+    op.drop_index("ix_social_accounts_user_id", table_name="social_accounts")
+    op.drop_table("social_accounts")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,6 +9,7 @@ pyjwt>=2.8
 pydantic>=2.0
 pydantic-settings>=2.0
 email-validator>=2.0
+httpx>=0.27
 python-multipart>=0.0.9
 python-dotenv>=1.0
 google-genai>=1.0

--- a/backend/tests/test_social.py
+++ b/backend/tests/test_social.py
@@ -1,0 +1,58 @@
+"""소셜 로그인 — 팩토리(순수) + 엔드포인트(DB, verifier 모킹)."""
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from app.services.social.base import SocialIdentity
+from app.services.social.factory import get_verifier
+from app.services.social.kakao import KakaoVerifier
+
+
+def test_factory_returns_provider_verifier():
+    assert isinstance(get_verifier("kakao"), KakaoVerifier)
+    assert get_verifier("GOOGLE").provider == "google"
+
+
+def test_factory_unknown_provider_raises():
+    with pytest.raises(ValueError):
+        get_verifier("myspace")
+
+
+def test_social_login_creates_then_reuses_user(client, monkeypatch):
+    import app.api.v1.social as social_mod
+
+    email = f"soc-{uuid4().hex[:8]}@oncare.com"
+    identity = SocialIdentity(
+        provider="kakao",
+        provider_user_id=f"kakao-{uuid4().hex[:8]}",
+        email=email,
+        name="소셜유저",
+    )
+
+    class _FakeVerifier:
+        async def verify(self, token):  # noqa: ARG002
+            return identity
+
+    monkeypatch.setattr(social_mod, "get_verifier", lambda provider: _FakeVerifier())
+
+    r = client.post("/v1/auth/social/kakao", json={"token": "any"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["access_token"] and body["refresh_token"]
+
+    me = client.get("/v1/users/me", headers={"Authorization": f"Bearer {body['access_token']}"})
+    assert me.status_code == 200
+    assert me.json()["email"] == email
+    uid = me.json()["id"]
+
+    # 같은 소셜 신원으로 다시 로그인 → 같은 사용자
+    r2 = client.post("/v1/auth/social/kakao", json={"token": "any"})
+    me2 = client.get("/v1/users/me", headers={"Authorization": f"Bearer {r2.json()['access_token']}"})
+    assert me2.json()["id"] == uid
+
+
+def test_social_login_unsupported_provider_400(client):
+    r = client.post("/v1/auth/social/myspace", json={"token": "x"})
+    assert r.status_code == 400


### PR DESCRIPTION
Closes #104

## 개요
백엔드 **소셜 로그인** 입니다. 인증 강화 PR **#99 위에 스택**(base: `feature/backend-auth`). `main` 미반영.
스택 순서: **#98(기반) ← #99(인증) ← 본 PR(소셜)**.

## 변경 (커밋 순서)
1. **feat: `social_accounts` 모델 + 마이그레이션 0002** — (user_id, provider, provider_user_id) 저장, `(provider, provider_user_id)` 유일. 한 사용자에 여러 provider 연결 가능. (마이그레이션 워크플로 실사용)
2. **feat: 소셜 로그인 엔드포인트 + provider 검증기** — `POST /auth/social/{provider}`.
   - `SocialVerifier` 추상화(base + factory, recognizer/embedder 패턴과 동일) + **Kakao/Google/Naver** 실검증, **Apple 스텁**(JWKS 검증은 이후 → 501).
   - provider 토큰 검증 → 사용자 조회/생성(연결: `(provider, uid)` → 이메일 → 신규) → **access+refresh JWT 발급**.
   - `httpx` 런타임 의존성 추가.
3. **test: 소셜 로그인 테스트** — 팩토리(순수) + verifier 모킹 엔드포인트(생성→재사용 동일 사용자, 미지원 provider 400).

## 검증
- 로컬 순수 유닛 테스트 **13개 통과**(소셜 팩토리 포함). DB 테스트(소셜 로그인 생성/재사용·마이그레이션 0002)는 본 PR **Backend CI**(Postgres/pgvector)에서 실행.
- 하위호환: 기존 로그인/토큰 흐름 변경 없음. 새 엔드포인트만 추가.

## 다음
- **Apple 로그인**(identity_token JWKS 검증) 별도 구현.
- 다음 Phase: 온보딩·프로필 API → Vision/RAG 앱 연동·공공 식품영양성분 DB 매핑.

리뷰어: @seoyeon0516 @aJISUa
