### PR TITLE
feat(auth): 라우터 인증 가드 + 로그아웃 연결

### DIFF
--- a/frontend/flutter/lib/app/router/app_router.dart
+++ b/frontend/flutter/lib/app/router/app_router.dart
@@ -9,6 +9,7 @@ import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/core/logging/app_logger.dart';
 import 'package:oncare/design_system/catalog/ui_catalog_page.dart';
 import 'package:oncare/features/ai_coach/presentation/pages/ai_coach_page.dart';
+import 'package:oncare/features/auth/presentation/controllers/session_controller.dart';
 import 'package:oncare/features/auth/presentation/pages/sign_in_page.dart';
 import 'package:oncare/features/dashboard/presentation/pages/dashboard_page.dart';
 import 'package:oncare/features/diet/presentation/pages/diet_record_page.dart';
@@ -17,12 +18,39 @@ import 'package:oncare/features/my_health/presentation/pages/my_health_page.dart
 import 'package:oncare/features/notification/presentation/pages/notification_page.dart';
 import 'package:oncare/features/place/presentation/pages/place_page.dart';
 
+/// Pure auth-guard policy for the router's `redirect`. Kept free of
+/// `BuildContext`/`GoRouterState` so it can be unit-tested directly.
+///
+/// - signed-out (or still restoring the session) → forced onto the
+///   sign-in screen;
+/// - already in the app (demo or authenticated) → kept off the sign-in
+///   screen (bounced to the dashboard).
+///
+/// Returning `null` means "no redirect — stay put".
+String? sessionRedirect(SessionStatus status, String location) {
+  final atSignIn = location == AppRoutes.signIn;
+  switch (status) {
+    case SessionStatus.unknown:
+    case SessionStatus.signedOut:
+      return atSignIn ? null : AppRoutes.signIn;
+    case SessionStatus.demo:
+    case SessionStatus.authenticated:
+      return atSignIn ? AppRoutes.dashboard : null;
+  }
+}
+
 /// Single source of truth for the app's routing tree. The `config`
 /// is read once at build time — dev-only routes (UI catalog) are
 /// excluded from prod builds.
