### PR TITLE
feat(auth): 소셜 로그인 (카카오·구글)

### DIFF
--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -42,6 +42,8 @@ class LocalApiInterceptor extends Interceptor {
     'POST /ai-coach/chat': _aiCoachChat,
     'POST /auth/login': _authLogin,
     'POST /auth/register': _authRegister,
+    'POST /auth/social/kakao': _authSocial,
+    'POST /auth/social/google': _authSocial,
     'GET /users/me': _usersMe,
     'GET /users/me/profile': _usersMeProfile,
     'PUT /users/me': _usersMeUpdate,
@@ -704,6 +706,22 @@ class LocalApiInterceptor extends Interceptor {
         'email': email,
       },
     );
+  }
+
+  /// POST /auth/social/{provider} — the demo exchanges any non-empty
+  /// provider token for a session. Real provider-token verification is
+  /// done by FastAPI (+ provider SDK) when USE_MOCK_API=false.
+  Future<Response<Object?>> _authSocial(RequestOptions options) async {
+    final body = _jsonBody(options);
+    final token = (body['token'] as String? ?? '').trim();
+    if (token.isEmpty) {
+      return _badRequest(options, 'token is required');
+    }
+    return _ok(options, <String, Object?>{
+      'access_token': 'demo-social-${DateTime.now().microsecondsSinceEpoch}',
+      'refresh_token': 'demo-refresh',
+      'token_type': 'bearer',
+    });
   }
 
   // ---- Profile (내 프로필 / 건강 목표) — AppKeyValues 로 영속 ----

--- a/frontend/flutter/lib/features/auth/presentation/controllers/session_controller.dart
+++ b/frontend/flutter/lib/features/auth/presentation/controllers/session_controller.dart
@@ -43,17 +43,15 @@ class SessionController extends StateNotifier<SessionState> {
     }
   }
 
