### PR TITLE
feat(exercise): 운동 추가 실저장 연동

### DIFF
--- a/backend/app/api/v1/exercise.py
+++ b/backend/app/api/v1/exercise.py
@@ -26,7 +26,7 @@ from app.services.exercise_service import (
 
 router = APIRouter(tags=["exercise"])
 
-_ALLOWED_TYPES = {"cardio", "strength", "yoga", "walking", "stretching"}
+_ALLOWED_TYPES = {"cardio", "strength", "yoga", "walking", "stretching", "other"}
 
 
 @router.get("/exercise/weeks/current", response_model=ExerciseWeekResponse)

--- a/backend/tests/test_exercise.py
+++ b/backend/tests/test_exercise.py
@@ -1,0 +1,39 @@
+"""운동 기록 추가/조회 — DB 필요(로컬 skip, CI 실행)."""
+from __future__ import annotations
+
+from uuid import uuid4
+
+
+def _login(client) -> dict:
+    email = f"ex-{uuid4().hex[:8]}@oncare.com"
+    client.post("/v1/auth/register", json={"email": email, "password": "pw!", "name": "u"})
+    token = client.post("/v1/auth/login", data={"username": email, "password": "pw!"}).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_add_session_reflected_in_week(client):
+    h = _login(client)
+    r = client.post(
+        "/v1/exercise/sessions",
+        json={"type": "other", "minutes": 30, "calories": 120, "day_label": "월"},
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["type"] == "other"
+    assert r.json()["minutes"] == 30
+
+    week = client.get("/v1/exercise/weeks/current", headers=h)
+    assert week.status_code == 200
+    assert week.json()["total_minutes"] == 30
+
+
+def test_add_session_rejects_unknown_type(client):
+    h = _login(client)
+    r = client.post("/v1/exercise/sessions", json={"type": "flying", "minutes": 10}, headers=h)
+    assert r.status_code == 400
+
+
+def test_add_session_rejects_nonpositive_minutes(client):
+    h = _login(client)
+    r = client.post("/v1/exercise/sessions", json={"type": "cardio", "minutes": 0}, headers=h)
+    assert r.status_code == 400

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -34,6 +34,7 @@ class LocalApiInterceptor extends Interceptor {
     'GET /dashboard/summary': _dashboardSummary,
     'GET /diet/days/today': _dietToday,
     'GET /exercise/weeks/current': _exerciseCurrentWeek,
+    'POST /exercise/sessions': _exerciseAddSession,
     'GET /schedule/events': _scheduleEvents,
     'GET /notifications': _notifications,
     'GET /ai-coach/feedback': _aiCoachFeedback,
@@ -384,6 +385,57 @@ class LocalApiInterceptor extends Interceptor {
     'walking' => const <String>['공원 산책'],
     _ => const <String>[],
   };
+
+  /// POST /exercise/sessions — persist a workout into drift so the next
+  /// GET /exercise/weeks/current includes it (stats + chart + list). The
+  /// `ex-` id prefix (not `seed-`) means seedIfEmpty never wipes it.
+  Future<Response<Object?>> _exerciseAddSession(RequestOptions options) async {
+    final body = options.data;
+    Map<String, Object?> payload;
+    if (body is Map) {
+      payload = body.cast<String, Object?>();
+    } else if (body is String && body.isNotEmpty) {
+      payload = (jsonDecode(body) as Map<Object?, Object?>)
+          .cast<String, Object?>();
+    } else {
+      payload = <String, Object?>{};
+    }
+
+    final type = (payload['type'] as String?) ?? 'cardio';
+    final minutes = (payload['minutes'] as num?)?.toInt() ?? 0;
+    if (minutes <= 0) {
+      return _badRequest(options, 'minutes must be > 0');
+    }
+    final calories = (payload['calories'] as num?)?.toInt() ?? 0;
+    final dayLabel =
+        (payload['day_label'] as String?) ??
+        _weekdayLabels[DateTime.now().weekday - 1];
+
+    final id = 'ex-${DateTime.now().microsecondsSinceEpoch}';
+    await _db
+        .into(_db.exerciseSessions)
+        .insert(
+          ExerciseSessionsCompanion.insert(
+            id: id,
+            weekStart: _mondayOfThisWeekString(),
+            dayLabel: dayLabel,
+            type: type,
+            minutes: minutes,
+            calories: calories,
+          ),
+        );
+
+    return _ok(options, <String, Object?>{
+      'id': id,
+      'day_label': dayLabel,
+      'type': type,
+      'minutes': minutes,
+      'calories': calories,
+      'date_label': _dateLabelForDayLabel(dayLabel),
+      'time_label': _defaultTimeLabel(type),
+      'items': _defaultItems(type),
+    });
+  }
 
   // ---- Schedule ----
 

--- a/frontend/flutter/lib/features/exercise/data/repositories/dio_exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/dio_exercise_repository.dart
@@ -14,4 +14,23 @@ class DioExerciseRepository implements ExerciseRepository {
     final res = await _dio.get<Map<String, Object?>>('/exercise/weeks/current');
     return ExerciseWeek.fromJson(res.data!);
   }
+
+  @override
+  Future<ExerciseSession> addSession({
+    required ExerciseType type,
+    required int minutes,
+    required int calories,
+    required String dayLabel,
+  }) async {
+    final res = await _dio.post<Map<String, Object?>>(
+      '/exercise/sessions',
+      data: <String, Object?>{
+        'type': type.name,
+        'minutes': minutes,
+        'calories': calories,
+        'day_label': dayLabel,
+      },
+    );
+    return ExerciseSession.fromJson(res.data!);
+  }
 }

--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
@@ -5,6 +5,24 @@ class MockExerciseRepository implements ExerciseRepository {
   const MockExerciseRepository();
 
   @override
+  Future<ExerciseSession> addSession({
+    required ExerciseType type,
+    required int minutes,
+    required int calories,
+    required String dayLabel,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 120));
+    return ExerciseSession(
+      id: 'mock-ex',
+      dayLabel: dayLabel,
+      type: type,
+      minutes: minutes,
+      calories: calories,
+      dateLabel: '오늘',
+    );
+  }
+
+  @override
   Future<ExerciseWeek> fetchThisWeek() async {
     await Future<void>.delayed(const Duration(milliseconds: 150));
     return const ExerciseWeek(

--- a/frontend/flutter/lib/features/exercise/domain/repositories/exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/domain/repositories/exercise_repository.dart
@@ -2,4 +2,13 @@ import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 
 abstract class ExerciseRepository {
   Future<ExerciseWeek> fetchThisWeek();
+
+  /// Persist a new workout session (POST /exercise/sessions) and return
+  /// the created session as the server materialised it.
+  Future<ExerciseSession> addSession({
+    required ExerciseType type,
+    required int minutes,
+    required int calories,
+    required String dayLabel,
+  });
 }

--- a/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
@@ -32,21 +32,3 @@ final myGymProvider = FutureProvider<Gym?>((ref) {
 final nearbyGymsProvider = FutureProvider<List<Gym>>((ref) {
   return ref.watch(gymRepositoryProvider).fetchNearby();
 }, name: 'nearbyGyms');
-
-/// Sessions added through the floating "운동 기록 추가" FAB. Layered on
-/// top of [exerciseWeekProvider] so they show up immediately in the
-/// list without round-tripping through drift.
-class AddedSessionsNotifier extends Notifier<List<ExerciseSession>> {
-  @override
-  List<ExerciseSession> build() => const <ExerciseSession>[];
-
-  void add(ExerciseSession session) {
-    state = <ExerciseSession>[session, ...state];
-  }
-}
-
-final addedSessionsProvider =
-    NotifierProvider<AddedSessionsNotifier, List<ExerciseSession>>(
-      AddedSessionsNotifier.new,
-      name: 'addedSessions',
-    );

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/add_session_sheet.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/add_session_sheet.dart
@@ -41,6 +41,7 @@ class _AddSessionFormState extends ConsumerState<_AddSessionForm> {
   ExerciseType _type = ExerciseType.cardio;
   final TextEditingController _minutesController = TextEditingController();
   final TextEditingController _itemsController = TextEditingController();
+  bool _saving = false;
 
   @override
   void dispose() {
@@ -49,39 +50,34 @@ class _AddSessionFormState extends ConsumerState<_AddSessionForm> {
     super.dispose();
   }
 
-  void _save() {
+  Future<void> _save() async {
+    if (_saving) return;
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
     final minutes = int.tryParse(_minutesController.text.trim()) ?? 0;
     if (minutes <= 0) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('운동 시간을 입력해주세요')));
+      messenger.showSnackBar(const SnackBar(content: Text('운동 시간을 입력해주세요')));
       return;
     }
-    final raw = _itemsController.text.trim();
-    final items = raw.isEmpty
-        ? const <String>[]
-        : raw
-              .split(RegExp(r'[,\n]'))
-              .map((s) => s.trim())
-              .where((s) => s.isNotEmpty)
-              .toList();
-    final now = DateTime.now();
-    final session = ExerciseSession(
-      id: 'ux-${now.microsecondsSinceEpoch}',
-      dateLabel: '오늘',
-      timeLabel:
-          '${now.hour.toString().padLeft(2, '0')}:${now.minute.toString().padLeft(2, '0')}',
-      dayLabel: _weekdayLabels[now.weekday - 1],
-      type: _type,
-      minutes: minutes,
-      calories: _estimateCalories(_type, minutes),
-      items: items,
-    );
-    ref.read(addedSessionsProvider.notifier).add(session);
-    Navigator.of(context).pop();
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(const SnackBar(content: Text('운동 기록이 추가되었어요')));
+    setState(() => _saving = true);
+    final dayLabel = _weekdayLabels[DateTime.now().weekday - 1];
+    try {
+      // 서버(mock 모드는 drift)에 저장 → 주간 데이터 무효화로 통계·차트·목록 모두 반영.
+      await ref.read(exerciseRepositoryProvider).addSession(
+        type: _type,
+        minutes: minutes,
+        calories: _estimateCalories(_type, minutes),
+        dayLabel: dayLabel,
+      );
+      ref.invalidate(exerciseWeekProvider);
+      navigator.pop();
+      messenger.showSnackBar(const SnackBar(content: Text('운동 기록이 추가되었어요')));
+    } catch (_) {
+      if (mounted) setState(() => _saving = false);
+      messenger.showSnackBar(
+        const SnackBar(content: Text('저장에 실패했어요. 잠시 후 다시 시도해 주세요')),
+      );
+    }
   }
 
   @override
@@ -189,14 +185,23 @@ class _AddSessionFormState extends ConsumerState<_AddSessionForm> {
           SizedBox(
             height: 48,
             child: FilledButton(
-              onPressed: _save,
+              onPressed: _saving ? null : _save,
               style: FilledButton.styleFrom(
                 backgroundColor: AppColors.primary,
                 shape: const RoundedRectangleBorder(
                   borderRadius: BorderRadius.all(AppRadius.lg),
                 ),
               ),
-              child: const Text('저장하기'),
+              child: _saving
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: Colors.white,
+                      ),
+                    )
+                  : const Text('저장하기'),
             ),
           ),
         ],

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/workout_record_tab.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/workout_record_tab.dart
@@ -22,6 +22,8 @@ class WorkoutRecordTab extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final async = ref.watch(exerciseWeekProvider);
     return async.when(
+      // 운동 추가 후 invalidate 시 전체 화면이 스피너로 깜빡이지 않도록 이전 데이터 유지.
+      skipLoadingOnRefresh: true,
       data: (week) => _Body(week: week),
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (Object e, _) => ErrorView(
@@ -32,15 +34,13 @@ class WorkoutRecordTab extends ConsumerWidget {
   }
 }
 
-class _Body extends ConsumerWidget {
+class _Body extends StatelessWidget {
   const _Body({required this.week});
   final ExerciseWeek week;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final added = ref.watch(addedSessionsProvider);
-    final allSessions = <ExerciseSession>[...added, ...week.sessions];
     final hasStackedSeries =
         week.cardioMinutes.isNotEmpty ||
         week.strengthMinutes.isNotEmpty ||
@@ -149,7 +149,7 @@ class _Body extends ConsumerWidget {
         AiCoachCard(message: week.aiCoachMessage),
         const SizedBox(height: AppSpacing.lg),
 
-        for (final s in allSessions) ...<Widget>[
+        for (final s in week.sessions) ...<Widget>[
           _SessionCard(session: s),
           const SizedBox(height: AppSpacing.sm),
         ],

--- a/frontend/flutter/test/core/network/local_api_interceptor_exercise_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_exercise_test.dart
@@ -126,4 +126,38 @@ void main() {
     expect(body['streak_days'], 0);
     expect((body['sessions']! as List<Object?>), isEmpty);
   });
+
+  test('POST /exercise/sessions persists and shows up in weeks/current', () async {
+    final add = await dio.post<Map<String, Object?>>(
+      '/exercise/sessions',
+      data: <String, Object?>{
+        'type': 'cardio',
+        'minutes': 40,
+        'calories': 300,
+        'day_label': '화',
+      },
+    );
+    expect(add.statusCode, 200);
+    expect(add.data!['type'], 'cardio');
+    expect(add.data!['minutes'], 40);
+    expect(add.data!['day_label'], '화');
+    expect(add.data!['date_label'], isNotNull);
+
+    // 재조회 시 화요일(0→40) 반영, 합계 증가(135→175).
+    final res = await dio.get<Map<String, Object?>>('/exercise/weeks/current');
+    final daily = (res.data!['daily_minutes']! as List<Object?>)
+        .cast<num>()
+        .toList();
+    expect(daily, <num>[30, 40, 45, 0, 60, 0, 0]);
+    expect(res.data!['total_minutes'], 175);
+  });
+
+  test('POST /exercise/sessions rejects non-positive minutes', () async {
+    final res = await dio.post<Map<String, Object?>>(
+      '/exercise/sessions',
+      data: <String, Object?>{'type': 'cardio', 'minutes': 0},
+      options: Options(validateStatus: (int? s) => true),
+    );
+    expect(res.statusCode, 400);
+  });
 }


### PR DESCRIPTION
Closes #124

## 개요
운동 추가가 **화면에만 뜨고 저장 안 되던 문제**를 실연동으로 해결. 배포 하드닝 PR #123 위에 스택(base: `feature/backend-deploy-hardening`). `main` 미반영.

## 문제
추가 폼이 새 세션을 메모리(`addedSessionsProvider`)에만 넣어 → 목록엔 뜨나 통계/차트 미반영, 새로고침 시 소실. 백엔드 `POST /exercise/sessions`는 이미 있었지만 프론트가 미호출.

## 변경 (커밋 순서)
1. **feat: 백엔드 'other' 허용 + 테스트** — 프론트 '기타' 유형 저장 허용. 첫 운동 백엔드 테스트(주간 반영·잘못된 유형/시간 400).
2. **feat: 프론트/목 실저장** — 추가 폼 → `ExerciseRepository.addSession`(POST) → `exerciseWeekProvider` 무효화로 통계·차트·목록 일괄 반영. `LocalApiInterceptor` POST 핸들러가 drift에 저장(웹 데모도 저장됨, `ex-` id라 seed 슬라이드에도 보존). 인메모리 오버레이 제거, `skipLoadingOnRefresh`로 화면 깜빡임 방지.

## 데모 효과
운동 추가 → **통계·차트·목록 즉시 반영 + 새로고침해도 유지** (기존엔 목록만·비영속).

## 검증
- `flutter analyze` 무경고, 프론트 테스트 통과(운동 인터셉터 POST 2 + 기존 회귀 없음, 29개 green).
- 백엔드: 운동 추가 DB 테스트는 **Backend CI** 실행.
- 참고: 이 리포 데이터 모델상 운동 items(자유 텍스트)는 유형별 기본값으로 표시됨(스키마 미보유) — 별도 이슈.