### PR TITLE
feat(profile): 내 프로필·건강목표 저장 실연동

### DIFF
--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -41,6 +41,9 @@ class LocalApiInterceptor extends Interceptor {
     'GET /ai-coach/feedback': _aiCoachFeedback,
     'POST /ai-coach/chat': _aiCoachChat,
     'GET /users/me': _usersMe,
+    'GET /users/me/profile': _usersMeProfile,
+    'PUT /users/me': _usersMeUpdate,
+    'PUT /users/me/health-goals': _usersMeHealthGoals,
     'GET /users/me/health': _usersMeHealth,
     'GET /places/nearby': _placesNearby,
     // Vitals — three fixed kinds (weight | blood-pressure | blood-sugar).
@@ -660,12 +663,78 @@ class LocalApiInterceptor extends Interceptor {
 
   // ---- Users / Me ----
 
+  // ---- Profile (내 프로필 / 건강 목표) — AppKeyValues 로 영속 ----
+
+  static const Map<String, Object?> _defaultProfile = <String, Object?>{
+    'id': 'user-demo',
+    'name': '김민수',
+    'email': 'minsu@oncare.com',
+    'phone': '010-1234-5678',
+    'birth_date': '1990-01-15',
+    'gender': '',
+    'conditions': '',
+    'goals': '',
+    'goal_weight_kg': 70,
+    'goal_bp_systolic': 120,
+    'goal_blood_sugar': 100,
+    'daily_calories': 2000,
+    'daily_sodium_mg': 2000,
+    'onboarded': true,
+  };
+
+  Future<Map<String, Object?>> _readProfileOverlay() async {
+    final raw = await _db.readValue('profile_overlay');
+    if (raw == null || raw.isEmpty) return <String, Object?>{};
+    return (jsonDecode(raw) as Map<Object?, Object?>).cast<String, Object?>();
+  }
+
+  Future<Map<String, Object?>> _mergedProfile() async {
+    return <String, Object?>{..._defaultProfile, ...await _readProfileOverlay()};
+  }
+
+  Future<void> _mergeProfileOverlay(Map<String, Object?> patch) async {
+    final overlay = await _readProfileOverlay();
+    overlay.addAll(patch);
+    await _db.putValue('profile_overlay', jsonEncode(overlay));
+  }
+
   Future<Response<Object?>> _usersMe(RequestOptions options) async {
+    final p = await _mergedProfile();
     return _ok(options, <String, Object?>{
-      'id': 'user-demo',
-      'name': '김민수',
-      'email': 'minsu@oncare.com',
+      'id': p['id'],
+      'name': p['name'],
+      'email': p['email'],
     });
+  }
+
+  Future<Response<Object?>> _usersMeProfile(RequestOptions options) async {
+    return _ok(options, await _mergedProfile());
+  }
+
+  Future<Response<Object?>> _usersMeUpdate(RequestOptions options) async {
+    final body = _jsonBody(options);
+    final patch = <String, Object?>{};
+    for (final String k in <String>['name', 'email', 'phone', 'birth_date']) {
+      if (body[k] != null) patch[k] = body[k];
+    }
+    await _mergeProfileOverlay(patch);
+    return _ok(options, await _mergedProfile());
+  }
+
+  Future<Response<Object?>> _usersMeHealthGoals(RequestOptions options) async {
+    final body = _jsonBody(options);
+    final patch = <String, Object?>{};
+    for (final String k in <String>[
+      'goal_weight_kg',
+      'goal_bp_systolic',
+      'goal_blood_sugar',
+      'daily_calories',
+      'daily_sodium_mg',
+    ]) {
+      if (body[k] != null) patch[k] = body[k];
+    }
+    await _mergeProfileOverlay(patch);
+    return _ok(options, await _mergedProfile());
   }
 
   Future<Response<Object?>> _usersMeHealth(RequestOptions options) async {
@@ -916,6 +985,16 @@ class LocalApiInterceptor extends Interceptor {
   }
 
   // ---- helpers ----
+
+  /// Parse a request body (JSON Map or raw String) into a Map.
+  Map<String, Object?> _jsonBody(RequestOptions options) {
+    final body = options.data;
+    if (body is Map) return body.cast<String, Object?>();
+    if (body is String && body.isNotEmpty) {
+      return (jsonDecode(body) as Map<Object?, Object?>).cast<String, Object?>();
+    }
+    return <String, Object?>{};
+  }
 
   /// Build a 200 OK response carrying [body]. Subclasses of handlers
   /// will build their bodies as plain Map/List structures (snake_case)

--- a/frontend/flutter/lib/features/account/data/repositories/dio_account_repository.dart
+++ b/frontend/flutter/lib/features/account/data/repositories/dio_account_repository.dart
@@ -1,0 +1,55 @@
+import 'package:dio/dio.dart';
+
+import 'package:oncare/features/account/domain/entities/user_profile.dart';
+import 'package:oncare/features/account/domain/repositories/account_repository.dart';
+
+class DioAccountRepository implements AccountRepository {
+  DioAccountRepository(this._dio);
+  final Dio _dio;
+
+  @override
+  Future<UserProfile> fetchProfile() async {
+    final res = await _dio.get<Map<String, Object?>>('/users/me/profile');
+    return UserProfile.fromJson(res.data!);
+  }
+
+  @override
+  Future<UserProfile> updateProfile({
+    String? name,
+    String? email,
+    String? phone,
+    String? birthDate,
+  }) async {
+    final res = await _dio.put<Map<String, Object?>>(
+      '/users/me',
+      data: <String, Object?>{
+        'name': ?name,
+        'email': ?email,
+        'phone': ?phone,
+        'birth_date': ?birthDate,
+      },
+    );
+    return UserProfile.fromJson(res.data!);
+  }
+
+  @override
+  Future<UserProfile> updateHealthGoals({
+    num? goalWeightKg,
+    int? goalBpSystolic,
+    int? goalBloodSugar,
+    int? dailyCalories,
+    int? dailySodiumMg,
+  }) async {
+    final res = await _dio.put<Map<String, Object?>>(
+      '/users/me/health-goals',
+      data: <String, Object?>{
+        'goal_weight_kg': ?goalWeightKg,
+        'goal_bp_systolic': ?goalBpSystolic,
+        'goal_blood_sugar': ?goalBloodSugar,
+        'daily_calories': ?dailyCalories,
+        'daily_sodium_mg': ?dailySodiumMg,
+      },
+    );
+    return UserProfile.fromJson(res.data!);
+  }
+}

--- a/frontend/flutter/lib/features/account/data/repositories/mock_account_repository.dart
+++ b/frontend/flutter/lib/features/account/data/repositories/mock_account_repository.dart
@@ -1,0 +1,41 @@
+import 'package:oncare/features/account/domain/entities/user_profile.dart';
+import 'package:oncare/features/account/domain/repositories/account_repository.dart';
+
+/// Not wired by default (the app uses [DioAccountRepository] → the drift-backed
+/// LocalApiInterceptor). Kept for unit tests / offline overrides.
+class MockAccountRepository implements AccountRepository {
+  const MockAccountRepository();
+
+  static const UserProfile _demo = UserProfile(
+    id: 'user-demo',
+    name: '김민수',
+    email: 'minsu@oncare.com',
+    phone: '010-1234-5678',
+    birthDate: '1990-01-15',
+    goalWeightKg: 70,
+    goalBpSystolic: 120,
+    goalBloodSugar: 100,
+    dailyCalories: 2000,
+    dailySodiumMg: 2000,
+  );
+
+  @override
+  Future<UserProfile> fetchProfile() async => _demo;
+
+  @override
+  Future<UserProfile> updateProfile({
+    String? name,
+    String? email,
+    String? phone,
+    String? birthDate,
+  }) async => _demo;
+
+  @override
+  Future<UserProfile> updateHealthGoals({
+    num? goalWeightKg,
+    int? goalBpSystolic,
+    int? goalBloodSugar,
+    int? dailyCalories,
+    int? dailySodiumMg,
+  }) async => _demo;
+}

--- a/frontend/flutter/lib/features/account/domain/entities/user_profile.dart
+++ b/frontend/flutter/lib/features/account/domain/entities/user_profile.dart
@@ -1,0 +1,40 @@
+/// GET /users/me/profile — the consolidated profile the settings modals
+/// edit (내 프로필 + 건강 목표).
+class UserProfile {
+  const UserProfile({
+    required this.id,
+    required this.name,
+    required this.email,
+    this.phone = '',
+    this.birthDate = '',
+    this.goalWeightKg,
+    this.goalBpSystolic,
+    this.goalBloodSugar,
+    this.dailyCalories,
+    this.dailySodiumMg,
+  });
+
+  final String id;
+  final String name;
+  final String email;
+  final String phone;
+  final String birthDate;
+  final num? goalWeightKg;
+  final int? goalBpSystolic;
+  final int? goalBloodSugar;
+  final int? dailyCalories;
+  final int? dailySodiumMg;
+
+  factory UserProfile.fromJson(Map<String, Object?> json) => UserProfile(
+    id: (json['id'] as String?) ?? '',
+    name: (json['name'] as String?) ?? '',
+    email: (json['email'] as String?) ?? '',
+    phone: (json['phone'] as String?) ?? '',
+    birthDate: (json['birth_date'] as String?) ?? '',
+    goalWeightKg: json['goal_weight_kg'] as num?,
+    goalBpSystolic: (json['goal_bp_systolic'] as num?)?.toInt(),
+    goalBloodSugar: (json['goal_blood_sugar'] as num?)?.toInt(),
+    dailyCalories: (json['daily_calories'] as num?)?.toInt(),
+    dailySodiumMg: (json['daily_sodium_mg'] as num?)?.toInt(),
+  );
+}

--- a/frontend/flutter/lib/features/account/domain/repositories/account_repository.dart
+++ b/frontend/flutter/lib/features/account/domain/repositories/account_repository.dart
@@ -1,0 +1,22 @@
+import 'package:oncare/features/account/domain/entities/user_profile.dart';
+
+abstract class AccountRepository {
+  Future<UserProfile> fetchProfile();
+
+  /// PUT /users/me — update basic profile (name/email/phone/birth).
+  Future<UserProfile> updateProfile({
+    String? name,
+    String? email,
+    String? phone,
+    String? birthDate,
+  });
+
+  /// PUT /users/me/health-goals — update goal targets.
+  Future<UserProfile> updateHealthGoals({
+    num? goalWeightKg,
+    int? goalBpSystolic,
+    int? goalBloodSugar,
+    int? dailyCalories,
+    int? dailySodiumMg,
+  });
+}

--- a/frontend/flutter/lib/features/account/presentation/controllers/account_controller.dart
+++ b/frontend/flutter/lib/features/account/presentation/controllers/account_controller.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare/core/network/dio_client.dart';
+import 'package:oncare/features/account/data/repositories/dio_account_repository.dart';
+import 'package:oncare/features/account/domain/entities/user_profile.dart';
+import 'package:oncare/features/account/domain/repositories/account_repository.dart';
+
+final accountRepositoryProvider = Provider<AccountRepository>(
+  (ref) => DioAccountRepository(ref.watch(dioProvider)),
+  name: 'accountRepository',
+);
+
+final profileProvider = FutureProvider<UserProfile>((ref) {
+  return ref.watch(accountRepositoryProvider).fetchProfile();
+}, name: 'profile');

--- a/frontend/flutter/lib/features/my_health/presentation/widgets/settings_modals.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/widgets/settings_modals.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/design_system/tokens/radius.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/account/domain/entities/user_profile.dart';
+import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
 
 // ---------------------------------------------------------------------------
 // Shared scaffold
@@ -17,12 +20,14 @@ class _SettingsDialog extends StatelessWidget {
     required this.body,
     required this.footerLabel,
     this.onFooter,
+    this.saving = false,
   });
 
   final String title;
   final Widget body;
   final String footerLabel;
   final VoidCallback? onFooter;
+  final bool saving;
 
   @override
   Widget build(BuildContext context) {
@@ -71,8 +76,19 @@ class _SettingsDialog extends StatelessWidget {
                       borderRadius: BorderRadius.all(AppRadius.lg),
                     ),
                   ),
-                  onPressed: onFooter ?? () => Navigator.of(context).pop(),
-                  child: Text(footerLabel),
+                  onPressed: saving
+                      ? null
+                      : (onFooter ?? () => Navigator.of(context).pop()),
+                  child: saving
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: Colors.white,
+                          ),
+                        )
+                      : Text(footerLabel),
                 ),
               ),
             ],
