### PR TITLE
feat(account): 회원 탈퇴 플로우

### DIFF
--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -47,6 +47,7 @@ class LocalApiInterceptor extends Interceptor {
     'GET /users/me': _usersMe,
     'GET /users/me/profile': _usersMeProfile,
     'PUT /users/me': _usersMeUpdate,
+    'DELETE /users/me': _usersMeDelete,
     'POST /users/me/onboarding': _usersMeOnboarding,
     'PUT /users/me/health-goals': _usersMeHealthGoals,
     'GET /users/me/health': _usersMeHealth,
@@ -796,6 +797,13 @@ class LocalApiInterceptor extends Interceptor {
     }
     await _mergeProfileOverlay(patch);
     return _ok(options, await _mergedProfile());
+  }
+
+  /// DELETE /users/me — withdraw. The demo wipes the profile overlay so a
+  /// subsequent session starts clean, mirroring FastAPI's cascade delete.
+  Future<Response<Object?>> _usersMeDelete(RequestOptions options) async {
+    await _db.putValue('profile_overlay', '');
+    return _ok(options, <String, Object?>{'status': 'deleted'});
   }
 
   /// POST /users/me/onboarding — first-run setup. Persists any provided

--- a/frontend/flutter/lib/features/account/data/repositories/dio_account_repository.dart
+++ b/frontend/flutter/lib/features/account/data/repositories/dio_account_repository.dart
@@ -14,6 +14,11 @@ class DioAccountRepository implements AccountRepository {
   }
 
   @override
+  Future<void> deleteAccount() async {
+    await _dio.delete<Map<String, Object?>>('/users/me');
+  }
+
+  @override
   Future<UserProfile> submitOnboarding({
     String? birthDate,
     String? gender,

--- a/frontend/flutter/lib/features/account/data/repositories/mock_account_repository.dart
+++ b/frontend/flutter/lib/features/account/data/repositories/mock_account_repository.dart
@@ -23,6 +23,9 @@ class MockAccountRepository implements AccountRepository {
   Future<UserProfile> fetchProfile() async => _demo;
 
   @override
+  Future<void> deleteAccount() async {}
+
+  @override
   Future<UserProfile> submitOnboarding({
     String? birthDate,
     String? gender,

--- a/frontend/flutter/lib/features/account/domain/repositories/account_repository.dart
+++ b/frontend/flutter/lib/features/account/domain/repositories/account_repository.dart
@@ -3,6 +3,11 @@ import 'package:oncare/features/account/domain/entities/user_profile.dart';
 abstract class AccountRepository {
   Future<UserProfile> fetchProfile();
 
+  /// DELETE /users/me — withdraw the account. The server cascade-deletes
+  /// the profile, diet/exercise/vitals, schedule, notifications and
+  /// linked social accounts.
+  Future<void> deleteAccount();
+
   /// POST /users/me/onboarding — first-run setup. All fields optional
   /// (partial save allowed); the backend marks the profile onboarded.
   Future<UserProfile> submitOnboarding({

--- a/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
@@ -7,6 +7,7 @@ import 'package:oncare/design_system/atoms/app_card.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/design_system/tokens/radius.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
 import 'package:oncare/features/auth/presentation/controllers/session_controller.dart';
 import 'package:oncare/features/my_health/domain/entities/health_history.dart';
 import 'package:oncare/features/my_health/presentation/controllers/my_health_controller.dart';
@@ -106,6 +107,8 @@ class _Body extends StatelessWidget {
             ),
             const SizedBox(height: AppSpacing.lg),
             const _SignOutButton(),
+            const SizedBox(height: AppSpacing.sm),
+            const _WithdrawButton(),
           ],
         ),
       ),
@@ -158,6 +161,59 @@ class _SignOutButton extends ConsumerWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _WithdrawButton extends ConsumerWidget {
+  const _WithdrawButton();
+
+  Future<void> _confirmAndWithdraw(BuildContext context, WidgetRef ref) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('회원 탈퇴'),
+        content: const Text(
+          '정말 탈퇴하시겠어요?\n'
+          '프로필·식단·운동·건강 기록이 모두 삭제되며 되돌릴 수 없어요.',
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('취소'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            style: TextButton.styleFrom(foregroundColor: AppColors.destructive),
+            child: const Text('탈퇴하기'),
+          ),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    try {
+      await ref.read(accountRepositoryProvider).deleteAccount();
+      // 세션을 로그아웃 상태로 전환 → 가드가 로그인 화면으로 되돌린다.
+      await ref.read(sessionControllerProvider.notifier).signOut();
+    } catch (_) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('탈퇴에 실패했어요. 잠시 후 다시 시도해 주세요')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Center(
+      child: TextButton(
+        onPressed: () => _confirmAndWithdraw(context, ref),
+        style: TextButton.styleFrom(foregroundColor: AppColors.mutedForeground),
+        child: const Text(
+          '회원 탈퇴',
+          style: TextStyle(decoration: TextDecoration.underline),
+        ),
       ),
     );
   }

--- a/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
@@ -226,4 +226,20 @@ void main() {
     );
     expect(res.statusCode, 400);
   });
+
+  test('DELETE /users/me withdraws and resets the profile overlay', () async {
+    // Seed an overlay so we can prove the delete wiped it.
+    await dio.put<Map<String, Object?>>(
+      '/users/me',
+      data: <String, Object?>{'name': '탈퇴예정'},
+    );
+
+    final del = await dio.delete<Map<String, Object?>>('/users/me');
+    expect(del.statusCode, 200);
+    expect(del.data!['status'], 'deleted');
+
+    // Overlay wiped → profile back to defaults.
+    final prof = await dio.get<Map<String, Object?>>('/users/me/profile');
+    expect(prof.data!['name'], '김민수');
+  });
 }


### PR DESCRIPTION
## 요약
소셜 로그인(#139) 위에 스택. **회원 탈퇴 플로우**를 추가해 계정 도메인 프론트 배선을 마무리한다. My 화면에서 탈퇴 시 `DELETE /users/me` 후 로그아웃되어 로그인 화면으로 돌아간다.

## 변경
- **API 배선**: `AccountRepository.deleteAccount()` → `DELETE /users/me`(cascade 삭제). 목 인터셉터는 `profile_overlay` 초기화 + `{status:deleted}` 반환.
- **My 화면** (`my_health_page.dart`): 설정 하단 위험영역에 "회원 탈퇴" 버튼 → 확인 다이얼로그(데이터 삭제·복구 불가 경고) → `deleteAccount()` → `signOut()`. 가드가 로그인 화면으로 복귀.

## 테스트
- 목 탈퇴(`{status:deleted}` + overlay 초기화 반영) — 신규 1건.
- `flutter analyze` 무경고 · `flutter test` **114 통과**. (실패 1건은 무관·기존 `app_button_golden_test` — 폰트 렌더링 환경차, CI 미포함.)

## 계정 도메인 완료
로그인(#131) → 가드/로그아웃(#133) → 회원가입(#135) → 온보딩(#137) → 소셜(#139) → **탈퇴(이 PR)**.

## 스택
base: `feature/frontend-social` (#139) — main 아님

Closes #140