-  /// Email/password login → POST /auth/login (OAuth2 form). Throws on failure.
-  Future<void> login({required String email, required String password}) async {
-    final dio = _ref.read(dioProvider);
-    final res = await dio.post<Map<String, Object?>>(
-      '/auth/login',
-      data: <String, Object?>{'username': email, 'password': password},
-      options: Options(contentType: Headers.formUrlEncodedContentType),
-    );
-    final access = (res.data?['access_token'] as String?) ?? '';
-    final refresh = (res.data?['refresh_token'] as String?) ?? '';
-    if (access.isEmpty) throw Exception('로그인 응답에 토큰이 없습니다.');
+  /// Persist tokens from an auth response and flip to authenticated.
+  /// Shared by [login] and [socialLogin]. Throws if no access token.
+  Future<void> _applyTokens(
+    Map<String, Object?>? data, {
+    required String label,
+  }) async {
+    final access = (data?['access_token'] as String?) ?? '';
+    final refresh = (data?['refresh_token'] as String?) ?? '';
+    if (access.isEmpty) throw Exception('$label 응답에 토큰이 없습니다.');
     try {
       await _ref
           .read(secureTokenStoreProvider)
@@ -63,6 +61,31 @@ class SessionController extends StateNotifier<SessionState> {
     }
     _setToken(access);
     state = const SessionState(status: SessionStatus.authenticated);
+  }
+
+  /// Email/password login → POST /auth/login (OAuth2 form). Throws on failure.
+  Future<void> login({required String email, required String password}) async {
+    final dio = _ref.read(dioProvider);
+    final res = await dio.post<Map<String, Object?>>(
+      '/auth/login',
+      data: <String, Object?>{'username': email, 'password': password},
+      options: Options(contentType: Headers.formUrlEncodedContentType),
+    );
+    await _applyTokens(res.data, label: '로그인');
+  }
+
+  /// Social login — exchanges a provider (kakao/google) token for our
+  /// session via POST /auth/social/{provider}. Throws on failure.
+  Future<void> socialLogin({
+    required String provider,
+    required String token,
+  }) async {
+    final dio = _ref.read(dioProvider);
+    final res = await dio.post<Map<String, Object?>>(
+      '/auth/social/$provider',
+      data: <String, Object?>{'token': token},
+    );
+    await _applyTokens(res.data, label: '소셜 로그인');
   }
 
   /// Register a new account → POST /auth/register (returns the created

--- a/frontend/flutter/lib/features/auth/presentation/pages/sign_in_page.dart
+++ b/frontend/flutter/lib/features/auth/presentation/pages/sign_in_page.dart
@@ -60,6 +60,26 @@ class _SignInPageState extends ConsumerState<SignInPage> {
     }
   }
 
+  Future<void> _social(String provider) async {
+    if (_loading) return;
+    final messenger = ScaffoldMessenger.of(context);
+    setState(() => _loading = true);
+    try {
+      // 실기기 SDK(kakao/google) 연동 전까지는 데모 토큰을 보낸다. 실서버
+      // (USE_MOCK_API=false)에서는 FastAPI가 provider 토큰을 실제 검증한다.
+      await ref
+          .read(sessionControllerProvider.notifier)
+          .socialLogin(provider: provider, token: 'demo-$provider-token');
+      if (!mounted) return;
+      context.go(AppRoutes.dashboard);
+    } catch (_) {
+      if (mounted) setState(() => _loading = false);
+      messenger.showSnackBar(
+        const SnackBar(content: Text('소셜 로그인에 실패했어요. 잠시 후 다시 시도해 주세요')),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -155,7 +175,17 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                         label: '로그인',
                         onTap: _login,
                       ),
+                      const SizedBox(height: AppSpacing.lg),
+                      const _OrDivider(),
+                      const SizedBox(height: AppSpacing.lg),
+                      _SocialButton.kakao(
+                        onTap: _loading ? null : () => _social('kakao'),
+                      ),
                       const SizedBox(height: AppSpacing.sm),
+                      _SocialButton.google(
+                        onTap: _loading ? null : () => _social('google'),
+                      ),
+                      const SizedBox(height: AppSpacing.md),
                       Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: <Widget>[
@@ -187,6 +217,101 @@ class _SignInPageState extends ConsumerState<SignInPage> {
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// "— 또는 —" separator between the email login and social buttons.
+class _OrDivider extends StatelessWidget {
+  const _OrDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Row(
+      children: <Widget>[
+        Expanded(child: Divider(color: AppColors.border)),
+        Padding(
+          padding: EdgeInsets.symmetric(horizontal: AppSpacing.md),
+          child: Text(
+            '또는',
+            style: TextStyle(color: AppColors.mutedForeground, fontSize: 13),
+          ),
+        ),
+        Expanded(child: Divider(color: AppColors.border)),
+      ],
+    );
+  }
+}
+
+/// Provider-branded social sign-in button. Real SDK token acquisition is
+/// deferred; the [onTap] currently drives a demo-token exchange.
+class _SocialButton extends StatelessWidget {
+  const _SocialButton({
+    required this.label,
+    required this.icon,
+    required this.background,
+    required this.foreground,
+    required this.onTap,
+    this.border,
+    this.iconSize = 20,
+  });
+
+  factory _SocialButton.kakao({required VoidCallback? onTap}) => _SocialButton(
+    label: '카카오로 시작하기',
+    icon: Icons.chat_bubble_rounded,
+    background: const Color(0xFFFEE500),
+    foreground: const Color(0xFF191600),
+    onTap: onTap,
+  );
+
+  factory _SocialButton.google({required VoidCallback? onTap}) => _SocialButton(
+    label: '구글로 시작하기',
+    icon: Icons.g_mobiledata,
+    background: AppColors.card,
+    foreground: AppColors.foreground,
+    border: AppColors.border,
+    iconSize: 28,
+    onTap: onTap,
+  );
+
+  final String label;
+  final IconData icon;
+  final Color background;
+  final Color foreground;
+  final Color? border;
+  final double iconSize;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: background,
+      borderRadius: const BorderRadius.all(AppRadius.lg),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: const BorderRadius.all(AppRadius.lg),
+        child: Container(
+          height: 50,
+          decoration: BoxDecoration(
+            borderRadius: const BorderRadius.all(AppRadius.lg),
+            border: border != null ? Border.all(color: border!) : null,
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Icon(icon, color: foreground, size: iconSize),
+              const SizedBox(width: AppSpacing.sm),
+              Text(
+                label,
+                style: TextStyle(
+                  color: foreground,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
@@ -207,4 +207,23 @@ void main() {
     expect(prof.data!['daily_sodium_mg'], 1500);
     expect(prof.data!['onboarded'], true);
   });
+
+  test('POST /auth/social/kakao issues a token for a provider token', () async {
+    final res = await dio.post<Map<String, Object?>>(
+      '/auth/social/kakao',
+      data: <String, Object?>{'token': 'kakao-oauth-token'},
+    );
+    expect(res.statusCode, 200);
+    expect((res.data!['access_token']! as String).isNotEmpty, isTrue);
+    expect(res.data!['token_type'], 'bearer');
+  });
+
+  test('POST /auth/social/google rejects an empty provider token', () async {
+    final res = await dio.post<Map<String, Object?>>(
+      '/auth/social/google',
+      data: <String, Object?>{'token': ''},
+      options: Options(validateStatus: (int? s) => true),
+    );
+    expect(res.statusCode, 400);
+  });
 }


### PR DESCRIPTION
## 요약
온보딩(#137) 위에 스택. 로그인 화면에 **카카오·구글 소셜 로그인**을 추가한다. 탭 시 `POST /auth/social/{provider}`로 세션을 발급받아 대시보드로 진입한다.

## 변경
- **세션** (`session_controller.dart`): `socialLogin(provider, token)` → `POST /auth/social/{provider}`. 로그인/소셜의 토큰 저장 로직을 `_applyTokens`로 공통화(중복 제거).
- **로그인 화면** (`sign_in_page.dart`): 이메일 로그인 아래 "또는" 구분선 + 카카오(노랑)/구글(테두리) 버튼. 탭 → `socialLogin` → 대시보드, 실패 시 스낵바.
- **목 백엔드** (`local_api_interceptor.dart`): `POST /auth/social/{kakao,google}` — 임의 provider 토큰을 데모 세션으로 교환, 빈 토큰 400.

## 데모/실서버 경계
실기기 provider SDK(`kakao_flutter_sdk`/`google_sign_in`) 연동 전까지는 **데모 토큰**을 전송한다. `USE_MOCK_API=false`이면 FastAPI(+provider SDK)가 실제 토큰을 검증한다. (버튼~백엔드 배선은 완료; provider SDK 토큰 취득만 후속.)

## 테스트
- 목 소셜(토큰 발급 / 빈 토큰 400) — 신규 2건.
- `flutter analyze` 무경고 · `flutter test` **113 통과**. (실패 1건은 무관·기존 `app_button_golden_test` — 폰트 렌더링 환경차, CI 미포함.)

## 스택
base: `feature/frontend-onboarding` (#137) — main 아님

Closes #138
