### PR TITLE
feat(backend): 식단·운동 기록 삭제 API

### DIFF
--- a/backend/app/api/v1/diet.py
+++ b/backend/app/api/v1/diet.py
@@ -140,3 +140,22 @@ async def diet_analyze(
     )
 
     return DietAnalyzeResponse(entry_id=entry.id, analysis=analysis)
+
+
+@router.delete("/diet/entries/{entry_id}")
+def delete_entry(
+    entry_id: str,
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> dict:
+    """식단 기록 삭제. 본인 소유 엔트리만 삭제 가능(아니면 404)."""
+    row = db.scalar(
+        select(DietEntry)
+        .where(DietEntry.id == entry_id)
+        .where(DietEntry.user_id == current_user.id)
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="식단 기록을 찾을 수 없습니다.")
+    db.delete(row)
+    db.commit()
+    return {"status": "deleted"}

--- a/backend/app/api/v1/exercise.py
+++ b/backend/app/api/v1/exercise.py
@@ -78,3 +78,22 @@ def add_session(
     # 단건 응답도 프론트 표시 형식(date_label/time_label/items)을 채워 반환
     one = build_current_week([row])["sessions"][0]
     return ExerciseSessionOut(**one)
+
+
+@router.delete("/exercise/sessions/{session_id}")
+def delete_session(
+    session_id: str,
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> dict:
+    """운동 기록 삭제. 본인 소유 세션만 삭제 가능(아니면 404)."""
+    row = db.scalar(
+        select(ExerciseSession)
+        .where(ExerciseSession.id == session_id)
+        .where(ExerciseSession.user_id == current_user.id)
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="운동 기록을 찾을 수 없습니다.")
+    db.delete(row)
+    db.commit()
+    return {"status": "deleted"}

--- a/backend/tests/test_diet.py
+++ b/backend/tests/test_diet.py
@@ -44,3 +44,28 @@ def test_analyze_rejects_empty_file(client):
         data={"meal_type": "lunch"},
     )
     assert r.status_code == 400
+
+
+def test_delete_entry_removes_from_today(client):
+    # diet 테스트는 데모 사용자를 공유하므로(무인증) 전역 합계 대신
+    # 이 엔트리 id 의 유무로 검증한다.
+    entry_id = client.post(
+        "/v1/diet/analyze",
+        files={"image": ("food.jpg", _JPEG, "image/jpeg")},
+        data={"meal_type": "lunch"},
+    ).json()["entry_id"]
+
+    before = client.get("/v1/diet/days/today").json()["entries"]
+    assert any(e["id"] == entry_id for e in before)
+
+    d = client.delete(f"/v1/diet/entries/{entry_id}")
+    assert d.status_code == 200, d.text
+    assert d.json()["status"] == "deleted"
+
+    after = client.get("/v1/diet/days/today").json()["entries"]
+    assert all(e["id"] != entry_id for e in after)
+
+
+def test_delete_entry_404_when_missing(client):
+    r = client.delete("/v1/diet/entries/diet-nope")
+    assert r.status_code == 404

--- a/backend/tests/test_exercise.py
+++ b/backend/tests/test_exercise.py
@@ -37,3 +37,25 @@ def test_add_session_rejects_nonpositive_minutes(client):
     h = _login(client)
     r = client.post("/v1/exercise/sessions", json={"type": "cardio", "minutes": 0}, headers=h)
     assert r.status_code == 400
+
+
+def test_delete_session_removes_from_week(client):
+    h = _login(client)
+    sid = client.post(
+        "/v1/exercise/sessions",
+        json={"type": "cardio", "minutes": 40, "calories": 200, "day_label": "화"},
+        headers=h,
+    ).json()["id"]
+
+    d = client.delete(f"/v1/exercise/sessions/{sid}", headers=h)
+    assert d.status_code == 200, d.text
+    assert d.json()["status"] == "deleted"
+
+    week = client.get("/v1/exercise/weeks/current", headers=h)
+    assert week.json()["total_minutes"] == 0
+
+
+def test_delete_session_404_when_missing(client):
+    h = _login(client)
+    r = client.delete("/v1/exercise/sessions/ex-nope", headers=h)
+    assert r.status_code == 404


### PR DESCRIPTION
## 요약
일정 생성(#143) 위에 스택. 식단·운동 기록 **삭제 API**를 추가한다. 추가만 되고 삭제가 없던 문제를 해결한다. (프론트 삭제 UI는 이 위에 스택될 별도 PR.)

## 변경
- `DELETE /diet/entries/{entry_id}` (`diet.py`) — 본인 식단 기록 삭제.
- `DELETE /exercise/sessions/{session_id}` (`exercise.py`) — 본인 운동 기록 삭제.
- 둘 다 **user_id 스코프**로 소유 검증. 없거나 타인 소유면 **404**. 삭제는 오늘 식단 집계/이번 주 운동 집계에 반영.

## 테스트
- `test_diet.py` / `test_exercise.py`: 생성 → 삭제 → 집계 0, 없는 id → 404 (신규 4건).
- DB 필요라 로컬 skip, **CI(pgvector)에서 실행**. 로컬은 ruff 통과.

## 스택
base: `feature/frontend-schedule-create` (#143) — main 아님

Closes #144
