### PR TITLE
feat(account): 온보딩 화면 (가입 직후 초기 설정)

### DIFF
--- a/frontend/flutter/lib/app/router/app_router.dart
+++ b/frontend/flutter/lib/app/router/app_router.dart
@@ -8,6 +8,7 @@ import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/core/logging/app_logger.dart';
 import 'package:oncare/design_system/catalog/ui_catalog_page.dart';
+import 'package:oncare/features/account/presentation/pages/onboarding_page.dart';
 import 'package:oncare/features/ai_coach/presentation/pages/ai_coach_page.dart';
 import 'package:oncare/features/auth/presentation/controllers/session_controller.dart';
 import 'package:oncare/features/auth/presentation/pages/sign_in_page.dart';
@@ -123,6 +124,10 @@ GoRouter buildAppRouter({
       GoRoute(
         path: AppRoutes.signUp,
         builder: (context, state) => const SignUpPage(),
+      ),
+      GoRoute(
+        path: AppRoutes.onboarding,
+        builder: (context, state) => const OnboardingPage(),
       ),
       if (!config.isProd)
         GoRoute(

--- a/frontend/flutter/lib/app/router/routes.dart
+++ b/frontend/flutter/lib/app/router/routes.dart
@@ -18,6 +18,9 @@ class AppRoutes {
   static const String signIn = '/auth/sign-in';
   static const String signUp = '/auth/sign-up';
 
+  // First-run onboarding (shown right after sign-up)
+  static const String onboarding = '/onboarding';
+
   // Dev-only routes (registered only in non-prod builds).
   static const String uiCatalog = '/dev/ui-catalog';
 }

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -45,6 +45,7 @@ class LocalApiInterceptor extends Interceptor {
     'GET /users/me': _usersMe,
     'GET /users/me/profile': _usersMeProfile,
     'PUT /users/me': _usersMeUpdate,
+    'POST /users/me/onboarding': _usersMeOnboarding,
     'PUT /users/me/health-goals': _usersMeHealthGoals,
     'GET /users/me/health': _usersMeHealth,
     'GET /places/nearby': _placesNearby,
@@ -775,6 +776,32 @@ class LocalApiInterceptor extends Interceptor {
     ]) {
       if (body[k] != null) patch[k] = body[k];
     }
+    await _mergeProfileOverlay(patch);
+    return _ok(options, await _mergedProfile());
+  }
+
+  /// POST /users/me/onboarding — first-run setup. Persists any provided
+  /// fields and marks the profile onboarded; mirrors FastAPI's partial save.
+  Future<Response<Object?>> _usersMeOnboarding(RequestOptions options) async {
+    final body = _jsonBody(options);
+    final patch = <String, Object?>{};
+    for (final String k in <String>[
+      'name',
+      'birth_date',
+      'gender',
+      'height_cm',
+      'weight_kg',
+      'conditions',
+      'goals',
+      'goal_weight_kg',
+      'goal_bp_systolic',
+      'goal_blood_sugar',
+      'daily_calories',
+      'daily_sodium_mg',
+    ]) {
+      if (body[k] != null) patch[k] = body[k];
+    }
+    patch['onboarded'] = true;
     await _mergeProfileOverlay(patch);
     return _ok(options, await _mergedProfile());
   }

--- a/frontend/flutter/lib/features/account/data/repositories/dio_account_repository.dart
+++ b/frontend/flutter/lib/features/account/data/repositories/dio_account_repository.dart
@@ -14,6 +14,35 @@ class DioAccountRepository implements AccountRepository {
   }
 
   @override
+  Future<UserProfile> submitOnboarding({
+    String? birthDate,
+    String? gender,
+    num? heightCm,
+    num? weightKg,
+    String? conditions,
+    num? goalWeightKg,
+    int? goalBpSystolic,
+    int? goalBloodSugar,
+    int? dailySodiumMg,
+  }) async {
+    final res = await _dio.post<Map<String, Object?>>(
+      '/users/me/onboarding',
+      data: <String, Object?>{
+        'birth_date': ?birthDate,
+        'gender': ?gender,
+        'height_cm': ?heightCm,
+        'weight_kg': ?weightKg,
+        'conditions': ?conditions,
+        'goal_weight_kg': ?goalWeightKg,
+        'goal_bp_systolic': ?goalBpSystolic,
+        'goal_blood_sugar': ?goalBloodSugar,
+        'daily_sodium_mg': ?dailySodiumMg,
+      },
+    );
+    return UserProfile.fromJson(res.data!);
+  }
+
+  @override
   Future<UserProfile> updateProfile({
     String? name,
     String? email,

--- a/frontend/flutter/lib/features/account/data/repositories/mock_account_repository.dart
+++ b/frontend/flutter/lib/features/account/data/repositories/mock_account_repository.dart
@@ -23,6 +23,19 @@ class MockAccountRepository implements AccountRepository {
   Future<UserProfile> fetchProfile() async => _demo;
 
   @override
+  Future<UserProfile> submitOnboarding({
+    String? birthDate,
+    String? gender,
+    num? heightCm,
+    num? weightKg,
+    String? conditions,
+    num? goalWeightKg,
+    int? goalBpSystolic,
+    int? goalBloodSugar,
+    int? dailySodiumMg,
+  }) async => _demo;
+
+  @override
   Future<UserProfile> updateProfile({
     String? name,
     String? email,

--- a/frontend/flutter/lib/features/account/domain/repositories/account_repository.dart
+++ b/frontend/flutter/lib/features/account/domain/repositories/account_repository.dart
@@ -3,6 +3,20 @@ import 'package:oncare/features/account/domain/entities/user_profile.dart';
 abstract class AccountRepository {
   Future<UserProfile> fetchProfile();
 
+  /// POST /users/me/onboarding — first-run setup. All fields optional
+  /// (partial save allowed); the backend marks the profile onboarded.
+  Future<UserProfile> submitOnboarding({
+    String? birthDate,
+    String? gender,
+    num? heightCm,
+    num? weightKg,
+    String? conditions,
+    num? goalWeightKg,
+    int? goalBpSystolic,
+    int? goalBloodSugar,
+    int? dailySodiumMg,
+  });
+
   /// PUT /users/me — update basic profile (name/email/phone/birth).
   Future<UserProfile> updateProfile({
     String? name,

--- a/frontend/flutter/lib/features/account/presentation/pages/onboarding_page.dart
+++ b/frontend/flutter/lib/features/account/presentation/pages/onboarding_page.dart
@@ -1,0 +1,375 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:oncare/app/router/routes.dart';
+import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
+import 'package:oncare/features/auth/presentation/widgets/auth_fields.dart';
+
+/// First-run onboarding — a 3-step wizard shown right after sign-up.
+/// Collects basic info → chronic conditions → health goals, then
+/// POST /users/me/onboarding and enters the app. Fully skippable.
+class OnboardingPage extends ConsumerStatefulWidget {
+  const OnboardingPage({super.key});
+
+  @override
+  ConsumerState<OnboardingPage> createState() => _OnboardingPageState();
+}
+
+class _OnboardingPageState extends ConsumerState<OnboardingPage> {
+  static const int _steps = 3;
+  static const List<String> _conditionOptions = <String>[
+    '고혈압',
+    '당뇨',
+    '고지혈증',
+    '비만',
+  ];
+
+  final PageController _pager = PageController();
+  int _step = 0;
+  bool _saving = false;
+
+  final TextEditingController _birthDate = TextEditingController();
+  String? _gender; // 'male' | 'female' | 'other'
+  final TextEditingController _height = TextEditingController();
+  final TextEditingController _weight = TextEditingController();
+  final Set<String> _conditions = <String>{};
+  final TextEditingController _goalWeight = TextEditingController();
+  final TextEditingController _goalBp = TextEditingController();
+  final TextEditingController _goalSugar = TextEditingController();
+  final TextEditingController _dailySodium = TextEditingController();
+
+  @override
+  void dispose() {
+    _pager.dispose();
+    _birthDate.dispose();
+    _height.dispose();
+    _weight.dispose();
+    _goalWeight.dispose();
+    _goalBp.dispose();
+    _goalSugar.dispose();
+    _dailySodium.dispose();
+    super.dispose();
+  }
+
+  num? _num(TextEditingController c) => num.tryParse(c.text.trim());
+  int? _int(TextEditingController c) => int.tryParse(c.text.trim());
+
+  void _next() {
+    if (_step < _steps - 1) {
+      _pager.nextPage(
+        duration: const Duration(milliseconds: 250),
+        curve: Curves.easeOut,
+      );
+    }
+  }
+
+  void _back() {
+    if (_step > 0) {
+      _pager.previousPage(
+        duration: const Duration(milliseconds: 250),
+        curve: Curves.easeOut,
+      );
+    }
+  }
+
+  void _skip() => context.go(AppRoutes.dashboard);
+
+  Future<void> _finish() async {
+    if (_saving) return;
+    final messenger = ScaffoldMessenger.of(context);
+    setState(() => _saving = true);
+    try {
+      final birth = _birthDate.text.trim();
+      await ref
+          .read(accountRepositoryProvider)
+          .submitOnboarding(
+            birthDate: birth.isEmpty ? null : birth,
+            gender: _gender,
+            heightCm: _num(_height),
+            weightKg: _num(_weight),
+            conditions: _conditions.isEmpty ? null : _conditions.join(', '),
+            goalWeightKg: _num(_goalWeight),
+            goalBpSystolic: _int(_goalBp),
+            goalBloodSugar: _int(_goalSugar),
+            dailySodiumMg: _int(_dailySodium),
+          );
+      ref.invalidate(profileProvider);
+      if (!mounted) return;
+      context.go(AppRoutes.dashboard);
+    } catch (_) {
+      if (mounted) setState(() => _saving = false);
+      messenger.showSnackBar(
+        const SnackBar(content: Text('저장에 실패했어요. 잠시 후 다시 시도해 주세요')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isLast = _step == _steps - 1;
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        child: Column(
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppSpacing.lg,
+                AppSpacing.md,
+                AppSpacing.sm,
+                AppSpacing.sm,
+              ),
+              child: Row(
+                children: <Widget>[
+                  Text(
+                    '${_step + 1} / $_steps',
+                    style: const TextStyle(
+                      color: AppColors.mutedForeground,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const Spacer(),
+                  TextButton(
+                    onPressed: _skip,
+                    style: TextButton.styleFrom(
+                      foregroundColor: AppColors.mutedForeground,
+                    ),
+                    child: const Text('나중에 하기'),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(999),
+                child: LinearProgressIndicator(
+                  value: (_step + 1) / _steps,
+                  minHeight: 6,
+                  backgroundColor: AppColors.inputBackground,
+                  valueColor: const AlwaysStoppedAnimation<Color>(
+                    AppColors.primary,
+                  ),
+                ),
+              ),
+            ),
+            Expanded(
+              child: PageView(
+                controller: _pager,
+                physics: const NeverScrollableScrollPhysics(),
+                onPageChanged: (i) => setState(() => _step = i),
+                children: <Widget>[
+                  _stepBasic(),
+                  _stepConditions(),
+                  _stepGoals(),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(AppSpacing.lg),
+              child: Row(
+                children: <Widget>[
+                  if (_step > 0) ...<Widget>[
+                    OutlinedButton(
+                      onPressed: _saving ? null : _back,
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: AppColors.foreground,
+                        side: const BorderSide(color: AppColors.border),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: AppSpacing.lg,
+                          vertical: 16,
+                        ),
+                      ),
+                      child: const Text('이전'),
+                    ),
+                    const SizedBox(width: AppSpacing.md),
+                  ],
+                  Expanded(
+                    child: AuthGradientButton(
+                      loading: _saving,
+                      label: isLast ? '완료' : '다음',
+                      onTap: isLast ? _finish : _next,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _stepBody({
+    required String title,
+    required String subtitle,
+    required List<Widget> children,
+  }) {
+    final theme = Theme.of(context);
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.lg,
+        AppSpacing.xl,
+        AppSpacing.lg,
+        AppSpacing.lg,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Text(
+            title,
+            style: theme.textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            subtitle,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: AppColors.mutedForeground,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.xl),
+          ...children,
+        ],
+      ),
+    );
+  }
+
+  Widget _stepBasic() {
+    return _stepBody(
+      title: '기본 정보',
+      subtitle: '맞춤 건강 관리를 위해 기본 정보를 알려주세요.',
+      children: <Widget>[
+        AuthField(
+          controller: _birthDate,
+          hint: '생년월일 (YYYY-MM-DD)',
+          icon: Icons.cake_outlined,
+          keyboardType: TextInputType.datetime,
+        ),
+        const SizedBox(height: AppSpacing.md),
+        _GenderSelector(
+          value: _gender,
+          onChanged: (g) => setState(() => _gender = g),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        AuthField(
+          controller: _height,
+          hint: '키 (cm)',
+          icon: Icons.straighten,
+          keyboardType: TextInputType.number,
+        ),
+        const SizedBox(height: AppSpacing.md),
+        AuthField(
+          controller: _weight,
+          hint: '몸무게 (kg)',
+          icon: Icons.monitor_weight_outlined,
+          keyboardType: TextInputType.number,
+        ),
+      ],
+    );
+  }
+
+  Widget _stepConditions() {
+    return _stepBody(
+      title: '건강 상태',
+      subtitle: '관리 중인 만성질환을 선택해 주세요. (복수 선택 가능)',
+      children: <Widget>[
+        Wrap(
+          spacing: AppSpacing.sm,
+          runSpacing: AppSpacing.sm,
+          children: <Widget>[
+            for (final String c in _conditionOptions)
+              FilterChip(
+                label: Text(c),
+                selected: _conditions.contains(c),
+                onSelected: (sel) => setState(() {
+                  if (sel) {
+                    _conditions.add(c);
+                  } else {
+                    _conditions.remove(c);
+                  }
+                }),
+                selectedColor: AppColors.accent,
+                checkmarkColor: AppColors.secondary,
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _stepGoals() {
+    return _stepBody(
+      title: '건강 목표',
+      subtitle: '달성하고 싶은 목표를 입력해 주세요. 나중에 바꿀 수 있어요.',
+      children: <Widget>[
+        AuthField(
+          controller: _goalWeight,
+          hint: '목표 체중 (kg)',
+          icon: Icons.flag_outlined,
+          keyboardType: TextInputType.number,
+        ),
+        const SizedBox(height: AppSpacing.md),
+        AuthField(
+          controller: _goalBp,
+          hint: '목표 혈압 - 수축기 (mmHg)',
+          icon: Icons.favorite_outline,
+          keyboardType: TextInputType.number,
+        ),
+        const SizedBox(height: AppSpacing.md),
+        AuthField(
+          controller: _goalSugar,
+          hint: '목표 공복 혈당 (mg/dL)',
+          icon: Icons.water_drop_outlined,
+          keyboardType: TextInputType.number,
+        ),
+        const SizedBox(height: AppSpacing.md),
+        AuthField(
+          controller: _dailySodium,
+          hint: '하루 나트륨 목표 (mg)',
+          icon: Icons.spa_outlined,
+          keyboardType: TextInputType.number,
+        ),
+      ],
+    );
+  }
+}
+
+class _GenderSelector extends StatelessWidget {
+  const _GenderSelector({required this.value, required this.onChanged});
+  final String? value;
+  final ValueChanged<String?> onChanged;
+
+  static const Map<String, String> _labels = <String, String>{
+    'male': '남성',
+    'female': '여성',
+    'other': '기타',
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final entries = _labels.entries.toList();
+    return Row(
+      children: <Widget>[
+        for (int i = 0; i < entries.length; i++) ...<Widget>[
+          Expanded(
+            child: ChoiceChip(
+              label: SizedBox(
+                width: double.infinity,
+                child: Text(entries[i].value, textAlign: TextAlign.center),
+              ),
+              selected: value == entries[i].key,
+              onSelected: (_) => onChanged(entries[i].key),
+              selectedColor: AppColors.accent,
+            ),
+          ),
+          if (i < entries.length - 1) const SizedBox(width: AppSpacing.sm),
+        ],
+      ],
+    );
+  }
+}

--- a/frontend/flutter/lib/features/auth/presentation/pages/sign_up_page.dart
+++ b/frontend/flutter/lib/features/auth/presentation/pages/sign_up_page.dart
@@ -74,7 +74,9 @@ class _SignUpPageState extends ConsumerState<SignUpPage> {
           .read(sessionControllerProvider.notifier)
           .register(email: email, password: password, name: name);
       if (!mounted) return;
-      context.go(AppRoutes.dashboard);
+      // New accounts land in first-run onboarding; the guard keeps the
+      // (now authenticated) user on this protected route.
+      context.go(AppRoutes.onboarding);
     } on DioException catch (e) {
       if (mounted) setState(() => _loading = false);
       final msg = e.response?.statusCode == 409

--- a/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
@@ -183,4 +183,28 @@ void main() {
     );
     expect(res.statusCode, 400);
   });
+
+  test('POST /users/me/onboarding persists fields + onboarded flag', () async {
+    final res = await dio.post<Map<String, Object?>>(
+      '/users/me/onboarding',
+      data: <String, Object?>{
+        'birth_date': '1988-03-03',
+        'gender': 'female',
+        'conditions': '고혈압, 당뇨',
+        'goal_weight_kg': 62,
+        'daily_sodium_mg': 1500,
+      },
+    );
+    expect(res.statusCode, 200);
+    expect(res.data!['onboarded'], true);
+    expect(res.data!['gender'], 'female');
+
+    // GET /users/me/profile reflects the onboarding write.
+    final prof = await dio.get<Map<String, Object?>>('/users/me/profile');
+    expect(prof.data!['birth_date'], '1988-03-03');
+    expect(prof.data!['conditions'], '고혈압, 당뇨');
+    expect(prof.data!['goal_weight_kg'], 62);
+    expect(prof.data!['daily_sodium_mg'], 1500);
+    expect(prof.data!['onboarded'], true);
+  });
 }


### PR DESCRIPTION
## 요약
회원가입(#135) 위에 스택. **가입 직후 초기 설정 온보딩**을 추가한다. 3단계 위저드를 거쳐 `POST /users/me/onboarding` 후 대시보드로 진입하며, 언제든 건너뛸 수 있다.

## 변경
- **온보딩 위저드** (`onboarding_page.dart`, 신규): PageView 3스텝
  - ① 기본정보(생년월일·성별·키·몸무게) ② 만성질환(복수 선택 칩) ③ 건강목표(목표 체중·혈압·혈당·나트륨)
  - 진행바 + 이전/다음/완료, 상단 "나중에 하기" 건너뛰기.
- **API 배선**: `AccountRepository.submitOnboarding()` → `POST /users/me/onboarding`(부분 저장). 목 인터셉터가 `profile_overlay` 병합 + `onboarded=true`(FastAPI 동일).
- **라우팅**: `/onboarding` 최상위 전체화면(인증 보호). 회원가입 성공 시 대시보드 대신 온보딩으로.
- 완료 시 `profileProvider` 무효화 → My 화면에 즉시 반영.

## 테스트
- 목 온보딩(입력 영속 + `onboarded=true`, GET 프로필 반영) — 신규 1건.
- `flutter analyze` 무경고 · `flutter test` **111 통과**. (실패 1건은 무관·기존 `app_button_golden_test` — 폰트 렌더링 환경차, CI 미포함.)

## 스택
base: `feature/frontend-register` (#135) — main 아님

Closes #136