+///
+/// When [readStatus] is supplied the router enforces [sessionRedirect];
+/// [refresh] should fire whenever the session changes so the guard is
+/// re-evaluated without rebuilding the router (which drops nav state).
 GoRouter buildAppRouter({
   required AppConfig config,
   NavigatorObserver? observer,
+  SessionStatus Function()? readStatus,
+  Listenable? refresh,
 }) {
   return GoRouter(
     initialLocation: AppRoutes.signIn,
@@ -30,6 +58,11 @@ GoRouter buildAppRouter({
     observers: observer == null
         ? const <NavigatorObserver>[]
         : <NavigatorObserver>[observer],
+    refreshListenable: refresh,
+    redirect: readStatus == null
+        ? null
+        : (context, state) =>
+              sessionRedirect(readStatus(), state.matchedLocation),
     routes: <RouteBase>[
       StatefulShellRoute.indexedStack(
         builder: (context, state, navigationShell) =>
@@ -100,5 +133,19 @@ final appRouterProvider = Provider<GoRouter>((ref) {
   final observer = config.isProd
       ? null
       : NavLoggerObserver(ref.watch(appLoggerProvider));
-  return buildAppRouter(config: config, observer: observer);
+  // Bridge session changes into a Listenable so the router re-evaluates its
+  // login guard without rebuilding — a rebuild would drop the navigation
+  // stack. The status itself is read lazily inside `redirect`.
+  final refresh = ValueNotifier<int>(0);
+  ref.listen<SessionState>(
+    sessionControllerProvider,
+    (_, _) => refresh.value++,
+  );
+  ref.onDispose(refresh.dispose);
+  return buildAppRouter(
+    config: config,
+    observer: observer,
+    readStatus: () => ref.read(sessionControllerProvider).status,
+    refresh: refresh,
+  );
 });

--- a/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
@@ -7,6 +7,7 @@ import 'package:oncare/design_system/atoms/app_card.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/design_system/tokens/radius.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/auth/presentation/controllers/session_controller.dart';
 import 'package:oncare/features/my_health/domain/entities/health_history.dart';
 import 'package:oncare/features/my_health/presentation/controllers/my_health_controller.dart';
 import 'package:oncare/features/my_health/presentation/widgets/indicator_trend_modal.dart';
@@ -103,8 +104,60 @@ class _Body extends StatelessWidget {
                 ],
               ),
             ),
+            const SizedBox(height: AppSpacing.lg),
+            const _SignOutButton(),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _SignOutButton extends ConsumerWidget {
+  const _SignOutButton();
+
+  Future<void> _confirmAndSignOut(BuildContext context, WidgetRef ref) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('로그아웃'),
+        content: const Text('로그아웃 하시겠어요?'),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('취소'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            style: TextButton.styleFrom(foregroundColor: AppColors.destructive),
+            child: const Text('로그아웃'),
+          ),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    // Flipping the session to signed-out lets the router's redirect guard
+    // bounce us back to the sign-in screen automatically.
+    await ref.read(sessionControllerProvider.notifier).signOut();
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return AppCard(
+      outlined: true,
+      onTap: () => _confirmAndSignOut(context, ref),
+      child: const Row(
+        children: <Widget>[
+          Icon(Icons.logout, size: 20, color: AppColors.destructive),
+          SizedBox(width: AppSpacing.md),
+          Text(
+            '로그아웃',
+            style: TextStyle(
+              color: AppColors.destructive,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/frontend/flutter/test/app/router/session_redirect_test.dart
+++ b/frontend/flutter/test/app/router/session_redirect_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/app/router/app_router.dart';
+import 'package:oncare/app/router/routes.dart';
+import 'package:oncare/features/auth/presentation/controllers/session_controller.dart';
+
+void main() {
+  group('sessionRedirect (router login guard)', () {
+    test('signed-out on a protected route → forced to sign-in', () {
+      expect(
+        sessionRedirect(SessionStatus.signedOut, AppRoutes.dashboard),
+        AppRoutes.signIn,
+      );
+      expect(
+        sessionRedirect(SessionStatus.signedOut, AppRoutes.myHealth),
+        AppRoutes.signIn,
+      );
+      expect(
+        sessionRedirect(SessionStatus.signedOut, AppRoutes.aiCoach),
+        AppRoutes.signIn,
+      );
+    });
+
+    test('still-restoring (unknown) is guarded exactly like signed-out', () {
+      expect(
+        sessionRedirect(SessionStatus.unknown, AppRoutes.dashboard),
+        AppRoutes.signIn,
+      );
+      expect(sessionRedirect(SessionStatus.unknown, AppRoutes.signIn), isNull);
+    });
+
+    test('signed-out already on sign-in → stays put (null)', () {
+      expect(
+        sessionRedirect(SessionStatus.signedOut, AppRoutes.signIn),
+        isNull,
+      );
+    });
+
+    test('demo / authenticated on sign-in → bounced into the app', () {
+      expect(
+        sessionRedirect(SessionStatus.demo, AppRoutes.signIn),
+        AppRoutes.dashboard,
+      );
+      expect(
+        sessionRedirect(SessionStatus.authenticated, AppRoutes.signIn),
+        AppRoutes.dashboard,
+      );
+    });
+
+    test('demo / authenticated on a protected route → stays put (null)', () {
+      expect(sessionRedirect(SessionStatus.demo, AppRoutes.dashboard), isNull);
+      expect(
+        sessionRedirect(SessionStatus.authenticated, AppRoutes.exercise),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 요약
로그인 화면(#131) 위에 스택. **라우터에 세션 기반 인증 가드를 붙여 로그인을 실제로 강제**하고, My 화면에 로그아웃을 연결해 세션 루프를 완성한다. 지금까지 로그인 화면은 시작점일 뿐 강제되지 않았고(로그아웃 상태로도 보호 라우트 접근 가능), `signOut()`은 UI 미연결 상태였다.

## 변경
- **라우터 인증 가드** (`app_router.dart`)
  - `sessionRedirect(status, location)` — `BuildContext` 비의존 순수 정책 함수(단위 테스트 가능).
    - 로그아웃 / 복원 중(`unknown`): 보호 라우트 → 로그인 화면
    - 데모 / 인증: 로그인 화면 → 대시보드
  - `redirect` + `refreshListenable` 배선. `ref.listen`으로 세션 → `ValueNotifier` 브리지 → 세션 변화 시 라우터 **리빌드 없이** 가드만 재평가(내비게이션 스택 유지).
- **로그아웃** (`my_health_page.dart`)
  - 설정 섹션 아래 로그아웃 버튼 → 확인 다이얼로그 → `signOut()`. 가드가 자동으로 로그인 화면으로 복귀(죽어 있던 `signOut()` 배선 완료).

## 테스트
- `test/app/router/session_redirect_test.dart` — 가드 정책 전 조합 단위 테스트(5 케이스).
- `flutter analyze` 무경고 · `flutter test` **106 통과**. (실패 1건은 무관·기존 `app_button_golden_test` — 폰트 렌더링 환경차, CI 미포함.)

## 스택
base: `feature/frontend-login` (main 아님)

Closes #132
