### PR TITLE
feat(deploy): 운영 배포 하드닝 (CORS·HTTPS·보안 헤더)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -60,10 +60,14 @@ class Settings(BaseSettings):
     rag_auto_ingest: bool = True
 
     # --- 기타 ---
-    cors_allow_origins: str = "*"
+    cors_allow_origins: str = "*"  # 콤마구분 허용 출처. 운영에서는 '*' 금지(명시 필요)
     seed_demo_data: bool = True
     # 관리자 이메일(콤마구분) — 기동 시 해당 사용자를 is_admin=True 로 승격
     admin_emails: str = ""
+
+    # --- 운영 배포 하드닝 ---
+    force_https: bool = False       # HTTP→HTTPS 리다이렉트(프록시 뒤면 X-Forwarded-Proto 신뢰)
+    security_headers: bool = True   # 보안 응답 헤더(HSTS·nosniff·frame deny 등)
 
     # --- Rate limit (인증 엔드포인트 브루트포스 방어) ---
     rate_limit_enabled: bool = True
@@ -72,6 +76,14 @@ class Settings(BaseSettings):
     @property
     def admin_email_set(self) -> set[str]:
         return {e.strip().lower() for e in self.admin_emails.split(",") if e.strip()}
+
+    @property
+    def cors_origin_list(self) -> list[str]:
+        return [o.strip() for o in self.cors_allow_origins.split(",") if o.strip()]
+
+    @property
+    def is_cors_wildcard(self) -> bool:
+        return "*" in self.cors_origin_list
 
     @property
     def is_prod(self) -> bool:
