### PR TITLE
feat(rag): 홈 대화형 코칭 챗봇 UI (홈 정적 코치 → 채팅)

### DIFF
--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -37,6 +37,7 @@ class LocalApiInterceptor extends Interceptor {
     'GET /schedule/events': _scheduleEvents,
     'GET /notifications': _notifications,
     'GET /ai-coach/feedback': _aiCoachFeedback,
+    'POST /ai-coach/chat': _aiCoachChat,
     'GET /users/me': _usersMe,
     'GET /users/me/health': _usersMeHealth,
     'GET /places/nearby': _placesNearby,
@@ -457,6 +458,82 @@ class LocalApiInterceptor extends Interceptor {
         },
       ],
     });
+  }
+
+  /// Interactive coach chat. Reads `{ message, history[] }` and returns
+  /// `{ reply, sources[] }`. Keyword-matched canned answers grounded in the
+  /// same public guidelines the real RAG backend seeds, so the demo (mock
+  /// mode) exchanges real messages without a server.
+  Future<Response<Object?>> _aiCoachChat(RequestOptions options) async {
+    final body = options.data;
+    Map<String, Object?> payload;
+    if (body is Map) {
+      payload = body.cast<String, Object?>();
+    } else if (body is String && body.isNotEmpty) {
+      payload = (jsonDecode(body) as Map<Object?, Object?>)
+          .cast<String, Object?>();
+    } else {
+      payload = <String, Object?>{};
+    }
+    final message = (payload['message'] as String? ?? '').trim();
+    if (message.isEmpty) {
+      return _badRequest(options, 'message is empty');
+    }
+
+    final (String reply, List<String> sources) = _mockCoachReply(message);
+    return _ok(options, <String, Object?>{'reply': reply, 'sources': sources});
+  }
+
+  (String, List<String>) _mockCoachReply(String message) {
+    bool has(List<String> keys) => keys.any(message.contains);
+
+    if (has(<String>['나트륨', '혈압', '짜', '소금', '국물'])) {
+      return (
+        '나트륨을 줄이려면 국물은 남기고 건더기 위주로 드시고, 소금 대신 후추·마늘·레몬으로 '
+        '간을 해보세요. 하루 나트륨을 2000mg 이하로 맞추면 혈압 관리에 큰 도움이 돼요. 🌿',
+        <String>['나트륨 줄이기', 'DASH 식단 개요'],
+      );
+    }
+    if (has(<String>['당', '혈당', '설탕', '단 것', '디저트'])) {
+      return (
+        '혈당 관리를 위해 가당 음료와 디저트 같은 단순당을 줄이고, 식이섬유가 풍부한 통곡물·채소를 '
+        '늘려보세요. 음료는 물이나 무가당 차로 바꾸는 것만으로도 효과가 좋아요. 🍵',
+        <String>['당류 관리'],
+      );
+    }
+    if (has(<String>['운동', '걷', '헬스', '유산소', '근력'])) {
+      return (
+        '빠르게 걷기 같은 중강도 유산소를 주 5회, 하루 30분씩 해보세요. 여기에 주 2회 가벼운 근력 '
+        '운동을 더하면 혈압·혈당 관리에 특히 좋아요. 식후 10분 걷기도 큰 도움이 됩니다. 🚶',
+        <String>['고혈압과 운동', '유산소와 근력 균형'],
+      );
+    }
+    if (has(<String>['뭐 먹', '식단', '점심', '저녁', '아침', '메뉴'])) {
+      return (
+        '채소·통곡물·저지방 단백질 위주의 DASH 식단을 추천해요. 국·찌개는 싱겁게, 튀김보다 구이·찜으로 '
+        '드시면 좋아요. 혹시 최근 나트륨이 높았다면 담백한 샐러드나 생선구이가 균형을 맞춰줘요. 🥗',
+        <String>['DASH 식단 개요'],
+      );
+    }
+    if (has(<String>['물', '수분'])) {
+      return (
+        '하루 6~8잔의 물을 나눠 마시는 것이 혈압과 신진대사에 도움이 돼요. 카페인·가당 음료는 줄이고 '
+        '물로 대체해보세요. 💧',
+        <String>['수분 섭취'],
+      );
+    }
+    if (has(<String>['체중', '살', '다이어트', '몸무게'])) {
+      return (
+        '급격한 감량보다 식단과 운동을 병행한 완만한 감량이 안전해요. 체중을 5~10%만 줄여도 혈압·혈당 '
+        '지표가 눈에 띄게 좋아질 수 있어요. 함께 천천히 가봐요! 💪',
+        <String>['체중 관리'],
+      );
+    }
+    return (
+      '좋은 질문이에요! 식단·운동·혈압·혈당·수분 관리에 대해 더 구체적으로 물어봐 주시면 온이가 '
+      '맞춤으로 도와드릴게요. 예를 들어 "나트륨 줄이는 법"이나 "오늘 뭐 먹을까?"처럼요. 😊',
+      <String>[],
+    );
   }
 
   // ---- Users / Me ----

