### PR TITLE
feat(auth): 회원가입 화면 (가입 후 자동 로그인)

### DIFF
--- a/frontend/flutter/lib/app/router/app_router.dart
+++ b/frontend/flutter/lib/app/router/app_router.dart
@@ -11,6 +11,7 @@ import 'package:oncare/design_system/catalog/ui_catalog_page.dart';
 import 'package:oncare/features/ai_coach/presentation/pages/ai_coach_page.dart';
 import 'package:oncare/features/auth/presentation/controllers/session_controller.dart';
 import 'package:oncare/features/auth/presentation/pages/sign_in_page.dart';
+import 'package:oncare/features/auth/presentation/pages/sign_up_page.dart';
 import 'package:oncare/features/dashboard/presentation/pages/dashboard_page.dart';
 import 'package:oncare/features/diet/presentation/pages/diet_record_page.dart';
 import 'package:oncare/features/exercise/presentation/pages/exercise_page.dart';
@@ -28,14 +29,15 @@ import 'package:oncare/features/place/presentation/pages/place_page.dart';
 ///
 /// Returning `null` means "no redirect — stay put".
 String? sessionRedirect(SessionStatus status, String location) {
-  final atSignIn = location == AppRoutes.signIn;
+  final onAuthRoute =
+      location == AppRoutes.signIn || location == AppRoutes.signUp;
   switch (status) {
     case SessionStatus.unknown:
     case SessionStatus.signedOut:
-      return atSignIn ? null : AppRoutes.signIn;
+      return onAuthRoute ? null : AppRoutes.signIn;
     case SessionStatus.demo:
     case SessionStatus.authenticated:
-      return atSignIn ? AppRoutes.dashboard : null;
+      return onAuthRoute ? AppRoutes.dashboard : null;
   }
 }
 
