### PR TITLE
feat(auth): 인증 rate limit (브루트포스 방어)

### DIFF
--- a/backend/app/api/v1/social.py
+++ b/backend/app/api/v1/social.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core.rate_limit import rate_limit
 from app.core.security import create_access_token, create_refresh_token
 from app.db.session import get_db
 from app.models.models import SocialAccount, User
@@ -59,7 +60,11 @@ def _find_or_create_user(db: Session, identity: SocialIdentity) -> User:
     return user
 
 
-@router.post("/auth/social/{provider}", response_model=Token)
+@router.post(
+    "/auth/social/{provider}",
+    response_model=Token,
+    dependencies=[Depends(rate_limit("auth-social"))],
+)
 async def social_login(
     provider: str,
     payload: SocialLoginRequest,

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -20,6 +20,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.deps import CurrentUser, RequireUser
+from app.core.rate_limit import rate_limit
 from app.core.security import (
     create_access_token, create_refresh_token, decode_refresh_token,
     hash_password, verify_password,
@@ -194,7 +195,12 @@ def delete_me(
 
 # ---- 인증 (Stage 4 대비, 지금도 동작) ----
 
-@router.post("/auth/register", response_model=UserMe, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/auth/register",
+    response_model=UserMe,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(rate_limit("auth-register"))],
+)
 def register(payload: UserRegister, db: Annotated[Session, Depends(get_db)]) -> UserMe:
     exists = db.scalar(select(User).where(User.email == payload.email))
     if exists:
@@ -211,7 +217,11 @@ def register(payload: UserRegister, db: Annotated[Session, Depends(get_db)]) -> 
     return UserMe(id=user.id, name=user.name, email=user.email)
 
 
-@router.post("/auth/login", response_model=Token)
+@router.post(
+    "/auth/login",
+    response_model=Token,
+    dependencies=[Depends(rate_limit("auth-login"))],
+)
 def login(
     form: Annotated[OAuth2PasswordRequestForm, Depends()],
     db: Annotated[Session, Depends(get_db)],
@@ -225,7 +235,11 @@ def login(
     )
 
 
-@router.post("/auth/refresh", response_model=Token)
+@router.post(
+    "/auth/refresh",
+    response_model=Token,
+    dependencies=[Depends(rate_limit("auth-refresh"))],
+)
 def refresh(payload: RefreshRequest, db: Annotated[Session, Depends(get_db)]) -> Token:
     """refresh 토큰으로 새 access(+refresh) 토큰 발급(회전)."""
     invalid = HTTPException(status_code=401, detail="유효하지 않은 refresh 토큰입니다.")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -65,6 +65,10 @@ class Settings(BaseSettings):
     # 관리자 이메일(콤마구분) — 기동 시 해당 사용자를 is_admin=True 로 승격
     admin_emails: str = ""
 
+    # --- Rate limit (인증 엔드포인트 브루트포스 방어) ---
+    rate_limit_enabled: bool = True
+    rate_limit_auth_per_minute: int = 10  # IP·엔드포인트당 분당 시도 한도
+
     @property
     def admin_email_set(self) -> set[str]:
         return {e.strip().lower() for e in self.admin_emails.split(",") if e.strip()}

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -1,0 +1,56 @@
+"""간단한 인메모리 rate limiter (브루트포스 방어).
+
+인증 엔드포인트(로그인/회원가입/refresh/소셜)에 IP·엔드포인트별 슬라이딩 윈도우로
+분당 시도 횟수를 제한한다. 단일 인스턴스/데모에 충분하며, 다중 인스턴스 운영에서는
+Redis 백엔드로 교체(같은 check() 인터페이스 유지)하면 된다.
+
+RATE_LIMIT_ENABLED=false 로 끌 수 있고, RATE_LIMIT_AUTH_PER_MINUTE 로 한도를 조정한다.
+"""
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+
+from fastapi import HTTPException, Request, status
+
+from app.core.config import get_settings
+
+
+class RateLimiter:
+    def __init__(self) -> None:
+        self._hits: dict[str, deque[float]] = defaultdict(deque)
+
+    def clear(self) -> None:
+        """상태 초기화(테스트 격리용)."""
+        self._hits.clear()
+
+    def check(self, key: str, limit: int, window: float) -> None:
+        """key 에 대해 window(초) 동안 limit 회 초과 시 429."""
+        now = time.monotonic()
+        dq = self._hits[key]
+        cutoff = now - window
+        while dq and dq[0] <= cutoff:
+            dq.popleft()
+        if len(dq) >= limit:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.",
+                headers={"Retry-After": str(int(window))},
+            )
+        dq.append(now)
+
+
+limiter = RateLimiter()
+
+
+def rate_limit(bucket: str):
+    """엔드포인트에 붙일 의존성 팩토리. bucket 은 엔드포인트 구분자."""
+
+    def _dep(request: Request) -> None:
+        settings = get_settings()
+        if not settings.rate_limit_enabled:
+            return
+        ip = request.client.host if request.client else "unknown"
+        limiter.check(f"{bucket}:{ip}", settings.rate_limit_auth_per_minute, 60.0)
+
+    return _dep

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -40,6 +40,18 @@ def client():
         yield c
 
 
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter():
+    """각 테스트 전 rate limiter 상태 초기화(테스트 간 누적 방지).
+    fastapi 미설치 로컬 환경에서는 조용히 건너뛴다(순수 테스트에 무영향)."""
+    try:
+        from app.core.rate_limit import limiter
+        limiter.clear()
+    except Exception:  # noqa: BLE001
+        pass
+    yield
+
+
 @pytest.fixture
 def db_session(client):
     """시드까지 끝난 DB 세션. client 픽스처가 먼저 init_db(시드)를 돌린다."""

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,38 @@
+"""인증 엔드포인트 rate limit.
+
+fastapi 가 필요하므로 로컬(venv, fastapi 미설치)에서는 이 모듈을 통째로 skip 하고,
+CI(전체 의존성)에서 실행한다. 엔드포인트 테스트는 추가로 DB(client)가 필요하다.
+"""
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+
+def test_rate_limiter_unit_blocks_over_limit():
+    from fastapi import HTTPException
+
+    from app.core.rate_limit import RateLimiter
+
+    rl = RateLimiter()
+    for _ in range(3):
+        rl.check("k", 3, 60.0)  # 3회 허용
+    with pytest.raises(HTTPException):
+        rl.check("k", 3, 60.0)  # 4회째 429
+    rl.clear()
+    rl.check("k", 3, 60.0)  # clear 후 다시 허용
+
+
+def test_register_is_rate_limited(client):
+    # 기본 한도 10/분 → 11번째 요청은 429 (per-test 로 limiter 초기화됨)
+    last = None
+    for _ in range(11):
+        last = client.post(
+            "/v1/auth/register",
+            json={"email": f"rl-{uuid4().hex[:10]}@oncare.com", "password": "pw!", "name": "u"},
+        )
+    assert last.status_code == 429, last.text
+    assert "Retry-After" in last.headers


### PR DESCRIPTION
Closes #118

## 개요
Phase 3 보안 하드닝 2차 — 인증 엔드포인트 **rate limit**(브루트포스 방어). 정리 PR #117 위에 스택(base: `feature/backend-cleanup`). `main` 미반영.

## 변경 (커밋 순서)
1. **feat: 인메모리 rate limiter + 설정** — IP·엔드포인트별 슬라이딩 윈도우 `RateLimiter` + `rate_limit()` 의존성 + `RATE_LIMIT_ENABLED`/`RATE_LIMIT_AUTH_PER_MINUTE`(기본 10/분).
2. **feat: 엔드포인트 적용** — register/login/refresh/social 에 적용(초과 시 **429 + Retry-After**). 버킷 분리.
3. **test: 테스트 + 격리 픽스처** — 유닛(초과 429) + 엔드포인트(11번째 429). autouse 픽스처로 테스트 간 카운터 격리(지연 import → 로컬 순수테스트 무영향).

## 검증
- 로컬: 슬라이딩 윈도우 로직 검증, 순수 유닛 회귀 없음. rate limit DB 테스트는 **Backend CI** 실행.
- 하위호환: 기존 인증 응답 계약 불변(초과 시에만 429). `RATE_LIMIT_ENABLED=false` 로 비활성 가능.

## 참고
- 단일 인스턴스/데모 범위의 인메모리 구현 — 다중 인스턴스 운영은 동일 `check()` 인터페이스로 Redis 교체.

## 다음(Phase 3)
- 감사 로그, 운영 배포 설정(HTTPS/시크릿/CORS 조임).