@@ -89,6 +101,10 @@ class Settings(BaseSettings):
             if not self.jwt_secret or self.jwt_secret == DEFAULT_JWT_SECRET:
                 raise ValueError(
                     "운영(env=prod)에서는 JWT_SECRET 을 안전한 값으로 반드시 설정해야 합니다."
+                )
+            if self.is_cors_wildcard:
+                raise ValueError(
+                    "운영(env=prod)에서는 CORS 허용 출처를 명시해야 합니다(와일드카드 '*' 금지)."
                 )
         return self
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.v1 import (
@@ -34,13 +34,37 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+# HTTPS 강제(운영). 프록시 뒤면 X-Forwarded-Proto 를 신뢰(uvicorn --proxy-headers).
+if settings.force_https:
+    from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware
+
+    app.add_middleware(HTTPSRedirectMiddleware)
+
+# CORS: 와일드카드('*')면 자격증명(쿠키) 불가 → allow_credentials=False.
+# 명시 출처면 자격증명 허용. (앱은 Bearer 토큰이라 와일드카드+무자격증명으로 충분.)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[o.strip() for o in settings.cors_allow_origins.split(",")],
-    allow_credentials=True,
+    allow_origins=settings.cors_origin_list,
+    allow_credentials=not settings.is_cors_wildcard,
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+# 보안 응답 헤더(운영/HTTPS 에서는 HSTS 포함).
+if settings.security_headers:
+
+    @app.middleware("http")
+    async def _security_headers(request: Request, call_next):
+        response = await call_next(request)
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault("Referrer-Policy", "no-referrer")
+        if settings.is_prod or settings.force_https:
+            response.headers.setdefault(
+                "Strict-Transport-Security", "max-age=63072000; includeSubDomains"
+            )
+        return response
 
 # /v1 prefix 로 마운트 (프론트 base URL 이 /v1 을 포함하는 계약)
 app.include_router(system.router, prefix=settings.api_v1_prefix)

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -22,7 +22,11 @@ def test_prod_blocks_default_secret():
 
 
 def test_prod_ok_with_real_secret():
-    s = Settings(_env_file=None, env="prod", jwt_secret="a-strong-random-secret-value")
+    s = Settings(
+        _env_file=None, env="prod",
+        jwt_secret="a-strong-random-secret-value",
+        cors_allow_origins="https://app.oncare.com",
+    )
     assert s.is_prod is True
 
 
@@ -30,7 +34,10 @@ def test_demo_fallback_gated_by_env():
     # 개발: 기본 허용
     assert Settings(_env_file=None).demo_fallback_enabled is True
     # 운영: 설정과 무관하게 비활성
-    prod = Settings(_env_file=None, env="prod", jwt_secret="strong", allow_demo_fallback=True)
+    prod = Settings(
+        _env_file=None, env="prod", jwt_secret="strong",
+        cors_allow_origins="https://app.oncare.com", allow_demo_fallback=True,
+    )
     assert prod.demo_fallback_enabled is False
     # 명시적으로 끄면 개발에서도 비활성
     assert Settings(_env_file=None, allow_demo_fallback=False).demo_fallback_enabled is False

--- a/backend/tests/test_hardening.py
+++ b/backend/tests/test_hardening.py
@@ -1,0 +1,39 @@
+"""운영 배포 하드닝 — CORS 가드/파싱(순수) + 보안 헤더(DB)."""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.core.config import Settings
+
+
+# ---------- 순수 ----------
+
+def test_prod_blocks_wildcard_cors():
+    """운영에서 CORS 와일드카드('*')면 기동이 막혀야 한다."""
+    with pytest.raises(ValidationError):
+        Settings(_env_file=None, env="prod", jwt_secret="strong", cors_allow_origins="*")
+
+
+def test_cors_origin_list_parsing():
+    s = Settings(_env_file=None, cors_allow_origins="https://a.com, https://b.com ,")
+    assert s.cors_origin_list == ["https://a.com", "https://b.com"]
+    assert s.is_cors_wildcard is False
+    assert Settings(_env_file=None, cors_allow_origins="*").is_cors_wildcard is True
+
+
+def test_wildcard_disables_credentials_semantics():
+    # 와일드카드면 credentials 를 켜지 않는다(main.py 가 이 규칙을 사용)
+    assert Settings(_env_file=None, cors_allow_origins="*").is_cors_wildcard is True
+
+
+# ---------- DB(CI) ----------
+
+def test_security_headers_present(client):
+    r = client.get("/v1/ping")
+    assert r.status_code == 200
+    assert r.headers.get("X-Content-Type-Options") == "nosniff"
+    assert r.headers.get("X-Frame-Options") == "DENY"
+    assert r.headers.get("Referrer-Policy") == "no-referrer"
+    # dev(비운영·force_https=false)에서는 HSTS 를 붙이지 않는다
+    assert "Strict-Transport-Security" not in r.headers


### PR DESCRIPTION
Closes #122

## 개요
Phase 3 **마무리** — 운영 배포 하드닝. 감사 로그 PR #121 위에 스택(base: `feature/backend-audit`). `main` 미반영.

## 변경 (커밋 순서)
1. **feat: CORS 파싱 + 프로덕션 가드 + 하드닝 설정** — CORS 출처 리스트 파싱 + `is_cors_wildcard`, 운영에서 와일드카드면 **fail-fast**(명시 출처 필수). `FORCE_HTTPS`/`SECURITY_HEADERS` 설정.
2. **feat: HTTPS·보안 헤더·CORS 자격증명 규칙** — opt-in `HTTPSRedirectMiddleware`, 보안 헤더 미들웨어(nosniff·frame DENY·referrer, 운영/https 에 HSTS), 와일드카드면 `allow_credentials=False`(사양상 무효 방지; 앱은 Bearer 토큰이라 안전).
3. **test: CORS 가드·파싱·보안 헤더** — prod 와일드카드 차단·파싱(순수) + /v1/ping 보안 헤더(DB). 기존 prod 설정 테스트에 명시 CORS 추가.

## 검증
- 로컬: prod 와일드카드 CORS 차단 확인, CORS 파싱, 순수 회귀 없음, ruff 클린. 보안 헤더 DB 테스트는 **Backend CI** 실행.
- 하위호환: dev 기본은 여전히 `*`(무자격증명)로 동작 → 기존 프론트(Bearer) 영향 없음. 운영만 명시 출처 요구.

## 운영 배포 체크리스트(이 PR 이 강제/지원)
- `ENV=prod`, 강한 `JWT_SECRET`, 명시 `CORS_ALLOW_ORIGINS`, `AUTO_CREATE_TABLES=false`(Alembic), `SEED_DEMO_DATA=false`, `FORCE_HTTPS=true`(프록시 뒤 --proxy-headers).

Phase 3(보안·배포 하드닝) 완료: 관리자 격리(#115) · rate limit(#119) · 감사 로그(#121) · 배포 하드닝(본 PR).