### PR TITLE
feat(auth): 관리자 권한 격리 (공공문서 업로드 보호)

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -90,6 +90,17 @@ def require_auth(
     return user
 
 
+def require_admin(
+    user: Annotated[User, Depends(require_auth)],
+) -> User:
+    """관리자 전용: 유효 토큰 + is_admin. 아니면 403(미인증은 require_auth 가 401)."""
+    if not user.is_admin:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="관리자 권한이 필요합니다.")
+    return user
+
+
 CurrentUser = Annotated[User, Depends(get_current_user)]
 # 엄격 인증(쓰기/삭제 등 보호 엔드포인트용) — 데모 폴백 없음
 RequireUser = Annotated[User, Depends(require_auth)]
+# 관리자 전용(공공문서 업로드 등)
+RequireAdmin = Annotated[User, Depends(require_admin)]

--- a/backend/app/api/v1/coach_docs.py
+++ b/backend/app/api/v1/coach_docs.py
@@ -17,7 +17,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from app.api.deps import CurrentUser
+from app.api.deps import RequireAdmin
 from app.db.session import get_db
 from app.services.coach.rag import ingest_document
 
@@ -34,7 +34,7 @@ class PublicDocIn(BaseModel):
 @router.post("/coach/documents/public", status_code=201)
 def upload_public_doc(
     payload: PublicDocIn,
-    current_user: CurrentUser,  # 데모: 인증만. 운영선 관리자 권한 체크 필요
+    admin: RequireAdmin,  # 관리자 전용(비관리자 403, 미인증 401)
     db: Annotated[Session, Depends(get_db)],
 ) -> dict:
     if not payload.content.strip():

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -62,6 +62,12 @@ class Settings(BaseSettings):
     # --- 기타 ---
     cors_allow_origins: str = "*"
     seed_demo_data: bool = True
+    # 관리자 이메일(콤마구분) — 기동 시 해당 사용자를 is_admin=True 로 승격
+    admin_emails: str = ""
+
+    @property
+    def admin_email_set(self) -> set[str]:
+        return {e.strip().lower() for e in self.admin_emails.split(",") if e.strip()}
 
     @property
     def is_prod(self) -> bool:

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -39,6 +39,8 @@ def init_db() -> None:
         _seed_demo_places()
         _seed_demo_notifications()
 
+    _promote_admins()  # ADMIN_EMAILS 사용자를 관리자로 승격(멱등)
+
 
 def _seed_demo_user() -> None:
     db: Session = SessionLocal()
@@ -52,6 +54,29 @@ def _seed_demo_user() -> None:
                 hashed_password="",  # 데모용. 로그인은 Stage 4.
             )
             db.add(user)
