### PR TITLE
chore(backend): 미사용 import 정리 (정적 분석 스윕)

### DIFF
--- a/backend/app/api/v1/dashboard.py
+++ b/backend/app/api/v1/dashboard.py
@@ -8,7 +8,6 @@
 """
 from __future__ import annotations
 
-import json
 from datetime import datetime
 from typing import Annotated
 

--- a/backend/app/api/v1/diet.py
+++ b/backend/app/api/v1/diet.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile

--- a/backend/app/api/v1/notifications.py
+++ b/backend/app/api/v1/notifications.py
@@ -6,7 +6,6 @@
 """
 from __future__ import annotations
 
-import uuid
 from datetime import datetime, timezone
 from typing import Annotated
 

--- a/backend/app/services/coach/rag.py
+++ b/backend/app/services/coach/rag.py
@@ -11,9 +11,7 @@ STEP 8 챗봇도 retrieve_context() 를 그대로 재사용합니다.
 """
 from __future__ import annotations
 
-import json
 
-from pgvector.sqlalchemy import Vector
 from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 


### PR DESCRIPTION
Closes #116

## 개요
코드베이스 죽은 코드 정적 분석 스윕 + 정리. 요청대로 기능 작업과 **분리된 PR**. 보안 PR #115 위에 스택(base: `feature/backend-security`).

## 스윕
- 백엔드 `ruff`(F401/F811/F841) + `vulture`(app), 프론트 `flutter analyze lib`.
- **발견**: 미사용 import 5건만. 죽은 함수/클래스/파일 없음(vulture의 라우트·모델 지적은 FastAPI/pydantic 오탐). 프론트 클린.

## 변경 (import 제거만, 로직 불변)
- `dashboard.py` json · `diet.py` datetime.timezone · `notifications.py` uuid · `rag.py` json·pgvector.Vector

## 검증
- `ruff check` 무오류(재검사), 순수 유닛 테스트 회귀 없음. (import만 제거 — CI 영향 없음)