@@ -173,23 +189,40 @@ Future<void> showMyProfileModal(BuildContext context) {
   );
 }
 
-class _MyProfileDialog extends StatefulWidget {
+class _MyProfileDialog extends ConsumerWidget {
   const _MyProfileDialog();
+
   @override
-  State<_MyProfileDialog> createState() => _MyProfileDialogState();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(profileProvider);
+    return async.when(
+      data: (UserProfile p) => _MyProfileForm(initial: p),
+      loading: () => const _LoadingDialog(title: '내 프로필'),
+      error: (_, _) => const _MyProfileForm(
+        initial: UserProfile(id: '', name: '', email: ''),
+      ),
+    );
+  }
 }
 
-class _MyProfileDialogState extends State<_MyProfileDialog> {
-  late final TextEditingController _name = TextEditingController(text: '김민수');
-  late final TextEditingController _email = TextEditingController(
-    text: 'minsu@oncare.com',
-  );
-  late final TextEditingController _phone = TextEditingController(
-    text: '010-1234-5678',
-  );
-  late final TextEditingController _birth = TextEditingController(
-    text: '1990. 01. 15.',
-  );
+class _MyProfileForm extends ConsumerStatefulWidget {
+  const _MyProfileForm({required this.initial});
+  final UserProfile initial;
+
+  @override
+  ConsumerState<_MyProfileForm> createState() => _MyProfileFormState();
+}
+
+class _MyProfileFormState extends ConsumerState<_MyProfileForm> {
+  late final TextEditingController _name =
+      TextEditingController(text: widget.initial.name);
+  late final TextEditingController _email =
+      TextEditingController(text: widget.initial.email);
+  late final TextEditingController _phone =
+      TextEditingController(text: widget.initial.phone);
+  late final TextEditingController _birth =
+      TextEditingController(text: widget.initial.birthDate);
+  bool _saving = false;
 
   @override
   void dispose() {
@@ -200,11 +233,27 @@ class _MyProfileDialogState extends State<_MyProfileDialog> {
     super.dispose();
   }
 
-  void _save() {
-    Navigator.of(context).pop();
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('내 프로필이 저장되었어요')),
-    );
+  Future<void> _save() async {
+    if (_saving) return;
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+    setState(() => _saving = true);
+    try {
+      await ref.read(accountRepositoryProvider).updateProfile(
+        name: _name.text.trim(),
+        email: _email.text.trim(),
+        phone: _phone.text.trim(),
+        birthDate: _birth.text.trim(),
+      );
+      ref.invalidate(profileProvider);
+      navigator.pop();
+      messenger.showSnackBar(const SnackBar(content: Text('내 프로필이 저장되었어요')));
+    } catch (_) {
+      if (mounted) setState(() => _saving = false);
+      messenger.showSnackBar(
+        const SnackBar(content: Text('저장에 실패했어요. 잠시 후 다시 시도해 주세요')),
+      );
+    }
   }
 
   @override
@@ -213,6 +262,7 @@ class _MyProfileDialogState extends State<_MyProfileDialog> {
       title: '내 프로필',
       footerLabel: '저장하기',
       onFooter: _save,
+      saving: _saving,
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
@@ -241,6 +291,25 @@ class _MyProfileDialogState extends State<_MyProfileDialog> {
   }
 }
 
+/// Minimal spinner dialog shown while the profile loads.
+class _LoadingDialog extends StatelessWidget {
+  const _LoadingDialog({required this.title});
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return _SettingsDialog(
+      title: title,
+      footerLabel: '저장하기',
+      saving: true,
+      body: const Padding(
+        padding: EdgeInsets.symmetric(vertical: AppSpacing.xl),
+        child: Center(child: CircularProgressIndicator(color: AppColors.primary)),
+      ),
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // 건강 목표 modal
 // ---------------------------------------------------------------------------
@@ -252,20 +321,42 @@ Future<void> showHealthGoalModal(BuildContext context) {
   );
 }
 
-class _HealthGoalDialog extends StatefulWidget {
+class _HealthGoalDialog extends ConsumerWidget {
   const _HealthGoalDialog();
+
   @override
-  State<_HealthGoalDialog> createState() => _HealthGoalDialogState();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(profileProvider);
+    return async.when(
+      data: (UserProfile p) => _HealthGoalForm(initial: p),
+      loading: () => const _LoadingDialog(title: '건강 목표'),
+      error: (_, _) => const _HealthGoalForm(
+        initial: UserProfile(id: '', name: '', email: ''),
+      ),
+    );
+  }
 }
 
-class _HealthGoalDialogState extends State<_HealthGoalDialog> {
-  late final TextEditingController _weight = TextEditingController(text: '70');
-  late final TextEditingController _bp = TextEditingController(text: '120');
-  late final TextEditingController _sugar = TextEditingController(text: '100');
-  late final TextEditingController _kcal = TextEditingController(text: '2000');
-  late final TextEditingController _sodium = TextEditingController(
-    text: '2000',
-  );
+class _HealthGoalForm extends ConsumerStatefulWidget {
+  const _HealthGoalForm({required this.initial});
+  final UserProfile initial;
+
+  @override
+  ConsumerState<_HealthGoalForm> createState() => _HealthGoalFormState();
+}
+
+class _HealthGoalFormState extends ConsumerState<_HealthGoalForm> {
+  late final TextEditingController _weight =
+      TextEditingController(text: '${(widget.initial.goalWeightKg ?? 70).round()}');
+  late final TextEditingController _bp =
+      TextEditingController(text: '${widget.initial.goalBpSystolic ?? 120}');
+  late final TextEditingController _sugar =
+      TextEditingController(text: '${widget.initial.goalBloodSugar ?? 100}');
+  late final TextEditingController _kcal =
+      TextEditingController(text: '${widget.initial.dailyCalories ?? 2000}');
+  late final TextEditingController _sodium =
+      TextEditingController(text: '${widget.initial.dailySodiumMg ?? 2000}');
+  bool _saving = false;
 
   @override
   void dispose() {
@@ -277,11 +368,28 @@ class _HealthGoalDialogState extends State<_HealthGoalDialog> {
     super.dispose();
   }
 
-  void _save() {
-    Navigator.of(context).pop();
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('건강 목표가 저장되었어요')),
-    );
+  Future<void> _save() async {
+    if (_saving) return;
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+    setState(() => _saving = true);
+    try {
+      await ref.read(accountRepositoryProvider).updateHealthGoals(
+        goalWeightKg: int.tryParse(_weight.text.trim()),
+        goalBpSystolic: int.tryParse(_bp.text.trim()),
+        goalBloodSugar: int.tryParse(_sugar.text.trim()),
+        dailyCalories: int.tryParse(_kcal.text.trim()),
+        dailySodiumMg: int.tryParse(_sodium.text.trim()),
+      );
+      ref.invalidate(profileProvider);
+      navigator.pop();
+      messenger.showSnackBar(const SnackBar(content: Text('건강 목표가 저장되었어요')));
+    } catch (_) {
+      if (mounted) setState(() => _saving = false);
+      messenger.showSnackBar(
+        const SnackBar(content: Text('저장에 실패했어요. 잠시 후 다시 시도해 주세요')),
+      );
+    }
   }
 
   @override
@@ -293,6 +401,7 @@ class _HealthGoalDialogState extends State<_HealthGoalDialog> {
       title: '건강 목표',
       footerLabel: '저장하기',
       onFooter: _save,
+      saving: _saving,
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[

--- a/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
@@ -96,4 +96,32 @@ void main() {
     );
     expect(res.statusCode, 400);
   });
+
+  test('PUT /users/me persists profile; GET /users/me/profile + /users/me reflect it', () async {
+    final put = await dio.put<Map<String, Object?>>(
+      '/users/me',
+      data: <String, Object?>{'name': '이순신', 'phone': '010-9999-0000'},
+    );
+    expect(put.statusCode, 200);
+    expect(put.data!['name'], '이순신');
+
+    final prof = await dio.get<Map<String, Object?>>('/users/me/profile');
+    expect(prof.data!['name'], '이순신');
+    expect(prof.data!['phone'], '010-9999-0000');
+    expect(prof.data!['email'], 'minsu@oncare.com'); // 안 바꾼 값은 기본 유지
+
+    final me = await dio.get<Map<String, Object?>>('/users/me');
+    expect(me.data!['name'], '이순신');
+  });
+
+  test('PUT /users/me/health-goals persists goals', () async {
+    await dio.put<Map<String, Object?>>(
+      '/users/me/health-goals',
+      data: <String, Object?>{'goal_weight_kg': 65, 'daily_sodium_mg': 1800},
+    );
+    final prof = await dio.get<Map<String, Object?>>('/users/me/profile');
+    expect(prof.data!['goal_weight_kg'], 65);
+    expect(prof.data!['daily_sodium_mg'], 1800);
+    expect(prof.data!['goal_bp_systolic'], 120); // 미변경 목표는 기본 유지
+  });
 }


### PR DESCRIPTION
Closes #128

## 개요
계정 도메인 프론트 연동 **1단계** — 내 프로필·건강목표 모달을 실제 저장에 연결. 식단 분석 PR #127 위에 스택(base: `feature/diet-photo-analyze`). `main` 미반영. **프론트 전용**(백엔드 PUT 엔드포인트는 #101에서 이미 존재).

## 문제
설정 모달이 하드코딩 값 + 스낵바만 → 저장 불가.

## 변경 (커밋 순서)
1. **feat: account 피처 + 모달 연동** — `UserProfile`/`AccountRepository`(GET profile, PUT me, PUT health-goals) + `profileProvider`. 두 모달을 프리필 + 저장(PUT) + `profileProvider` 무효화로 재오픈 시 저장값 표시. 로딩/저장 상태.
2. **feat: 목 핸들러 + 테스트** — `LocalApiInterceptor`에 프로필 조회/수정/건강목표 핸들러(AppKeyValues `profile_overlay` JSON 병합) → **웹 데모에서 새로고침해도 유지**. `GET /users/me`도 반영. PUT→GET 라운드트립 테스트.

## 데모 효과
설정 → 내 프로필/건강 목표 → 값 수정 → 저장 → **재오픈 시 저장값 유지**(기존: 스낵바 dead-end).

## 검증
- `flutter analyze lib` 무경고, 프론트 테스트 통과(프로필 라운드트립 포함, 98개 통과). (golden 1건은 폰트 렌더링 환경차 — design_system 미변경·무관, CI 미포함)

## 참고
- my_health **페이지 헤더 이름** 실시간 반영은 후속(그 페이지는 아직 MockMyHealthRepository 사용 → Dio 재배선 필요). 모달 저장/프리필은 이 PR로 완결.