+            db.commit()
+    finally:
+        db.close()
+
+
+def _promote_admins() -> None:
+    """ADMIN_EMAILS(콤마구분)에 있는 사용자를 관리자로 승격(멱등)."""
+    from sqlalchemy import func
+
+    emails = get_settings().admin_email_set
+    if not emails:
+        return
+    db: Session = SessionLocal()
+    try:
+        users = db.scalars(
+            select(models.User).where(func.lower(models.User.email).in_(emails))
+        ).all()
+        changed = False
+        for u in users:
+            if not u.is_admin:
+                u.is_admin = True
+                changed = True
+        if changed:
             db.commit()
     finally:
         db.close()

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -35,6 +35,8 @@ class User(Base):
     name: Mapped[str] = mapped_column(String(100), default="")
     hashed_password: Mapped[str] = mapped_column(String(255), default="")
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    # 관리자 권한(공공문서 업로드 등 민감 엔드포인트 접근). 기본 False.
+    is_admin: Mapped[bool] = mapped_column(Boolean, default=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     health_profile: Mapped["HealthProfile | None"] = relationship(

--- a/backend/migrations/versions/0005_user_is_admin.py
+++ b/backend/migrations/versions/0005_user_is_admin.py
@@ -1,0 +1,31 @@
+"""users.is_admin (관리자 권한)
+
+민감 엔드포인트(공공문서 업로드 등)를 관리자 전용으로 보호하기 위한 플래그.
+기존 행 보존을 위한 추가형(additive) 마이그레이션.
+
+Revision ID: 0005_user_is_admin
+Revises: 0004_food_nutrients
+Create Date: 2026-07-04
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0005_user_is_admin"
+down_revision: str | Sequence[str] | None = "0004_food_nutrients"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("is_admin", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "is_admin")

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -1,0 +1,63 @@
+"""관리자 권한 — 공공문서 업로드 보호.
+
+- admin_email_set 파싱은 순수(로컬 실행).
+- 엔드포인트 보호(201/403/401)는 DB 필요(로컬 skip, CI 실행).
+"""
+from __future__ import annotations
+
+from uuid import uuid4
+
+
+def test_admin_email_set_parsing():
+    from app.core.config import Settings
+
+    s = Settings(_env_file=None, admin_emails="A@x.com, b@Y.com ,")
+    assert s.admin_email_set == {"a@x.com", "b@y.com"}
+
+
+def _register_login(client, email: str) -> str:
+    client.post("/v1/auth/register", json={"email": email, "password": "pw!", "name": "u"})
+    return client.post("/v1/auth/login", data={"username": email, "password": "pw!"}).json()["access_token"]
+
+
+def test_admin_can_upload_public_doc(client, db_session):
+    from sqlalchemy import select
+
+    from app.models.models import User
+
+    email = f"admin-{uuid4().hex[:8]}@oncare.com"
+    token = _register_login(client, email)
+
+    # 관리자로 승격(운영에선 ADMIN_EMAILS 로 부팅 시 승격)
+    user = db_session.scalar(select(User).where(User.email == email))
+    user.is_admin = True
+    db_session.commit()
+
+    r = client.post(
+        "/v1/coach/documents/public",
+        json={
+            "content": "물을 충분히 마시면 혈압 관리에 도움이 됩니다. 하루 6잔 이상을 권장합니다.",
+            "domain": "general",
+            "title": "수분 섭취 팁",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["ingested_chunks"] >= 1
+
+
+def test_non_admin_is_forbidden(client):
+    email = f"user-{uuid4().hex[:8]}@oncare.com"
+    token = _register_login(client, email)
+    r = client.post(
+        "/v1/coach/documents/public",
+        json={"content": "test", "title": "t"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 403
+
+
+def test_unauthenticated_is_rejected(client):
+    # require_admin 은 데모 폴백을 쓰지 않으므로 토큰 없으면 401
+    r = client.post("/v1/coach/documents/public", json={"content": "test", "title": "t"})
+    assert r.status_code == 401


### PR DESCRIPTION
Closes #114

## 개요
Phase 3 보안 하드닝 1차 — **관리자 권한 격리**. 챗봇 UI PR #111 위에 스택(base: `feature/coach-chatbot`). `main` 미반영.

## 문제
`POST /coach/documents/public`이 인증만 하면 누구나 호출 가능 → 임의 사용자가 공용 RAG 문서를 주입할 수 있는 권한 취약점.

## 변경 (커밋 순서)
1. **feat: is_admin + 마이그레이션 0005 + 부트스트랩** — `users.is_admin`(default false, 추가형) + `ADMIN_EMAILS` 기동 승격(멱등).
2. **feat: require_admin + 엔드포인트 보호** — 유효 토큰 + is_admin 요구하는 `require_admin`(데모 폴백 없음)으로 공공문서 업로드 게이팅(비관리자 403, 미인증 401).
3. **test: 관리자 권한 테스트** — 파싱(순수) + 201/403/401(DB).

## 검증
- 로컬 순수 유닛 통과(ADMIN_EMAILS 파싱). 마이그레이션 0005 + 권한 DB 테스트(201/403/401)는 **Backend CI**(Postgres/pgvector)에서 실행.
- 하위호환: 컬럼 추가형, 기존 엔드포인트 계약 불변(공공문서 업로드만 권한 상향).

## 다음(Phase 3)
- 인증 엔드포인트 rate limit, 감사 로그, 운영 배포 설정.