### PR TITLE
feat(schedule): 일정 생성 실연동

### DIFF
--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -37,6 +37,7 @@ class LocalApiInterceptor extends Interceptor {
     'GET /exercise/weeks/current': _exerciseCurrentWeek,
     'POST /exercise/sessions': _exerciseAddSession,
     'GET /schedule/events': _scheduleEvents,
+    'POST /schedule/events': _scheduleCreate,
     'GET /notifications': _notifications,
     'GET /ai-coach/feedback': _aiCoachFeedback,
     'POST /ai-coach/chat': _aiCoachChat,
@@ -539,6 +540,57 @@ class LocalApiInterceptor extends Interceptor {
         },
     ];
     return _ok(options, list);
+  }
+
+  /// Category → (emoji, color) so created events look consistent with the
+  /// seeded ones. Mirrors what a FastAPI build would fill server-side.
+  (String, String) _scheduleStyle(String category) => switch (category) {
+    'hospital' => ('🏥', '#DBEAFE'),
+    'exercise' => ('💪', '#DCFCE7'),
+    'meal' => ('🍽️', '#FFEDD5'),
+    'medication' => ('💊', '#EDE9FE'),
+    _ => ('📌', '#E0F2F7'),
+  };
+
+  /// POST /schedule/events — persist a new event to drift so it shows up in
+  /// GET /schedule/events and the dashboard's "오늘의 일정" for that date.
+  Future<Response<Object?>> _scheduleCreate(RequestOptions options) async {
+    final body = _jsonBody(options);
+    final date = (body['date'] as String? ?? '').trim();
+    final title = (body['title'] as String? ?? '').trim();
+    if (date.isEmpty || title.isEmpty) {
+      return _badRequest(options, 'date and title are required');
+    }
+    final time = (body['time'] as String? ?? '').trim();
+    final category = (body['category'] as String? ?? 'other').trim();
+    final (emoji, colorHex) = _scheduleStyle(category);
+    final id = 'evt-${DateTime.now().microsecondsSinceEpoch}';
+    await _db
+        .into(_db.scheduleEvents)
+        .insert(
+          ScheduleEventsCompanion.insert(
+            id: id,
+            date: date,
+            time: time,
+            title: title,
+            category: category,
+            emoji: Value(emoji),
+            colorHex: Value(colorHex),
+          ),
+        );
+    return Response<Object?>(
+      requestOptions: options,
+      statusCode: 201,
+      data: <String, Object?>{
+        'id': id,
+        'date': date,
+        'time': time,
+        'title': title,
+        'category': category,
+        'emoji': emoji,
+        'color_hex': colorHex,
+      },
+    );
   }
 
   // ---- Notifications ----

--- a/frontend/flutter/lib/features/schedule/data/repositories/dio_schedule_repository.dart
+++ b/frontend/flutter/lib/features/schedule/data/repositories/dio_schedule_repository.dart
@@ -21,4 +21,23 @@ class DioScheduleRepository implements ScheduleRepository {
         .map(ScheduleEvent.fromJson)
         .toList();
   }
+
+  @override
+  Future<ScheduleEvent> createEvent({
+    required String date,
+    required String title,
+    String time = '',
+    ScheduleCategory category = ScheduleCategory.other,
+  }) async {
+    final res = await _dio.post<Map<String, Object?>>(
+      '/schedule/events',
+      data: <String, Object?>{
+        'date': date,
+        'time': time,
+        'title': title,
+        'category': category.name,
+      },
+    );
+    return ScheduleEvent.fromJson(res.data!);
+  }
 }

--- a/frontend/flutter/lib/features/schedule/data/repositories/mock_schedule_repository.dart
+++ b/frontend/flutter/lib/features/schedule/data/repositories/mock_schedule_repository.dart
@@ -28,4 +28,20 @@ class MockScheduleRepository implements ScheduleRepository {
       ),
     ];
   }
+
+  @override
+  Future<ScheduleEvent> createEvent({
+    required String date,
+    required String title,
+    String time = '',
+    ScheduleCategory category = ScheduleCategory.other,
+  }) async {
+    return ScheduleEvent(
+      id: 'mock-${category.name}',
+      date: date,
+      time: time,
+      title: title,
+      category: category,
+    );
+  }
 }

