### PR TITLE
feat(profile): 온보딩 · 프로필 · 건강목표 · 회원탈퇴 API

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -91,3 +91,5 @@ def require_auth(
 
 
 CurrentUser = Annotated[User, Depends(get_current_user)]
+# 엄격 인증(쓰기/삭제 등 보호 엔드포인트용) — 데모 폴백 없음
+RequireUser = Annotated[User, Depends(require_auth)]

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -19,7 +19,7 @@ from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.api.deps import CurrentUser
+from app.api.deps import CurrentUser, RequireUser
 from app.core.security import (
     create_access_token, create_refresh_token, decode_refresh_token,
     hash_password, verify_password,
@@ -27,7 +27,8 @@ from app.core.security import (
 from app.db.session import get_db
 from app.models.models import HealthProfile, User
 from app.schemas.user import (
-    HealthProfileBrief, RefreshRequest, RiskInfo, SettingItem, Token, UserHealth, UserMe, UserRegister,
+    HealthGoalsUpdate, HealthProfileBrief, OnboardingRequest, ProfileUpdate, ProfileView,
+    RefreshRequest, RiskInfo, SettingItem, Token, UserHealth, UserMe, UserRegister,
 )
 from app.services.health_service import DEMO_SETTINGS, build_indicators_for_user
 
@@ -70,6 +71,125 @@ def get_my_health(
         activity_rank=rank,
         settings=[SettingItem(**s) for s in DEMO_SETTINGS],
     )
+
+
+# ---- 프로필 / 온보딩 / 건강 목표 / 탈퇴 ----
+
+def _get_or_create_profile(db: Session, user: User) -> HealthProfile:
+    """사용자의 HealthProfile 을 가져오거나(없으면) 생성한다."""
+    profile = user.health_profile
+    if profile is None:
+        profile = HealthProfile(user_id=user.id)
+        db.add(profile)
+        db.flush()
+    return profile
+
+
+def _profile_view(user: User) -> ProfileView:
+    p = user.health_profile
+    return ProfileView(
+        id=user.id,
+        name=user.name,
+        email=user.email,
+        phone=p.phone if p else "",
+        birth_date=p.birth_date if p else "",
+        gender=p.gender if p else "",
+        height_cm=p.height_cm if p else None,
+        weight_kg=p.weight_kg if p else None,
+        conditions=p.conditions if p else "",
+        goals=p.goals if p else "",
+        goal_weight_kg=p.goal_weight_kg if p else None,
+        goal_bp_systolic=p.goal_bp_systolic if p else None,
+        goal_blood_sugar=p.goal_blood_sugar if p else None,
+        daily_calories=p.daily_calories if p else None,
+        daily_sodium_mg=p.daily_sodium_mg if p else None,
+        onboarded=p.onboarded if p else False,
+    )
+
+
+@router.get("/users/me/profile", response_model=ProfileView)
+def get_my_profile(current_user: CurrentUser) -> ProfileView:
+    """내 프로필 통합 뷰(인구통계·목표·온보딩 여부). 조회는 데모 폴백 허용."""
+    return _profile_view(current_user)
+
+
+@router.post("/users/me/onboarding", response_model=ProfileView)
+def submit_onboarding(
+    payload: OnboardingRequest,
+    user: RequireUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> ProfileView:
+    """최초 온보딩 저장. 제공된 필드만 반영하고 onboarded=True 로 표시."""
+    data = payload.model_dump(exclude_unset=True)
+    if "name" in data and data["name"] is not None:
+        user.name = data.pop("name")
+    else:
+        data.pop("name", None)
+
+    profile = _get_or_create_profile(db, user)
+    for field, value in data.items():
+        setattr(profile, field, value)
+    profile.onboarded = True
+
+    db.commit()
+    db.refresh(user)
+    return _profile_view(user)
+
+
+@router.put("/users/me", response_model=ProfileView)
+def update_me(
+    payload: ProfileUpdate,
+    user: RequireUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> ProfileView:
+    """내 프로필 모달 저장: 이름/이메일(중복검사)/전화/생년월일."""
+    data = payload.model_dump(exclude_unset=True)
+
+    new_email = data.get("email")
+    if new_email is not None and new_email != user.email:
+        dup = db.scalar(select(User).where(User.email == new_email, User.id != user.id))
+        if dup is not None:
+            raise HTTPException(status_code=409, detail="이미 사용 중인 이메일입니다.")
+        user.email = new_email
+    if data.get("name") is not None:
+        user.name = data["name"]
+
+    profile = _get_or_create_profile(db, user)
+    if "phone" in data and data["phone"] is not None:
+        profile.phone = data["phone"]
+    if "birth_date" in data and data["birth_date"] is not None:
+        profile.birth_date = data["birth_date"]
+
+    db.commit()
+    db.refresh(user)
+    return _profile_view(user)
+
+
+@router.put("/users/me/health-goals", response_model=ProfileView)
+def update_health_goals(
+    payload: HealthGoalsUpdate,
+    user: RequireUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> ProfileView:
+    """건강 목표 모달 저장: 목표 체중/혈압/혈당/일일 칼로리·나트륨."""
+    profile = _get_or_create_profile(db, user)
+    for field, value in payload.model_dump(exclude_unset=True).items():
+        setattr(profile, field, value)
+    db.commit()
+    db.refresh(user)
+    return _profile_view(user)
+
+
+@router.delete("/users/me")
+def delete_me(
+    user: RequireUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> dict:
+    """회원 탈퇴. FK(ondelete=CASCADE)로 프로필·식단·운동·바이탈·일정·알림·
+    소셜계정·개인 코치문서가 함께 삭제된다."""
+    db.delete(user)
+    db.commit()
+    return {"status": "deleted"}
 
 
 # ---- 인증 (Stage 4 대비, 지금도 동작) ----

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -54,6 +54,24 @@ class HealthProfile(Base):
     risk_level: Mapped[str] = mapped_column(String(20), default="low")  # low|medium|high
     conditions: Mapped[str] = mapped_column(Text, default="")  # "고혈압, 당뇨 전단계"
     goals: Mapped[str] = mapped_column(Text, default="")
+
+    # 개인정보(내 프로필 모달) + 온보딩 인구통계
+    phone: Mapped[str] = mapped_column(String(20), default="")
+    birth_date: Mapped[str] = mapped_column(String(10), default="")   # YYYY-MM-DD
+    gender: Mapped[str] = mapped_column(String(10), default="")       # male|female|other
+    height_cm: Mapped[float | None] = mapped_column(Float, nullable=True)
+    weight_kg: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    # 건강 목표(건강 목표 모달)
+    goal_weight_kg: Mapped[float | None] = mapped_column(Float, nullable=True)
+    goal_bp_systolic: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    goal_blood_sugar: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    daily_calories: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    daily_sodium_mg: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # 온보딩 완료 여부(프론트 온보딩 게이팅용)
+    onboarded: Mapped[bool] = mapped_column(Boolean, default=False)
+
     activity_points: Mapped[int] = mapped_column(Integer, default=0)
     activity_rank: Mapped[int | None] = mapped_column(Integer, nullable=True)
     updated_at: Mapped[datetime] = mapped_column(

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -83,3 +83,60 @@ class UserRegister(BaseModel):
     email: str
     password: str
     name: str = ""
+
+
+# ---- 프로필 / 온보딩 / 건강 목표 ----
+class ProfileView(BaseModel):
+    """GET /users/me/profile — 내 프로필 화면용 통합 뷰."""
+    id: str
+    name: str
+    email: str
+    phone: str = ""
+    birth_date: str = ""
+    gender: str = ""
+    height_cm: Optional[float] = None
+    weight_kg: Optional[float] = None
+    conditions: str = ""
+    goals: str = ""
+    goal_weight_kg: Optional[float] = None
+    goal_bp_systolic: Optional[int] = None
+    goal_blood_sugar: Optional[int] = None
+    daily_calories: Optional[int] = None
+    daily_sodium_mg: Optional[int] = None
+    onboarded: bool = False
+
+
+class OnboardingRequest(BaseModel):
+    """POST /users/me/onboarding — 최초 온보딩(모두 선택, 부분 저장 허용).
+
+    name 은 User, 나머지는 HealthProfile 컬럼과 1:1 로 매핑된다.
+    """
+    name: Optional[str] = None
+    birth_date: Optional[str] = None       # YYYY-MM-DD
+    gender: Optional[str] = None           # male|female|other
+    height_cm: Optional[float] = None
+    weight_kg: Optional[float] = None
+    conditions: Optional[str] = None       # "고혈압, 당뇨 전단계"
+    goals: Optional[str] = None
+    goal_weight_kg: Optional[float] = None
+    goal_bp_systolic: Optional[int] = None
+    goal_blood_sugar: Optional[int] = None
+    daily_calories: Optional[int] = None
+    daily_sodium_mg: Optional[int] = None
+
+
+class ProfileUpdate(BaseModel):
+    """PUT /users/me — 내 프로필 모달(이름/이메일/전화/생년월일)."""
+    name: Optional[str] = None
+    email: Optional[str] = None
+    phone: Optional[str] = None
+    birth_date: Optional[str] = None
+
+
+class HealthGoalsUpdate(BaseModel):
+    """PUT /users/me/health-goals — 건강 목표 모달."""
+    goal_weight_kg: Optional[float] = None
+    goal_bp_systolic: Optional[int] = None
+    goal_blood_sugar: Optional[int] = None
+    daily_calories: Optional[int] = None
+    daily_sodium_mg: Optional[int] = None

--- a/backend/migrations/versions/0003_profile_fields.py
+++ b/backend/migrations/versions/0003_profile_fields.py
@@ -1,0 +1,52 @@
+"""profile & health-goal fields on health_profiles
+
+내 프로필/온보딩/건강 목표 저장을 위해 health_profiles 에 개인정보·인구통계·
+목표치 컬럼을 추가한다. 기존 행 보존을 위한 순수 추가(additive) 마이그레이션.
+
+Revision ID: 0003_profile_fields
+Revises: 0002_social_accounts
+Create Date: 2026-07-03
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0003_profile_fields"
+down_revision: str | Sequence[str] | None = "0002_social_accounts"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# (컬럼명, 타입, nullable, server_default)
+_COLUMNS = [
+    ("phone", sa.String(20), False, ""),
+    ("birth_date", sa.String(10), False, ""),
+    ("gender", sa.String(10), False, ""),
+    ("height_cm", sa.Float(), True, None),
+    ("weight_kg", sa.Float(), True, None),
+    ("goal_weight_kg", sa.Float(), True, None),
+    ("goal_bp_systolic", sa.Integer(), True, None),
+    ("goal_blood_sugar", sa.Integer(), True, None),
+    ("daily_calories", sa.Integer(), True, None),
+    ("daily_sodium_mg", sa.Integer(), True, None),
+]
+
+
+def upgrade() -> None:
+    for name, type_, nullable, default in _COLUMNS:
+        op.add_column(
+            "health_profiles",
+            sa.Column(name, type_, nullable=nullable, server_default=default),
+        )
+    op.add_column(
+        "health_profiles",
+        sa.Column("onboarded", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("health_profiles", "onboarded")
+    for name, *_ in reversed(_COLUMNS):
+        op.drop_column("health_profiles", name)

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -1,0 +1,109 @@
+"""프로필 / 온보딩 / 건강 목표 / 회원 탈퇴 — DB 필요(로컬 skip, CI 실행)."""
+from __future__ import annotations
+
+from uuid import uuid4
+
+
+def _register_and_login(client, name: str = "테스터") -> tuple[str, str]:
+    """가입+로그인 후 (access_token, email) 반환."""
+    email = f"prof-{uuid4().hex[:8]}@oncare.com"
+    password = "pw-12345!"
+    r = client.post("/v1/auth/register", json={"email": email, "password": password, "name": name})
+    assert r.status_code == 201, r.text
+    login = client.post("/v1/auth/login", data={"username": email, "password": password})
+    assert login.status_code == 200, login.text
+    return login.json()["access_token"], email
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_onboarding_saves_profile_and_marks_done(client):
+    token, email = _register_and_login(client)
+    body = {
+        "name": "온보딩유저",
+        "birth_date": "1990-01-15",
+        "gender": "male",
+        "height_cm": 175.0,
+        "weight_kg": 82.0,
+        "conditions": "고혈압, 당뇨 전단계",
+        "goals": "혈압 정상화",
+        "goal_weight_kg": 70.0,
+        "goal_bp_systolic": 120,
+        "daily_sodium_mg": 2000,
+    }
+    r = client.post("/v1/users/me/onboarding", json=body, headers=_auth(token))
+    assert r.status_code == 200, r.text
+    p = r.json()
+    assert p["onboarded"] is True
+    assert p["name"] == "온보딩유저"
+    assert p["conditions"] == "고혈압, 당뇨 전단계"
+    assert p["height_cm"] == 175.0
+    assert p["goal_bp_systolic"] == 120
+
+    # GET 으로도 동일하게 조회돼야 한다
+    got = client.get("/v1/users/me/profile", headers=_auth(token))
+    assert got.status_code == 200
+    assert got.json()["onboarded"] is True
+    assert got.json()["goal_weight_kg"] == 70.0
+
+
+def test_update_me_changes_name_and_phone(client):
+    token, _ = _register_and_login(client)
+    r = client.put(
+        "/v1/users/me",
+        json={"name": "새이름", "phone": "010-1234-5678", "birth_date": "1988-03-03"},
+        headers=_auth(token),
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["name"] == "새이름"
+    assert r.json()["phone"] == "010-1234-5678"
+
+    me = client.get("/v1/users/me", headers=_auth(token))
+    assert me.json()["name"] == "새이름"
+
+
+def test_update_me_duplicate_email_conflicts_409(client):
+    token_a, email_a = _register_and_login(client)
+    token_b, _ = _register_and_login(client)
+    r = client.put("/v1/users/me", json={"email": email_a}, headers=_auth(token_b))
+    assert r.status_code == 409
+
+
+def test_update_health_goals(client):
+    token, _ = _register_and_login(client)
+    r = client.put(
+        "/v1/users/me/health-goals",
+        json={
+            "goal_weight_kg": 68.0,
+            "goal_bp_systolic": 118,
+            "goal_blood_sugar": 100,
+            "daily_calories": 2000,
+            "daily_sodium_mg": 1800,
+        },
+        headers=_auth(token),
+    )
+    assert r.status_code == 200, r.text
+    p = r.json()
+    assert p["goal_weight_kg"] == 68.0
+    assert p["daily_sodium_mg"] == 1800
+
+
+def test_delete_me_removes_account(client):
+    token, email = _register_and_login(client)
+    r = client.delete("/v1/users/me", headers=_auth(token))
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "deleted"
+
+    # 계정이 사라졌으므로 재로그인 불가
+    again = client.post("/v1/auth/login", data={"username": email, "password": "pw-12345!"})
+    assert again.status_code == 401
+
+
+def test_profile_writes_require_auth(client):
+    # require_auth 는 데모 폴백을 쓰지 않으므로 토큰 없으면 401
+    assert client.post("/v1/users/me/onboarding", json={}).status_code == 401
+    assert client.put("/v1/users/me", json={"name": "x"}).status_code == 401
+    assert client.put("/v1/users/me/health-goals", json={}).status_code == 401
+    assert client.delete("/v1/users/me").status_code == 401


### PR DESCRIPTION
Closes #105

## 개요
Phase 1 마무리 — **온보딩·프로필 수정·건강목표·회원탈퇴** API. 소셜 로그인 PR **#100 위에 스택**(base: `feature/backend-social`). `main` 미반영.
스택 순서: **#98(기반) ← #99(인증) ← #100(소셜) ← 본 PR**.

## 배경
프론트 `settings_modals.dart`의 **내 프로필 / 건강 목표** 모달은 UI만 있고 저장 API가 없었습니다(스낵바만). 온보딩·회원탈퇴는 프론트/백 모두 부재. 그 계약을 백엔드에 정렬합니다.

## 변경 (커밋 순서)
1. **feat: HealthProfile 컬럼 + 마이그레이션 0003** — 개인정보(phone·birth_date·gender·height_cm·weight_kg)·목표치(goal_weight_kg·goal_bp_systolic·goal_blood_sugar·daily_calories·daily_sodium_mg)·`onboarded` 플래그. **추가형(additive)** 마이그레이션(NOT NULL엔 server_default) → 기존 행 보존.
2. **feat: 엔드포인트** —
   | Method | Path | 용도 | 인증 |
   |---|---|---|---|
   | GET | `/users/me/profile` | 프로필 통합 뷰 | 조회(데모폴백) |
   | POST | `/users/me/onboarding` | 최초 온보딩 저장(부분 허용) | **RequireUser** |
   | PUT | `/users/me` | 이름·이메일(중복검사)·전화·생년월일 | **RequireUser** |
   | PUT | `/users/me/health-goals` | 목표 체중/혈압/혈당·일일 칼로리·나트륨 | **RequireUser** |
   | DELETE | `/users/me` | 회원 탈퇴(FK CASCADE 전체 삭제) | **RequireUser** |

   쓰기·삭제는 **데모 폴백을 쓰지 않는 엄격 인증(`RequireUser`)** — 미인증자가 데모 사용자를 수정/삭제하는 사고 방지. 필드명은 프론트 모달과 1:1.
3. **test: 테스트** — 온보딩 저장→조회, 프로필 수정, 이메일 중복 409, 건강목표 저장, 탈퇴 후 재로그인 401, 무인증 가드 401.

## 검증
- 로컬 순수 유닛 **13개 통과**, 스키마 필드↔`HealthProfile` 컬럼 정합성 정적 확인. 프로필 6개(DB) + 마이그레이션 0003은 **Backend CI**(Postgres/pgvector `alembic upgrade head` → pytest)에서 실행.
- 하위호환: 기존 `GET /users/me`·`/users/me/health` 변경 없음. 컬럼은 전부 추가형.

## 다음
- Phase 2: Vision/RAG 앱 연동 + 공공 식품영양성분 DB 매핑.

리뷰어: @seoyeon0516 @aJISUa