@@ -117,6 +119,10 @@ GoRouter buildAppRouter({
       GoRoute(
         path: AppRoutes.signIn,
         builder: (context, state) => const SignInPage(),
+      ),
+      GoRoute(
+        path: AppRoutes.signUp,
+        builder: (context, state) => const SignUpPage(),
       ),
       if (!config.isProd)
         GoRoute(

--- a/frontend/flutter/lib/app/router/routes.dart
+++ b/frontend/flutter/lib/app/router/routes.dart
@@ -16,6 +16,7 @@ class AppRoutes {
 
   // Auth
   static const String signIn = '/auth/sign-in';
+  static const String signUp = '/auth/sign-up';
 
   // Dev-only routes (registered only in non-prod builds).
   static const String uiCatalog = '/dev/ui-catalog';

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -41,6 +41,7 @@ class LocalApiInterceptor extends Interceptor {
     'GET /ai-coach/feedback': _aiCoachFeedback,
     'POST /ai-coach/chat': _aiCoachChat,
     'POST /auth/login': _authLogin,
+    'POST /auth/register': _authRegister,
     'GET /users/me': _usersMe,
     'GET /users/me/profile': _usersMeProfile,
     'PUT /users/me': _usersMeUpdate,
@@ -679,6 +680,29 @@ class LocalApiInterceptor extends Interceptor {
       'refresh_token': 'demo-refresh',
       'token_type': 'bearer',
     });
+  }
+
+  /// POST /auth/register — mirrors FastAPI: returns the created user
+  /// `{id, name, email}` with 201. The demo accepts any non-empty
+  /// email/password (real duplicate/validation is enforced by FastAPI
+  /// when USE_MOCK_API=false). `name` defaults to the email local-part.
+  Future<Response<Object?>> _authRegister(RequestOptions options) async {
+    final body = _jsonBody(options);
+    final email = (body['email'] as String? ?? '').trim();
+    final password = (body['password'] as String? ?? '').trim();
+    final name = (body['name'] as String? ?? '').trim();
+    if (email.isEmpty || password.isEmpty) {
+      return _badRequest(options, 'email and password are required');
+    }
+    return Response<Object?>(
+      requestOptions: options,
+      statusCode: 201,
+      data: <String, Object?>{
+        'id': 'user-${DateTime.now().microsecondsSinceEpoch}',
+        'name': name.isEmpty ? email.split('@').first : name,
+        'email': email,
+      },
+    );
   }
 
   // ---- Profile (내 프로필 / 건강 목표) — AppKeyValues 로 영속 ----

--- a/frontend/flutter/lib/features/auth/presentation/controllers/session_controller.dart
+++ b/frontend/flutter/lib/features/auth/presentation/controllers/session_controller.dart
@@ -65,6 +65,26 @@ class SessionController extends StateNotifier<SessionState> {
     state = const SessionState(status: SessionStatus.authenticated);
   }
 
+  /// Register a new account → POST /auth/register (returns the created
+  /// user, not a token), then log in with the same credentials so the
+  /// user lands authenticated. Throws on failure (e.g. 409 duplicate).
+  Future<void> register({
+    required String email,
+    required String password,
+    String name = '',
+  }) async {
+    final dio = _ref.read(dioProvider);
+    await dio.post<Map<String, Object?>>(
+      '/auth/register',
+      data: <String, Object?>{
+        'email': email,
+        'password': password,
+        'name': name,
+      },
+    );
+    await login(email: email, password: password);
+  }
+
   /// Skip auth — demo mode. No token; the backend demo-fallback serves data.
   void enterDemo() {
     _setToken(null);

--- a/frontend/flutter/lib/features/auth/presentation/pages/sign_up_page.dart
+++ b/frontend/flutter/lib/features/auth/presentation/pages/sign_up_page.dart
@@ -1,61 +1,90 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
-import 'package:oncare/design_system/tokens/radius.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
 import 'package:oncare/features/auth/presentation/controllers/session_controller.dart';
 import 'package:oncare/features/auth/presentation/widgets/auth_fields.dart';
 
-/// 로그인 화면 — 이메일/비밀번호 로그인 + 우측 상단 "데모로 시작" 바로가기.
-class SignInPage extends ConsumerStatefulWidget {
-  const SignInPage({super.key});
+/// 회원가입 화면 — 이름/이메일/비밀번호로 계정을 만들고, 성공 시 자동
+/// 로그인해 대시보드로 진입한다(라우터 가드가 인증 상태를 감지).
+class SignUpPage extends ConsumerStatefulWidget {
+  const SignUpPage({super.key});
 
   @override
-  ConsumerState<SignInPage> createState() => _SignInPageState();
+  ConsumerState<SignUpPage> createState() => _SignUpPageState();
 }
 
-class _SignInPageState extends ConsumerState<SignInPage> {
+class _SignUpPageState extends ConsumerState<SignUpPage> {
+  final TextEditingController _name = TextEditingController();
   final TextEditingController _email = TextEditingController();
   final TextEditingController _password = TextEditingController();
+  final TextEditingController _passwordConfirm = TextEditingController();
   bool _obscure = true;
   bool _loading = false;
 
   @override
   void dispose() {
+    _name.dispose();
     _email.dispose();
     _password.dispose();
+    _passwordConfirm.dispose();
     super.dispose();
   }
 
-  void _enterDemo() {
-    ref.read(sessionControllerProvider.notifier).enterDemo();
-    context.go(AppRoutes.dashboard);
+  void _backToSignIn() {
+    if (context.canPop()) {
+      context.pop();
+    } else {
+      context.go(AppRoutes.signIn);
+    }
   }
 
-  Future<void> _login() async {
+  Future<void> _register() async {
     if (_loading) return;
     final messenger = ScaffoldMessenger.of(context);
+    final name = _name.text.trim();
     final email = _email.text.trim();
     final password = _password.text;
+    final confirm = _passwordConfirm.text;
     if (email.isEmpty || password.isEmpty) {
-      messenger.showSnackBar(const SnackBar(content: Text('이메일과 비밀번호를 입력해 주세요')));
+      messenger.showSnackBar(
+        const SnackBar(content: Text('이메일과 비밀번호를 입력해 주세요')),
+      );
+      return;
+    }
+    if (password.length < 8) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('비밀번호는 8자 이상이어야 해요')),
+      );
+      return;
+    }
+    if (password != confirm) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('비밀번호가 일치하지 않아요')),
+      );
       return;
     }
     setState(() => _loading = true);
     try {
-      await ref.read(sessionControllerProvider.notifier).login(
-        email: email,
-        password: password,
-      );
+      await ref
+          .read(sessionControllerProvider.notifier)
+          .register(email: email, password: password, name: name);
       if (!mounted) return;
       context.go(AppRoutes.dashboard);
+    } on DioException catch (e) {
+      if (mounted) setState(() => _loading = false);
+      final msg = e.response?.statusCode == 409
+          ? '이미 가입된 이메일이에요. 로그인해 주세요.'
+          : '회원가입에 실패했어요. 잠시 후 다시 시도해 주세요.';
+      messenger.showSnackBar(SnackBar(content: Text(msg)));
     } catch (_) {
       if (mounted) setState(() => _loading = false);
       messenger.showSnackBar(
-        const SnackBar(content: Text('로그인에 실패했어요. 이메일·비밀번호를 확인해 주세요')),
+        const SnackBar(content: Text('회원가입에 실패했어요. 잠시 후 다시 시도해 주세요.')),
       );
     }
   }
@@ -68,16 +97,14 @@ class _SignInPageState extends ConsumerState<SignInPage> {
       body: SafeArea(
         child: Stack(
           children: <Widget>[
-            // 우측 상단 데모 바로가기
             Align(
-              alignment: Alignment.topRight,
+              alignment: Alignment.topLeft,
               child: Padding(
-                padding: const EdgeInsets.all(AppSpacing.sm),
-                child: TextButton.icon(
-                  onPressed: _enterDemo,
-                  style: TextButton.styleFrom(foregroundColor: AppColors.mutedForeground),
-                  icon: const Text('데모로 시작', style: TextStyle(fontSize: 13)),
-                  label: const Icon(Icons.arrow_forward, size: 16),
+                padding: const EdgeInsets.all(AppSpacing.xs),
+                child: IconButton(
+                  onPressed: _backToSignIn,
+                  icon: const Icon(Icons.arrow_back),
+                  color: AppColors.mutedForeground,
                 ),
               ),
             ),
@@ -90,26 +117,8 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: <Widget>[
-                      // 브랜드 — 온케어 로고
-                      Center(
-                        child: Container(
-                          width: 84,
-                          height: 84,
-                          padding: const EdgeInsets.all(8),
-                          decoration: BoxDecoration(
-                            color: AppColors.card,
-                            borderRadius: const BorderRadius.all(AppRadius.card),
-                            border: Border.all(color: AppColors.border),
-                          ),
-                          child: Image.asset(
-                            'assets/images/oncare-logo.png',
-                            fit: BoxFit.contain,
-                          ),
-                        ),
-                      ),
-                      const SizedBox(height: AppSpacing.lg),
                       Text(
-                        '온케어',
+                        '회원가입',
                         textAlign: TextAlign.center,
                         style: theme.textTheme.headlineSmall?.copyWith(
                           fontWeight: FontWeight.w700,
@@ -117,7 +126,7 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                       ),
                       const SizedBox(height: 4),
                       Text(
-                        '고혈압·당뇨 관리를 위한 AI 헬스케어',
+                        '온케어 계정을 만들어 건강 관리를 시작하세요',
                         textAlign: TextAlign.center,
                         style: theme.textTheme.bodyMedium?.copyWith(
                           color: AppColors.mutedForeground,
@@ -125,6 +134,12 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                       ),
                       const SizedBox(height: AppSpacing.xxl),
 
+                      AuthField(
+                        controller: _name,
+                        hint: '이름',
+                        icon: Icons.person_outline,
+                      ),
+                      const SizedBox(height: AppSpacing.md),
                       AuthField(
                         controller: _email,
                         hint: '이메일',
@@ -134,10 +149,9 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                       const SizedBox(height: AppSpacing.md),
                       AuthField(
                         controller: _password,
-                        hint: '비밀번호',
+                        hint: '비밀번호 (8자 이상)',
                         icon: Icons.lock_outline,
                         obscure: _obscure,
-                        onSubmitted: (_) => _login(),
                         trailing: IconButton(
                           icon: Icon(
                             _obscure ? Icons.visibility_off : Icons.visibility,
@@ -147,39 +161,37 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                           onPressed: () => setState(() => _obscure = !_obscure),
                         ),
                       ),
+                      const SizedBox(height: AppSpacing.md),
+                      AuthField(
+                        controller: _passwordConfirm,
+                        hint: '비밀번호 확인',
+                        icon: Icons.lock_outline,
+                        obscure: _obscure,
+                        onSubmitted: (_) => _register(),
+                      ),
                       const SizedBox(height: AppSpacing.xl),
 
-                      // 로그인 버튼(그라데이션)
                       AuthGradientButton(
                         loading: _loading,
-                        label: '로그인',
-                        onTap: _login,
+                        label: '가입하고 시작하기',
+                        onTap: _register,
                       ),
                       const SizedBox(height: AppSpacing.sm),
                       Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: <Widget>[
                           const Text(
-                            '계정이 없으신가요?',
+                            '이미 계정이 있으신가요?',
                             style: TextStyle(color: AppColors.mutedForeground),
                           ),
                           TextButton(
-                            onPressed: () => context.push(AppRoutes.signUp),
+                            onPressed: _backToSignIn,
                             style: TextButton.styleFrom(
                               foregroundColor: AppColors.primary,
                             ),
-                            child: const Text('회원가입'),
+                            child: const Text('로그인'),
                           ),
                         ],
-                      ),
-                      Center(
-                        child: TextButton(
-                          onPressed: _enterDemo,
-                          style: TextButton.styleFrom(
-                            foregroundColor: AppColors.primary,
-                          ),
-                          child: const Text('로그인 없이 데모 둘러보기'),
-                        ),
                       ),
                     ],
                   ),
@@ -192,4 +204,3 @@ class _SignInPageState extends ConsumerState<SignInPage> {
     );
   }
 }
-

--- a/frontend/flutter/lib/features/auth/presentation/widgets/auth_fields.dart
+++ b/frontend/flutter/lib/features/auth/presentation/widgets/auth_fields.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+
+import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/design_system/tokens/radius.dart';
+import 'package:oncare/design_system/tokens/spacing.dart';
+
+/// Brand gradient shared by the auth screens (sign-in / sign-up).
+const LinearGradient authBrandGradient = LinearGradient(
+  begin: Alignment.topLeft,
+  end: Alignment.bottomRight,
+  colors: <Color>[AppColors.primary, AppColors.secondary],
+);
+
+/// Filled, icon-prefixed text field used across the auth screens.
+class AuthField extends StatelessWidget {
+  const AuthField({
+    super.key,
+    required this.controller,
+    required this.hint,
+    required this.icon,
+    this.obscure = false,
+    this.keyboardType,
+    this.trailing,
+    this.onSubmitted,
+    this.textInputAction,
+  });
+
+  final TextEditingController controller;
+  final String hint;
+  final IconData icon;
+  final bool obscure;
+  final TextInputType? keyboardType;
+  final Widget? trailing;
+  final ValueChanged<String>? onSubmitted;
+  final TextInputAction? textInputAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      obscureText: obscure,
+      keyboardType: keyboardType,
+      textInputAction:
+          textInputAction ??
+          (onSubmitted != null ? TextInputAction.done : TextInputAction.next),
+      onSubmitted: onSubmitted,
+      decoration: InputDecoration(
+        hintText: hint,
+        prefixIcon: Icon(icon, color: AppColors.mutedForeground, size: 20),
+        suffixIcon: trailing,
+        filled: true,
+        fillColor: AppColors.inputBackground,
+        border: const OutlineInputBorder(
+          borderRadius: BorderRadius.all(AppRadius.lg),
+          borderSide: BorderSide.none,
+        ),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+          vertical: AppSpacing.md,
+        ),
+      ),
+    );
+  }
+}
+
+/// Full-width gradient CTA with an inline loading spinner, shared by the
+/// sign-in and sign-up screens.
+class AuthGradientButton extends StatelessWidget {
+  const AuthGradientButton({
+    super.key,
+    required this.label,
+    required this.onTap,
+    required this.loading,
+  });
+
+  final String label;
+  final VoidCallback onTap;
+  final bool loading;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      borderRadius: const BorderRadius.all(AppRadius.lg),
+      child: InkWell(
+        onTap: loading ? null : onTap,
+        borderRadius: const BorderRadius.all(AppRadius.lg),
+        child: Ink(
+          height: 52,
+          decoration: BoxDecoration(
+            gradient: loading ? null : authBrandGradient,
+            color: loading ? AppColors.muted : null,
+            borderRadius: const BorderRadius.all(AppRadius.lg),
+          ),
+          child: Center(
+            child: loading
+                ? const SizedBox(
+                    width: 22,
+                    height: 22,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      valueColor: AlwaysStoppedAnimation<Color>(
+                        AppColors.primary,
+                      ),
+                    ),
+                  )
+                : Text(
+                    label,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/flutter/test/app/router/session_redirect_test.dart
+++ b/frontend/flutter/test/app/router/session_redirect_test.dart
@@ -54,5 +54,19 @@ void main() {
         isNull,
       );
     });
+
+    test('sign-up route is public like sign-in', () {
+      // signed-out / restoring may reach it; already-in-app is bounced out.
+      expect(sessionRedirect(SessionStatus.signedOut, AppRoutes.signUp), isNull);
+      expect(sessionRedirect(SessionStatus.unknown, AppRoutes.signUp), isNull);
+      expect(
+        sessionRedirect(SessionStatus.demo, AppRoutes.signUp),
+        AppRoutes.dashboard,
+      );
+      expect(
+        sessionRedirect(SessionStatus.authenticated, AppRoutes.signUp),
+        AppRoutes.dashboard,
+      );
+    });
   });
 }

--- a/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
@@ -147,4 +147,40 @@ void main() {
     );
     expect(res.statusCode, 400);
   });
+
+  test('POST /auth/register creates a user (201) for valid input', () async {
+    final res = await dio.post<Map<String, Object?>>(
+      '/auth/register',
+      data: <String, Object?>{
+        'email': 'new@oncare.com',
+        'password': 'password123',
+        'name': '홍길동',
+      },
+    );
+    expect(res.statusCode, 201);
+    expect(res.data!['email'], 'new@oncare.com');
+    expect(res.data!['name'], '홍길동');
+    expect((res.data!['id']! as String).isNotEmpty, isTrue);
+  });
+
+  test('POST /auth/register defaults name to the email local-part', () async {
+    final res = await dio.post<Map<String, Object?>>(
+      '/auth/register',
+      data: <String, Object?>{
+        'email': 'solo@oncare.com',
+        'password': 'password123',
+      },
+    );
+    expect(res.statusCode, 201);
+    expect(res.data!['name'], 'solo');
+  });
+
+  test('POST /auth/register rejects empty credentials', () async {
+    final res = await dio.post<Map<String, Object?>>(
+      '/auth/register',
+      data: <String, Object?>{'email': '', 'password': ''},
+      options: Options(validateStatus: (int? s) => true),
+    );
+    expect(res.statusCode, 400);
+  });
 }


### PR DESCRIPTION
## 요약
인증 가드(#133) 위에 스택. **회원가입 화면**을 추가해 신규 계정 생성 경로를 연다. 가입 성공 시 동일 자격증명으로 자동 로그인 → 대시보드(라우터 가드가 인증 감지).

## 변경
- **회원가입 화면** (`sign_up_page.dart`, 신규): 이름·이메일·비밀번호·비밀번호 확인. 클라이언트 검증(필수 / 8자 이상 / 일치), 실패 메시지(409 = 이미 가입된 이메일), 로그인 링크·뒤로가기.
- **세션** (`session_controller.dart`): `register()` — `POST /auth/register` 후 동일 자격증명으로 `login()` 체인(가입 즉시 인증 진입).
- **라우터** (`routes.dart`, `app_router.dart`): `/auth/sign-up` 라우트 + 가드에서 **로그인/가입 경로를 공개 처리**(그 외는 로그인 강제 유지).
- **로그인 화면**: 공용 위젯 적용 + "회원가입" 링크.
- **공용 위젯** (`auth_fields.dart`, 신규): `AuthField`/`AuthGradientButton`을 로그인·가입이 공유(중복 제거).
- **목 백엔드** (`local_api_interceptor.dart`): `POST /auth/register` → FastAPI와 동일 `{id, name, email}` 201, 빈 값 400.

## 테스트
- 가드 회원가입 경로 케이스 + 목 register(201 / 기본 이름 / 400) — 신규 4건.
- `flutter analyze` 무경고 · `flutter test` **110 통과**. (실패 1건은 무관·기존 `app_button_golden_test` — 폰트 렌더링 환경차, CI 미포함.)

## 스택
base: `feature/frontend-auth-guard` (#133) — main 아님

Closes #134