--- a/frontend/flutter/lib/features/schedule/domain/repositories/schedule_repository.dart
+++ b/frontend/flutter/lib/features/schedule/domain/repositories/schedule_repository.dart
@@ -3,4 +3,13 @@ import 'package:oncare/features/schedule/domain/entities/schedule_event.dart';
 abstract class ScheduleRepository {
   /// Events whose `date` matches the given `YYYY-MM-DD` string.
   Future<List<ScheduleEvent>> fetchByDate(String date);
+
+  /// POST /schedule/events — create a calendar event. The server derives
+  /// the emoji/color from [category] and returns the stored event.
+  Future<ScheduleEvent> createEvent({
+    required String date,
+    required String title,
+    String time = '',
+    ScheduleCategory category = ScheduleCategory.other,
+  });
 }

--- a/frontend/flutter/lib/shared/widgets/modals/add_event_dialog.dart
+++ b/frontend/flutter/lib/shared/widgets/modals/add_event_dialog.dart
@@ -1,12 +1,22 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare/design_system/atoms/app_button.dart';
 import 'package:oncare/design_system/atoms/app_input.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/design_system/tokens/radius.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
+import 'package:oncare/features/schedule/domain/entities/schedule_event.dart';
+import 'package:oncare/features/schedule/presentation/controllers/schedule_controller.dart';
 
-const List<String> _categories = <String>['병원', '운동', '식사', '약 복용', '기타'];
+const Map<String, ScheduleCategory> _categoryMap = <String, ScheduleCategory>{
+  '병원': ScheduleCategory.hospital,
+  '운동': ScheduleCategory.exercise,
+  '식사': ScheduleCategory.meal,
+  '약 복용': ScheduleCategory.medication,
+  '기타': ScheduleCategory.other,
+};
 
 Future<void> showAddEventDialog(BuildContext context) {
   return showDialog<void>(
@@ -16,14 +26,68 @@ Future<void> showAddEventDialog(BuildContext context) {
   );
 }
 
-class _AddEventDialog extends StatefulWidget {
-  const _AddEventDialog();
-  @override
-  State<_AddEventDialog> createState() => _AddEventDialogState();
+String _todayString() {
+  final now = DateTime.now();
+  final mm = now.month.toString().padLeft(2, '0');
+  final dd = now.day.toString().padLeft(2, '0');
+  return '${now.year}-$mm-$dd';
 }
 
-class _AddEventDialogState extends State<_AddEventDialog> {
-  String _category = _categories.first;
+class _AddEventDialog extends ConsumerStatefulWidget {
+  const _AddEventDialog();
+  @override
+  ConsumerState<_AddEventDialog> createState() => _AddEventDialogState();
+}
+
+class _AddEventDialogState extends ConsumerState<_AddEventDialog> {
+  final TextEditingController _title = TextEditingController();
+  late final TextEditingController _date = TextEditingController(
+    text: _todayString(),
+  );
+  final TextEditingController _time = TextEditingController();
+  String _category = _categoryMap.keys.first;
+  bool _saving = false;
+
+  @override
+  void dispose() {
+    _title.dispose();
+    _date.dispose();
+    _time.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (_saving) return;
+    final messenger = ScaffoldMessenger.of(context);
+    final title = _title.text.trim();
+    final date = _date.text.trim();
+    if (title.isEmpty || date.isEmpty) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('제목과 날짜를 입력해 주세요')),
+      );
+      return;
+    }
+    setState(() => _saving = true);
+    try {
+      await ref
+          .read(scheduleRepositoryProvider)
+          .createEvent(
+            date: date,
+            time: _time.text.trim(),
+            title: title,
+            category: _categoryMap[_category] ?? ScheduleCategory.other,
+          );
+      // 오늘 일정이면 대시보드 "오늘의 일정"에 반영된다.
+      ref.invalidate(dashboardSummaryProvider);
+      if (!mounted) return;
+      Navigator.of(context).pop();
+    } catch (_) {
+      if (mounted) setState(() => _saving = false);
+      messenger.showSnackBar(
+        const SnackBar(content: Text('일정 추가에 실패했어요. 잠시 후 다시 시도해 주세요')),
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -68,11 +132,11 @@ class _AddEventDialogState extends State<_AddEventDialog> {
               ],
             ),
             const SizedBox(height: AppSpacing.md),
-            const AppInput(label: '일정 제목', hint: '예: 병원 정기검진'),
+            AppInput(controller: _title, label: '일정 제목', hint: '예: 병원 정기검진'),
             const SizedBox(height: AppSpacing.sm),
-            const AppInput(label: '날짜', hint: '2026-05-14'),
+            AppInput(controller: _date, label: '날짜', hint: '2026-05-14'),
             const SizedBox(height: AppSpacing.sm),
-            const AppInput(label: '시간', hint: '10:00'),
+            AppInput(controller: _time, label: '시간', hint: '10:00'),
             const SizedBox(height: AppSpacing.sm),
             Container(
               padding: const EdgeInsets.symmetric(
@@ -92,7 +156,7 @@ class _AddEventDialogState extends State<_AddEventDialog> {
                     if (value != null) setState(() => _category = value);
                   },
                   items: <DropdownMenuItem<String>>[
-                    for (final c in _categories)
+                    for (final String c in _categoryMap.keys)
                       DropdownMenuItem<String>(value: c, child: Text(c)),
                   ],
                 ),
@@ -100,9 +164,9 @@ class _AddEventDialogState extends State<_AddEventDialog> {
             ),
             const SizedBox(height: AppSpacing.lg),
             AppButton(
-              label: '추가하기',
+              label: _saving ? '추가 중...' : '추가하기',
               fullWidth: true,
-              onPressed: () => Navigator.of(context).pop(),
+              onPressed: _saving ? null : _submit,
             ),
           ],
         ),

--- a/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
@@ -242,4 +242,38 @@ void main() {
     final prof = await dio.get<Map<String, Object?>>('/users/me/profile');
     expect(prof.data!['name'], '김민수');
   });
+
+  test('POST /schedule/events persists; GET returns it for that date', () async {
+    final res = await dio.post<Map<String, Object?>>(
+      '/schedule/events',
+      data: <String, Object?>{
+        'date': '2026-07-04',
+        'time': '15:30',
+        'title': '치과 예약',
+        'category': 'hospital',
+      },
+    );
+    expect(res.statusCode, 201);
+    expect(res.data!['title'], '치과 예약');
+    expect(res.data!['emoji'], '🏥'); // derived from category
+    expect((res.data!['id']! as String).isNotEmpty, isTrue);
+
+    final list = await dio.get<List<Object?>>(
+      '/schedule/events',
+      queryParameters: <String, Object?>{'date': '2026-07-04'},
+    );
+    final titles = list.data!
+        .cast<Map<String, Object?>>()
+        .map((e) => e['title']);
+    expect(titles, contains('치과 예약'));
+  });
+
+  test('POST /schedule/events rejects a missing title', () async {
+    final res = await dio.post<Map<String, Object?>>(
+      '/schedule/events',
+      data: <String, Object?>{'date': '2026-07-04', 'title': ''},
+      options: Options(validateStatus: (int? s) => true),
+    );
+    expect(res.statusCode, 400);
+  });
 }


