### PR TITLE
feat(auth): 보안 감사 로그 (인증·관리자 이벤트)

### DIFF
--- a/backend/app/api/v1/coach_docs.py
+++ b/backend/app/api/v1/coach_docs.py
@@ -13,12 +13,13 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.api.deps import RequireAdmin
 from app.db.session import get_db
+from app.services.audit import client_ip, record as audit
 from app.services.coach.rag import ingest_document
 
 router = APIRouter(tags=["coach-docs"])
@@ -35,6 +36,7 @@ class PublicDocIn(BaseModel):
 def upload_public_doc(
     payload: PublicDocIn,
     admin: RequireAdmin,  # 관리자 전용(비관리자 403, 미인증 401)
+    request: Request,
     db: Annotated[Session, Depends(get_db)],
 ) -> dict:
     if not payload.content.strip():
@@ -49,4 +51,8 @@ def upload_public_doc(
         raise HTTPException(status_code=503, detail=f"임베딩 불가: {e}")
     except Exception as e:  # noqa: BLE001
         raise HTTPException(status_code=502, detail=f"적재 실패: {e}")
+    audit(
+        db, event="admin.public_doc_upload", user_id=admin.id,
+        ip=client_ip(request), success=True, detail=f"{payload.domain}:{payload.title}",
+    )
     return {"ingested_chunks": n, "domain": payload.domain, "title": payload.title}

--- a/backend/app/api/v1/social.py
+++ b/backend/app/api/v1/social.py
@@ -10,13 +10,14 @@ from __future__ import annotations
 import uuid
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.rate_limit import rate_limit
 from app.core.security import create_access_token, create_refresh_token
 from app.db.session import get_db
+from app.services.audit import client_ip, record as audit
 from app.models.models import SocialAccount, User
 from app.schemas.user import SocialLoginRequest, Token
 from app.services.social.base import SocialAuthError, SocialIdentity
@@ -68,6 +69,7 @@ def _find_or_create_user(db: Session, identity: SocialIdentity) -> User:
 async def social_login(
     provider: str,
     payload: SocialLoginRequest,
+    request: Request,
     db: Annotated[Session, Depends(get_db)],
 ) -> Token:
     try:
@@ -80,9 +82,11 @@ async def social_login(
     except NotImplementedError:
         raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="아직 지원하지 않는 소셜 로그인입니다.")
     except SocialAuthError:
+        audit(db, event="auth.social", ip=client_ip(request), success=False, detail=provider)
         raise HTTPException(status_code=401, detail="소셜 인증에 실패했습니다.")
 
     user = _find_or_create_user(db, identity)
+    audit(db, event="auth.social", user_id=user.id, ip=client_ip(request), success=True, detail=provider)
     return Token(
         access_token=create_access_token(user.id),
         refresh_token=create_refresh_token(user.id),

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -14,13 +14,14 @@ import uuid
 from typing import Annotated
 
 import jwt
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.deps import CurrentUser, RequireUser
 from app.core.rate_limit import rate_limit
+from app.services.audit import client_ip, record as audit
 from app.core.security import (
     create_access_token, create_refresh_token, decode_refresh_token,
     hash_password, verify_password,
@@ -201,9 +202,14 @@ def delete_me(
     status_code=status.HTTP_201_CREATED,
     dependencies=[Depends(rate_limit("auth-register"))],
 )
-def register(payload: UserRegister, db: Annotated[Session, Depends(get_db)]) -> UserMe:
+def register(
+    request: Request,
+    payload: UserRegister,
+    db: Annotated[Session, Depends(get_db)],
+) -> UserMe:
     exists = db.scalar(select(User).where(User.email == payload.email))
     if exists:
+        audit(db, event="auth.register", ip=client_ip(request), success=False, detail=payload.email)
         raise HTTPException(status_code=409, detail="이미 가입된 이메일입니다.")
     user = User(
         id=f"user-{uuid.uuid4().hex[:12]}",
@@ -214,6 +220,7 @@ def register(payload: UserRegister, db: Annotated[Session, Depends(get_db)]) -> 
     db.add(user)
     db.commit()
     db.refresh(user)
+    audit(db, event="auth.register", user_id=user.id, ip=client_ip(request), success=True)
     return UserMe(id=user.id, name=user.name, email=user.email)
 
 
@@ -223,12 +230,15 @@ def register(payload: UserRegister, db: Annotated[Session, Depends(get_db)]) -> 
     dependencies=[Depends(rate_limit("auth-login"))],
 )
 def login(
+    request: Request,
     form: Annotated[OAuth2PasswordRequestForm, Depends()],
     db: Annotated[Session, Depends(get_db)],
 ) -> Token:
     user = db.scalar(select(User).where(User.email == form.username))
     if not user or not verify_password(form.password, user.hashed_password):
+        audit(db, event="auth.login", ip=client_ip(request), success=False, detail=form.username)
         raise HTTPException(status_code=401, detail="이메일 또는 비밀번호가 올바르지 않습니다.")
+    audit(db, event="auth.login", user_id=user.id, ip=client_ip(request), success=True)
     return Token(
         access_token=create_access_token(user.id),
         refresh_token=create_refresh_token(user.id),

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -232,3 +232,20 @@ class Place(Base):
     lat: Mapped[float | None] = mapped_column(Float, nullable=True)
     lng: Mapped[float | None] = mapped_column(Float, nullable=True)
     kakao_place_id: Mapped[str] = mapped_column(String(50), default="")
+
+
+class AuditLog(Base):
+    """보안 감사 로그 — 인증/관리자 이벤트 추적.
+
+    user_id 는 FK 를 두지 않는다(사용자가 삭제돼도 감사 기록은 남아야 하므로).
+    event 예: auth.login, auth.register, auth.social, admin.public_doc_upload.
+    """
+    __tablename__ = "audit_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    event: Mapped[str] = mapped_column(String(50), index=True)
+    user_id: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
+    ip: Mapped[str] = mapped_column(String(64), default="")
+    success: Mapped[bool] = mapped_column(Boolean, default=True)
+    detail: Mapped[str] = mapped_column(Text, default="")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/services/audit.py
+++ b/backend/app/services/audit.py
@@ -1,0 +1,40 @@
+"""보안 감사 로그 기록 (best-effort).
+
+인증/관리자 이벤트를 audit_logs 에 남긴다. 감사 기록 실패가 요청을 깨뜨리면 안 되므로
+best-effort(실패 시 rollback 후 무시)로 처리한다.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import Request
+from sqlalchemy.orm import Session
+
+from app.models.models import AuditLog
+
+log = logging.getLogger(__name__)
+
+
+def client_ip(request: Request) -> str:
+    """클라이언트 IP. 프록시 뒤면 X-Forwarded-For 첫 IP 사용."""
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        return xff.split(",")[0].strip()[:64]
+    return (request.client.host if request.client else "")[:64]
+
+
+def record(
+    db: Session, *, event: str, user_id: str | None = None,
+    ip: str = "", success: bool = True, detail: str = "",
+) -> None:
+    try:
+        db.add(AuditLog(
+            event=event, user_id=user_id, ip=ip, success=success, detail=detail[:2000],
+        ))
+        db.commit()
+    except Exception as e:  # noqa: BLE001 — 감사 실패가 요청을 깨면 안 됨
+        log.warning("감사 로그 기록 실패(무시): %s", e)
+        try:
+            db.rollback()
+        except Exception:  # noqa: BLE001
+            pass

--- a/backend/migrations/versions/0006_audit_logs.py
+++ b/backend/migrations/versions/0006_audit_logs.py
@@ -1,0 +1,41 @@
+"""audit_logs table (보안 감사 로그)
+
+인증(로그인 성공/실패·가입·소셜)·관리자 액션을 추적하기 위한 감사 테이블.
+
+Revision ID: 0006_audit_logs
+Revises: 0005_user_is_admin
+Create Date: 2026-07-04
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0006_audit_logs"
+down_revision: str | Sequence[str] | None = "0005_user_is_admin"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "audit_logs",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("event", sa.String(50), nullable=False),
+        # FK 없음: 사용자가 삭제돼도 감사 기록은 남는다
+        sa.Column("user_id", sa.String(64), nullable=True),
+        sa.Column("ip", sa.String(64), nullable=False, server_default=""),
+        sa.Column("success", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("detail", sa.Text(), nullable=False, server_default=""),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+    )
+    op.create_index("ix_audit_logs_event", "audit_logs", ["event"])
+    op.create_index("ix_audit_logs_user_id", "audit_logs", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_audit_logs_user_id", table_name="audit_logs")
+    op.drop_index("ix_audit_logs_event", table_name="audit_logs")
+    op.drop_table("audit_logs")

--- a/backend/tests/test_audit.py
+++ b/backend/tests/test_audit.py
@@ -1,0 +1,76 @@
+"""보안 감사 로그 — DB 필요(로컬 skip, CI 실행)."""
+from __future__ import annotations
+
+from uuid import uuid4
+
+
+def test_login_and_register_events_are_audited(client, db_session):
+    from sqlalchemy import select
+
+    from app.models.models import AuditLog
+
+    email = f"aud-{uuid4().hex[:8]}@oncare.com"
+    reg = client.post("/v1/auth/register", json={"email": email, "password": "pw!", "name": "u"})
+    uid = reg.json()["id"]
+
+    client.post("/v1/auth/login", data={"username": email, "password": "wrong-pw"})  # 실패
+    client.post("/v1/auth/login", data={"username": email, "password": "pw!"})        # 성공
+
+    db_session.expire_all()
+
+    # 가입 감사
+    regs = db_session.scalars(
+        select(AuditLog).where(AuditLog.event == "auth.register", AuditLog.user_id == uid)
+    ).all()
+    assert len(regs) >= 1
+
+    # 로그인 실패 감사(detail=시도 이메일, success=False)
+    fails = db_session.scalars(
+        select(AuditLog).where(
+            AuditLog.event == "auth.login",
+            AuditLog.success.is_(False),
+            AuditLog.detail == email,
+        )
+    ).all()
+    assert len(fails) >= 1
+
+    # 로그인 성공 감사(user_id 기록, success=True)
+    oks = db_session.scalars(
+        select(AuditLog).where(
+            AuditLog.event == "auth.login",
+            AuditLog.success.is_(True),
+            AuditLog.user_id == uid,
+        )
+    ).all()
+    assert len(oks) >= 1
+
+
+def test_admin_upload_is_audited(client, db_session):
+    from sqlalchemy import select
+
+    from app.models.models import AuditLog, User
+
+    email = f"aud-admin-{uuid4().hex[:8]}@oncare.com"
+    client.post("/v1/auth/register", json={"email": email, "password": "pw!", "name": "a"})
+    user = db_session.scalar(select(User).where(User.email == email))
+    user.is_admin = True
+    db_session.commit()
+    token = client.post("/v1/auth/login", data={"username": email, "password": "pw!"}).json()["access_token"]
+
+    client.post(
+        "/v1/coach/documents/public",
+        json={
+            "content": "충분한 수면은 혈압 관리에 도움이 됩니다. 하루 7시간 이상을 권장합니다.",
+            "title": "수면 팁",
+            "domain": "general",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    db_session.expire_all()
+    rows = db_session.scalars(
+        select(AuditLog).where(
+            AuditLog.event == "admin.public_doc_upload", AuditLog.user_id == user.id
+        )
+    ).all()
+    assert len(rows) >= 1


### PR DESCRIPTION
Closes #120

## 개요
Phase 3 보안 하드닝 3차 — **보안 감사 로그**. rate limit PR #119 위에 스택(base: `feature/backend-ratelimit`). `main` 미반영.

## 변경 (커밋 순서)
1. **feat: AuditLog 모델 + 마이그레이션 0006** — `audit_logs`(event·user_id·ip·success·detail·created_at). user_id **FK 없음** → 사용자 삭제돼도 감사 기록 보존.
2. **feat: 감사 서비스 + 이벤트 기록** — best-effort `audit.record()`(감사 실패가 요청 안 깨짐) + X-Forwarded-For IP. 기록: `auth.login`(성공/실패), `auth.register`, `auth.social`(성공/실패), `admin.public_doc_upload`.
3. **test: 감사 로그 테스트** — 로그인 성공/실패·가입·관리자 업로드가 정확히 기록되는지 DB 검증.

## 검증
- 로컬 순수 유닛 회귀 없음, ruff 클린. 마이그레이션 0006 + 감사 DB 테스트는 **Backend CI**(Postgres/pgvector) 실행.
- 하위호환: 응답 계약 불변(부수효과로 감사 행만 추가). 실패한 로그인 시도 이메일은 공격 탐지용으로 detail 에 저장.

## 다음(Phase 3)
- 운영 배포 하드닝(HTTPS 강제·CORS 조임·시크릿 점검) — Phase 3 마무리.