--- a/frontend/flutter/lib/features/ai_coach/data/repositories/dio_ai_coach_repository.dart
+++ b/frontend/flutter/lib/features/ai_coach/data/repositories/dio_ai_coach_repository.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 
 import 'package:oncare/features/ai_coach/domain/entities/ai_coach_state.dart';
+import 'package:oncare/features/ai_coach/domain/entities/chat_message.dart';
 import 'package:oncare/features/ai_coach/domain/repositories/ai_coach_repository.dart';
 
 class DioAiCoachRepository implements AiCoachRepository {
@@ -11,5 +12,20 @@ class DioAiCoachRepository implements AiCoachRepository {
   Future<AiCoachState> fetchState() async {
     final res = await _dio.get<Map<String, Object?>>('/ai-coach/feedback');
     return AiCoachState.fromJson(res.data!);
+  }
+
+  @override
+  Future<ChatMessage> sendMessage({
+    required String message,
+    required List<ChatMessage> history,
+  }) async {
+    final res = await _dio.post<Map<String, Object?>>(
+      '/ai-coach/chat',
+      data: <String, Object?>{
+        'message': message,
+        'history': <Map<String, Object?>>[for (final m in history) m.toJson()],
+      },
+    );
+    return ChatMessage.coachFromReply(res.data!);
   }
 }

--- a/frontend/flutter/lib/features/ai_coach/data/repositories/mock_ai_coach_repository.dart
+++ b/frontend/flutter/lib/features/ai_coach/data/repositories/mock_ai_coach_repository.dart
@@ -1,8 +1,21 @@
 import 'package:oncare/features/ai_coach/domain/entities/ai_coach_state.dart';
+import 'package:oncare/features/ai_coach/domain/entities/chat_message.dart';
 import 'package:oncare/features/ai_coach/domain/repositories/ai_coach_repository.dart';
 
 class MockAiCoachRepository implements AiCoachRepository {
   const MockAiCoachRepository();
+
+  @override
+  Future<ChatMessage> sendMessage({
+    required String message,
+    required List<ChatMessage> history,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 400));
+    return const ChatMessage(
+      role: ChatRole.coach,
+      content: '식단·운동·혈압·혈당 관리에 대해 무엇이든 물어봐 주세요. 온이가 도와드릴게요! 😊',
+    );
+  }
 
   @override
   Future<AiCoachState> fetchState() async {

--- a/frontend/flutter/lib/features/ai_coach/domain/entities/chat_message.dart
+++ b/frontend/flutter/lib/features/ai_coach/domain/entities/chat_message.dart
@@ -1,0 +1,35 @@
+enum ChatRole { user, coach }
+
+/// One message in the coach conversation. [pending] marks the transient
+/// "typing…" placeholder shown while awaiting the coach's reply.
+class ChatMessage {
+  const ChatMessage({
+    required this.role,
+    required this.content,
+    this.sources = const <String>[],
+    this.pending = false,
+  });
+
+  final ChatRole role;
+  final String content;
+  final List<String> sources; // 근거 공공 가이드라인 제목(코치 메시지에만)
+  final bool pending;
+
+  bool get isUser => role == ChatRole.user;
+
+  /// Request shape sent as chat history to the server (snake_case-safe).
+  Map<String, Object?> toJson() => <String, Object?>{
+    'role': isUser ? 'user' : 'coach',
+    'content': content,
+  };
+
+  /// Parse a coach reply from `POST /ai-coach/chat` → `{ reply, sources }`.
+  factory ChatMessage.coachFromReply(Map<String, Object?> json) => ChatMessage(
+    role: ChatRole.coach,
+    content: ((json['reply'] as String?) ?? '').trim(),
+    sources: <String>[
+      for (final Object? s in (json['sources'] as List<Object?>?) ?? const <Object?>[])
+        s.toString(),
+    ],
+  );
+}

--- a/frontend/flutter/lib/features/ai_coach/domain/repositories/ai_coach_repository.dart
+++ b/frontend/flutter/lib/features/ai_coach/domain/repositories/ai_coach_repository.dart
@@ -1,5 +1,12 @@
 import 'package:oncare/features/ai_coach/domain/entities/ai_coach_state.dart';
+import 'package:oncare/features/ai_coach/domain/entities/chat_message.dart';
 
 abstract class AiCoachRepository {
   Future<AiCoachState> fetchState();
+
+  /// Send a user message (+ prior turns) and get the coach's reply.
+  Future<ChatMessage> sendMessage({
+    required String message,
+    required List<ChatMessage> history,
+  });
 }

--- a/frontend/flutter/lib/features/ai_coach/presentation/controllers/chat_controller.dart
+++ b/frontend/flutter/lib/features/ai_coach/presentation/controllers/chat_controller.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare/features/ai_coach/domain/entities/chat_message.dart';
+import 'package:oncare/features/ai_coach/domain/repositories/ai_coach_repository.dart';
+import 'package:oncare/features/ai_coach/presentation/controllers/ai_coach_controller.dart';
+
+/// Suggested starter prompts shown on the home card and empty chat.
+const List<String> kCoachPrompts = <String>[
+  '나트륨 줄이는 법',
+  '오늘 뭐 먹을까?',
+  '운동 추천해줘',
+  '혈당 관리 팁',
+];
+
+const ChatMessage _welcome = ChatMessage(
+  role: ChatRole.coach,
+  content: '안녕하세요, AI 건강 코치 온이예요 🙂\n'
+      '고혈압·당뇨 관리를 위한 식단·운동·혈압·혈당 무엇이든 편하게 물어보세요.',
+);
+
+class ChatState {
+  const ChatState({this.messages = const <ChatMessage>[_welcome], this.sending = false});
+
+  final List<ChatMessage> messages;
+  final bool sending;
+
+  ChatState copyWith({List<ChatMessage>? messages, bool? sending}) => ChatState(
+    messages: messages ?? this.messages,
+    sending: sending ?? this.sending,
+  );
+}
+
+class ChatController extends StateNotifier<ChatState> {
+  ChatController(this._repo) : super(const ChatState());
+
+  final AiCoachRepository _repo;
+
+  Future<void> send(String text) async {
+    final message = text.trim();
+    if (message.isEmpty || state.sending) return;
+
+    // 현재까지의 대화(진행 중 placeholder 제외)를 history 로 전달.
+    final history = state.messages.where((ChatMessage m) => !m.pending).toList();
+
+    state = state.copyWith(
+      messages: <ChatMessage>[
+        ...history,
+        ChatMessage(role: ChatRole.user, content: message),
+        const ChatMessage(role: ChatRole.coach, content: '', pending: true),
+      ],
+      sending: true,
+    );
+
+    try {
+      final reply = await _repo.sendMessage(message: message, history: history);
+      state = state.copyWith(messages: _replacePending(reply), sending: false);
+    } catch (_) {
+      state = state.copyWith(
+        messages: _replacePending(
+          const ChatMessage(
+            role: ChatRole.coach,
+            content: '앗, 잠시 문제가 생겼어요. 잠시 후 다시 시도해 주세요.',
+          ),
+        ),
+        sending: false,
+      );
+    }
+  }
+
+  List<ChatMessage> _replacePending(ChatMessage reply) => <ChatMessage>[
+    ...state.messages.where((ChatMessage m) => !m.pending),
+    reply,
+  ];
+}
+
+final chatControllerProvider =
+    StateNotifierProvider<ChatController, ChatState>(
+      (ref) => ChatController(ref.watch(aiCoachRepositoryProvider)),
+      name: 'chatController',
+    );

--- a/frontend/flutter/lib/features/ai_coach/presentation/pages/coach_chat_page.dart
+++ b/frontend/flutter/lib/features/ai_coach/presentation/pages/coach_chat_page.dart
@@ -1,0 +1,486 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/design_system/tokens/radius.dart';
+import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/ai_coach/domain/entities/chat_message.dart';
+import 'package:oncare/features/ai_coach/presentation/controllers/chat_controller.dart';
+
+const LinearGradient _coachGradient = LinearGradient(
+  begin: Alignment.topLeft,
+  end: Alignment.bottomRight,
+  colors: <Color>[AppColors.primary, AppColors.secondary],
+);
+
+/// Full-screen interactive chat with the AI coach "온이".
+/// Opened from the home coach card; optionally pre-sends [initialMessage].
+class CoachChatPage extends ConsumerStatefulWidget {
+  const CoachChatPage({this.initialMessage, super.key});
+
+  final String? initialMessage;
+
+  @override
+  ConsumerState<CoachChatPage> createState() => _CoachChatPageState();
+}
+
+class _CoachChatPageState extends ConsumerState<CoachChatPage> {
+  final TextEditingController _input = TextEditingController();
+  final ScrollController _scroll = ScrollController();
+  final FocusNode _focus = FocusNode();
+
+  @override
+  void initState() {
+    super.initState();
+    final String? initial = widget.initialMessage;
+    if (initial != null && initial.trim().isNotEmpty) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        ref.read(chatControllerProvider.notifier).send(initial);
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _input.dispose();
+    _scroll.dispose();
+    _focus.dispose();
+    super.dispose();
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scroll.hasClients) {
+        _scroll.animateTo(
+          _scroll.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 250),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  void _send(String text) {
+    if (text.trim().isEmpty) return;
+    _input.clear();
+    ref.read(chatControllerProvider.notifier).send(text);
+    _scrollToBottom();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ChatState state = ref.watch(chatControllerProvider);
+    // Auto-scroll whenever the conversation grows / typing toggles.
+    ref.listen<ChatState>(chatControllerProvider, (_, _) => _scrollToBottom());
+
+    final bool showPrompts = state.messages.length <= 1 && !state.sending;
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        child: Column(
+          children: <Widget>[
+            const _ChatHeader(),
+            Expanded(
+              child: ListView(
+                controller: _scroll,
+                padding: const EdgeInsets.fromLTRB(
+                  AppSpacing.lg,
+                  AppSpacing.lg,
+                  AppSpacing.lg,
+                  AppSpacing.md,
+                ),
+                children: <Widget>[
+                  for (final ChatMessage m in state.messages)
+                    _MessageBubble(message: m),
+                  if (showPrompts) _PromptSuggestions(onTap: _send),
+                ],
+              ),
+            ),
+            _ChatInputBar(
+              controller: _input,
+              focusNode: _focus,
+              sending: state.sending,
+              onSend: () => _send(_input.text),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ChatHeader extends StatelessWidget {
+  const _ChatHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.sm,
+        AppSpacing.sm,
+        AppSpacing.md,
+        AppSpacing.md,
+      ),
+      decoration: const BoxDecoration(
+        color: AppColors.background,
+        border: Border(bottom: BorderSide(color: AppColors.border)),
+      ),
+      child: Row(
+        children: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.arrow_back, color: AppColors.foreground),
+            onPressed: () => Navigator.of(context).maybePop(),
+          ),
+          const _CoachAvatar(size: 40),
+          const SizedBox(width: AppSpacing.sm),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  '온이',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                Row(
+                  children: <Widget>[
+                    Container(
+                      width: 7,
+                      height: 7,
+                      decoration: const BoxDecoration(
+                        color: AppColors.success,
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                    const SizedBox(width: 5),
+                    Text(
+                      'AI 건강 코치',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: AppColors.mutedForeground,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CoachAvatar extends StatelessWidget {
+  const _CoachAvatar({this.size = 30});
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: const BoxDecoration(
+        gradient: _coachGradient,
+        shape: BoxShape.circle,
+      ),
+      alignment: Alignment.center,
+      child: Icon(Icons.smart_toy_rounded, color: Colors.white, size: size * 0.56),
+    );
+  }
+}
+
+class _MessageBubble extends StatelessWidget {
+  const _MessageBubble({required this.message});
+  final ChatMessage message;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final bool isUser = message.isUser;
+    final double maxWidth = MediaQuery.of(context).size.width * 0.76;
+
+    final Widget bubble = Container(
+      constraints: BoxConstraints(maxWidth: maxWidth),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.md,
+        vertical: AppSpacing.sm + 2,
+      ),
+      decoration: BoxDecoration(
+        gradient: isUser ? _coachGradient : null,
+        color: isUser ? null : AppColors.accent,
+        borderRadius: BorderRadius.only(
+          topLeft: const Radius.circular(16),
+          topRight: const Radius.circular(16),
+          bottomLeft: Radius.circular(isUser ? 16 : 4),
+          bottomRight: Radius.circular(isUser ? 4 : 16),
+        ),
+      ),
+      child: message.pending
+          ? const _TypingDots()
+          : Text(
+              message.content,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: isUser ? Colors.white : AppColors.foreground,
+                height: 1.45,
+              ),
+            ),
+    );
+
+    final Widget column = Column(
+      crossAxisAlignment:
+          isUser ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+      children: <Widget>[
+        bubble,
+        if (!isUser && message.sources.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(top: 6, left: 4),
+            child: _SourceChips(sources: message.sources),
+          ),
+      ],
+    );
+
+    final Widget row = Row(
+      mainAxisAlignment:
+          isUser ? MainAxisAlignment.end : MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        if (!isUser) ...<Widget>[
+          const _CoachAvatar(),
+          const SizedBox(width: AppSpacing.sm),
+        ],
+        Flexible(child: column),
+      ],
+    );
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppSpacing.md),
+      child: row
+          .animate()
+          .fadeIn(duration: 220.ms)
+          .slideY(begin: 0.12, end: 0, curve: Curves.easeOutCubic),
+    );
+  }
+}
+
+class _SourceChips extends StatelessWidget {
+  const _SourceChips({required this.sources});
+  final List<String> sources;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 6,
+      runSpacing: 6,
+      children: <Widget>[
+        for (final String s in sources)
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+            decoration: const BoxDecoration(
+              color: AppColors.muted,
+              borderRadius: BorderRadius.all(AppRadius.pill),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                const Icon(
+                  Icons.menu_book_outlined,
+                  size: 12,
+                  color: AppColors.secondary,
+                ),
+                const SizedBox(width: 4),
+                Text(
+                  s,
+                  style: const TextStyle(
+                    fontSize: 11,
+                    color: AppColors.secondary,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _TypingDots extends StatelessWidget {
+  const _TypingDots();
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        for (int i = 0; i < 3; i++)
+          Padding(
+            padding: EdgeInsets.only(right: i < 2 ? 5 : 0),
+            child:
+                Container(
+                      width: 7,
+                      height: 7,
+                      decoration: BoxDecoration(
+                        color: AppColors.mutedForeground.withValues(alpha: 0.6),
+                        shape: BoxShape.circle,
+                      ),
+                    )
+                    .animate(onPlay: (AnimationController c) => c.repeat(reverse: true))
+                    .fade(
+                      begin: 0.35,
+                      end: 1,
+                      duration: 500.ms,
+                      delay: (i * 150).ms,
+                      curve: Curves.easeInOut,
+                    )
+                    .scaleXY(begin: 0.8, end: 1),
+          ),
+      ],
+    );
+  }
+}
+
+class _PromptSuggestions extends StatelessWidget {
+  const _PromptSuggestions({required this.onTap});
+  final ValueChanged<String> onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 38, top: 2),
+      child: Wrap(
+        spacing: AppSpacing.sm,
+        runSpacing: AppSpacing.sm,
+        children: <Widget>[
+          for (final String p in kCoachPrompts)
+            Material(
+              color: AppColors.background,
+              shape: const RoundedRectangleBorder(
+                borderRadius: BorderRadius.all(AppRadius.pill),
+                side: BorderSide(color: AppColors.primary),
+              ),
+              child: InkWell(
+                borderRadius: const BorderRadius.all(AppRadius.pill),
+                onTap: () => onTap(p),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.md,
+                    vertical: AppSpacing.sm,
+                  ),
+                  child: Text(
+                    p,
+                    style: const TextStyle(
+                      color: AppColors.primary,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ChatInputBar extends StatelessWidget {
+  const _ChatInputBar({
+    required this.controller,
+    required this.focusNode,
+    required this.sending,
+    required this.onSend,
+  });
+
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final bool sending;
+  final VoidCallback onSend;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.md,
+        AppSpacing.sm,
+        AppSpacing.md,
+        AppSpacing.md,
+      ),
+      decoration: const BoxDecoration(
+        color: AppColors.background,
+        border: Border(top: BorderSide(color: AppColors.border)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: <Widget>[
+          Expanded(
+            child: Container(
+              decoration: const BoxDecoration(
+                color: AppColors.inputBackground,
+                borderRadius: BorderRadius.all(AppRadius.pill),
+              ),
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
+              child: TextField(
+                controller: controller,
+                focusNode: focusNode,
+                minLines: 1,
+                maxLines: 4,
+                textInputAction: TextInputAction.send,
+                onSubmitted: (_) => onSend(),
+                decoration: const InputDecoration(
+                  hintText: '온이에게 물어보세요…',
+                  border: InputBorder.none,
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(vertical: 12),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.sm),
+          _SendButton(sending: sending, onTap: onSend),
+        ],
+      ),
+    );
+  }
+}
+
+class _SendButton extends StatelessWidget {
+  const _SendButton({required this.sending, required this.onTap});
+  final bool sending;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      shape: const CircleBorder(),
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: sending ? null : onTap,
+        child: Container(
+          width: 44,
+          height: 44,
+          decoration: BoxDecoration(
+            gradient: sending ? null : _coachGradient,
+            color: sending ? AppColors.muted : null,
+            shape: BoxShape.circle,
+          ),
+          alignment: Alignment.center,
+          child: sending
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    valueColor: AlwaysStoppedAnimation<Color>(AppColors.primary),
+                  ),
+                )
+              : const Icon(Icons.arrow_upward_rounded, color: Colors.white, size: 22),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/flutter/lib/features/ai_coach/presentation/widgets/coach_chat_card.dart
+++ b/frontend/flutter/lib/features/ai_coach/presentation/widgets/coach_chat_card.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+
+import 'package:oncare/design_system/atoms/app_card.dart';
+import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/design_system/tokens/radius.dart';
+import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/ai_coach/presentation/controllers/chat_controller.dart';
+import 'package:oncare/features/ai_coach/presentation/pages/coach_chat_page.dart';
+
+const LinearGradient _coachGradient = LinearGradient(
+  begin: Alignment.topLeft,
+  end: Alignment.bottomRight,
+  colors: <Color>[AppColors.primary, AppColors.secondary],
+);
+
+/// Home-screen entry point to the AI coach. Shows 온이's daily note and an
+/// input-styled bar + starter chips that open the interactive chat.
+class CoachChatCard extends StatelessWidget {
+  const CoachChatCard({this.dietLine, this.exerciseLine, super.key});
+
+  final String? dietLine;
+  final String? exerciseLine;
+
+  void _open(BuildContext context, {String? prompt}) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => CoachChatPage(initialMessage: prompt),
+        fullscreenDialog: true,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final List<String> notes = <String>[
+      ?dietLine,
+      ?exerciseLine,
+    ];
+
+    return AppCard(
+      outlined: true,
+      onTap: () => _open(context),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Container(
+                width: 40,
+                height: 40,
+                decoration: const BoxDecoration(
+                  gradient: _coachGradient,
+                  shape: BoxShape.circle,
+                ),
+                alignment: Alignment.center,
+                child: const Icon(
+                  Icons.smart_toy_rounded,
+                  color: Colors.white,
+                  size: 22,
+                ),
+              ),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      '온이',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    Text(
+                      'AI 건강 코치',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: AppColors.mutedForeground,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const Icon(
+                Icons.chevron_right,
+                color: AppColors.mutedForeground,
+                size: 20,
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.md),
+          if (notes.isEmpty)
+            Text(
+              '오늘 건강에 대해 궁금한 점을 물어보세요. 식단·운동·혈압·혈당 무엇이든 도와드릴게요.',
+              style: theme.textTheme.bodyMedium?.copyWith(height: 1.45),
+            )
+          else
+            for (int i = 0; i < notes.length; i++) ...<Widget>[
+              Text(notes[i], style: theme.textTheme.bodyMedium?.copyWith(height: 1.45)),
+              if (i < notes.length - 1) const SizedBox(height: AppSpacing.xs),
+            ],
+          const SizedBox(height: AppSpacing.md),
+          // Input-styled bar (tap → open chat).
+          Container(
+            decoration: const BoxDecoration(
+              color: AppColors.inputBackground,
+              borderRadius: BorderRadius.all(AppRadius.pill),
+            ),
+            padding: const EdgeInsets.fromLTRB(AppSpacing.lg, 10, 6, 10),
+            child: Row(
+              children: <Widget>[
+                Expanded(
+                  child: Text(
+                    '온이에게 물어보세요…',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: AppColors.mutedForeground,
+                    ),
+                  ),
+                ),
+                Container(
+                  width: 32,
+                  height: 32,
+                  decoration: const BoxDecoration(
+                    gradient: _coachGradient,
+                    shape: BoxShape.circle,
+                  ),
+                  alignment: Alignment.center,
+                  child: const Icon(
+                    Icons.arrow_upward_rounded,
+                    color: Colors.white,
+                    size: 18,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          // Starter prompt chips.
+          Wrap(
+            spacing: AppSpacing.sm,
+            runSpacing: AppSpacing.sm,
+            children: <Widget>[
+              for (final String p in kCoachPrompts.take(3))
+                Material(
+                  color: AppColors.accent,
+                  borderRadius: const BorderRadius.all(AppRadius.pill),
+                  child: InkWell(
+                    borderRadius: const BorderRadius.all(AppRadius.pill),
+                    onTap: () => _open(context, prompt: p),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AppSpacing.md,
+                        vertical: 6,
+                      ),
+                      child: Text(
+                        p,
+                        style: const TextStyle(
+                          color: AppColors.secondary,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -5,6 +5,7 @@ import 'package:oncare/design_system/atoms/app_card.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/design_system/tokens/radius.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/ai_coach/presentation/widgets/coach_chat_card.dart';
 import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
 
 /// The Home tab body — five stacked cards matching the React original
@@ -39,11 +40,10 @@ class DashboardContent extends StatelessWidget {
         onBloodPressure: onQuickInputBloodPressure,
         onBloodSugar: onQuickInputBloodSugar,
       ),
-      if (summary.sodiumWarning != null || summary.exerciseFeedback != null)
-        _DailyFeedbackCard(
-          dietLine: summary.sodiumWarning,
-          exerciseLine: summary.exerciseFeedback,
-        ),
+      CoachChatCard(
+        dietLine: summary.sodiumWarning,
+        exerciseLine: summary.exerciseFeedback,
+      ),
       _HealthSummaryCard(summary: summary),
       _ScheduleCard(items: summary.todaySchedule, onOpenAll: onOpenSchedule),
       _WeekScoreCard(score: summary.weekScore, delta: summary.weekScoreDelta),
@@ -146,70 +146,6 @@ class _QuickInputCard extends StatelessWidget {
                 ),
               ),
             ],
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Combined daily-feedback card — sits between 오늘의 건강 기록 and
-/// 오늘의 건강 요약. White surface with the design-system gray
-/// border, robot avatar on the left, and one bullet per available
-/// feedback line (diet / exercise).
-class _DailyFeedbackCard extends StatelessWidget {
-  const _DailyFeedbackCard({this.dietLine, this.exerciseLine});
-
-  final String? dietLine;
-  final String? exerciseLine;
-
-  String _withEmoji(String text, String emoji) {
-    final t = text.trimRight();
-    return t.endsWith(emoji) ? t : '$t $emoji';
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final lines = <({String text, String emoji})>[
-      if (dietLine != null) (text: dietLine!, emoji: '🥗'),
-      if (exerciseLine != null) (text: exerciseLine!, emoji: '🚶'),
-    ];
-
-    return AppCard(
-      outlined: true,
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Container(
-            width: 36,
-            height: 36,
-            decoration: BoxDecoration(
-              color: AppColors.primary.withValues(alpha: 0.18),
-              borderRadius: const BorderRadius.all(AppRadius.lg),
-            ),
-            alignment: Alignment.center,
-            child: const Icon(
-              Icons.smart_toy_outlined,
-              color: AppColors.primary,
-              size: 20,
-            ),
-          ),
-          const SizedBox(width: AppSpacing.md),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                for (int i = 0; i < lines.length; i++) ...<Widget>[
-                  Text(
-                    _withEmoji(lines[i].text, lines[i].emoji),
-                    style: theme.textTheme.bodyMedium,
-                  ),
-                  if (i < lines.length - 1)
-                    const SizedBox(height: AppSpacing.sm),
-                ],
-              ],
-            ),
           ),
         ],
       ),

--- a/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
@@ -76,4 +76,24 @@ void main() {
     expect(res.data!['status'], 'ok');
     expect(res.data!['backend'], 'drift-local');
   });
+
+  test('POST /ai-coach/chat returns a grounded reply with sources', () async {
+    final res = await dio.post<Map<String, Object?>>(
+      '/ai-coach/chat',
+      data: <String, Object?>{'message': '나트륨을 줄이려면 어떻게 해요?'},
+    );
+    expect(res.statusCode, 200);
+    expect(res.data!['reply'], isNotEmpty);
+    final sources = (res.data!['sources']! as List<Object?>).cast<String>();
+    expect(sources, contains('나트륨 줄이기'));
+  });
+
+  test('POST /ai-coach/chat rejects an empty message', () async {
+    final res = await dio.post<Map<String, Object?>>(
+      '/ai-coach/chat',
+      data: <String, Object?>{'message': '   '},
+      options: Options(validateStatus: (int? s) => true),
+    );
+    expect(res.statusCode, 400);
+  });
 }

--- a/frontend/flutter/test/features/ai_coach/chat_controller_test.dart
+++ b/frontend/flutter/test/features/ai_coach/chat_controller_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/ai_coach/domain/entities/ai_coach_state.dart';
+import 'package:oncare/features/ai_coach/domain/entities/chat_message.dart';
+import 'package:oncare/features/ai_coach/domain/repositories/ai_coach_repository.dart';
+import 'package:oncare/features/ai_coach/presentation/controllers/ai_coach_controller.dart';
+import 'package:oncare/features/ai_coach/presentation/controllers/chat_controller.dart';
+
+class _FakeCoachRepo implements AiCoachRepository {
+  @override
+  Future<AiCoachState> fetchState() async =>
+      const AiCoachState(greeting: '', suggestions: <AiSuggestion>[]);
+
+  @override
+  Future<ChatMessage> sendMessage({
+    required String message,
+    required List<ChatMessage> history,
+  }) async => const ChatMessage(
+    role: ChatRole.coach,
+    content: '저염 식단이 도움이 됩니다.',
+    sources: <String>['나트륨 줄이기'],
+  );
+}
+
+void main() {
+  test('starts with a single welcome message from the coach', () {
+    final container = ProviderContainer(
+      overrides: <Override>[
+        aiCoachRepositoryProvider.overrideWithValue(_FakeCoachRepo()),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final state = container.read(chatControllerProvider);
+    expect(state.messages.length, 1);
+    expect(state.messages.single.role, ChatRole.coach);
+    expect(state.sending, isFalse);
+  });
+
+  test('send() appends the user message and the coach reply', () async {
+    final container = ProviderContainer(
+      overrides: <Override>[
+        aiCoachRepositoryProvider.overrideWithValue(_FakeCoachRepo()),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(chatControllerProvider.notifier).send('나트륨 줄이는 법');
+
+    final state = container.read(chatControllerProvider);
+    expect(state.sending, isFalse);
+    expect(
+      state.messages.any((ChatMessage m) => m.isUser && m.content == '나트륨 줄이는 법'),
+      isTrue,
+    );
+    expect(state.messages.last.role, ChatRole.coach);
+    expect(state.messages.last.content, contains('저염'));
+    expect(state.messages.last.sources, contains('나트륨 줄이기'));
+    // 진행 중 표시(pending)는 응답 후 남아있지 않아야 한다.
+    expect(state.messages.any((ChatMessage m) => m.pending), isFalse);
+  });
+}


### PR DESCRIPTION
Closes #110

## 개요
홈 화면의 **정적** 온이 코치를 대화형 챗봇 **UI**로 전환. 백엔드 챗 API PR 위에 스택(base: `feature/chatbot-api`).

## 변경 (프론트)
- 홈 `CoachChatCard`(온이 아바타·데일리 노트·입력 바·시작 칩) → 풀 `CoachChatPage`(말풍선·타이핑 인디케이터·근거 칩·그라데이션 전송).
- `ChatMessage` 엔티티 + `AiCoachRepository.sendMessage`(dio POST) + `ChatController`(StateNotifier).
- `LocalApiInterceptor` 키워드 기반 목 핸들러 → 웹 데모(목 모드)에서 서버 없이 대화.

## 디자인
primary→secondary 그라데이션(아바타·유저 말풍선·전송)·accent 코치 말풍선·AppCard 재사용, 주변 카드와 조화.

## 검증
`flutter analyze` 무경고, 프론트 테스트(인터셉터 챗 2 + 챗 컨트롤러 2, 기존 23개 회귀 없음).