### PR DESCRIPTION
## 요약
회원 탈퇴(#141) 위에 스택. **일정 생성**을 실연동한다. 지금까지 조회만 됐고(대시보드 "오늘의 일정"), "일정 추가" 다이얼로그는 껍데기(추가하기 = 닫기만)였다.

## 변경
- **API 배선**: `ScheduleRepository.createEvent()` → `POST /schedule/events {date,time,title,category}`. 목 인터셉터가 카테고리 → 이모지/색을 파생해 **drift `scheduleEvents`에 저장** → GET·대시보드에 반영.
- **일정 추가 다이얼로그** (`add_event_dialog.dart`): 껍데기를 실동작으로 전환. 제목·날짜·시간·카테고리 입력(컨트롤러 연결), 제목·날짜 필수 검증, 날짜 오늘 기본값, 저장 중 버튼 비활성. 생성 후 `dashboardSummaryProvider` 무효화 → 대시보드 "오늘의 일정"에 즉시 반영.

## 테스트
- 목 일정 생성(201 + 이모지 파생 + GET 반영) / 제목 누락 400 — 신규 2건.
- `flutter analyze` 무경고 · `flutter test` **116 통과**. (실패 1건은 무관·기존 `app_button_golden_test` — 폰트 렌더링 환경차, CI 미포함.)

## 스택
base: `feature/frontend-withdraw` (#141) — main 아님

Closes #142
