### PR TITLE
feat(diet): 식단·운동 기록 삭제 UI

### DIFF
--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -87,8 +87,12 @@ class LocalApiInterceptor extends Interceptor {
         _logger.d('[local-api] $key (exact)');
         return await exact(options);
       }
-      // (Regex routes will be added by later phases — diet/exercise/
-      // vitals/notifications/schedule etc.)
+      // Path-param routes (can't be keyed exactly) — e.g. DELETE by id.
+      final param = _paramRoute(method, path);
+      if (param != null) {
+        _logger.d('[local-api] $key (param)');
+        return await param(options);
+      }
       return null;
     } catch (e, st) {
       _logger.e('[local-api] $key failed', error: e, stackTrace: st);
@@ -101,6 +105,36 @@ class LocalApiInterceptor extends Interceptor {
         },
       );
     }
+  }
+
+  /// Resolve a handler for path-param routes (id in the URL). Returns null
+  /// if none matches so [_safeHandle] falls through to the real network.
+  _Handler? _paramRoute(String method, String path) {
+    if (method == 'DELETE' && path.startsWith('/diet/entries/')) {
+      return _dietDelete;
+    }
+    if (method == 'DELETE' && path.startsWith('/exercise/sessions/')) {
+      return _exerciseDelete;
+    }
+    return null;
+  }
+
+  Future<Response<Object?>> _dietDelete(RequestOptions options) async {
+    final id = options.path.split('/').last;
+    final n = await (_db.delete(
+      _db.dietEntries,
+    )..where((t) => t.id.equals(id))).go();
+    if (n == 0) return _notFound(options, '식단 기록을 찾을 수 없습니다.');
+    return _ok(options, <String, Object?>{'status': 'deleted'});
+  }
+
+  Future<Response<Object?>> _exerciseDelete(RequestOptions options) async {
+    final id = options.path.split('/').last;
+    final n = await (_db.delete(
+      _db.exerciseSessions,
+    )..where((t) => t.id.equals(id))).go();
+    if (n == 0) return _notFound(options, '운동 기록을 찾을 수 없습니다.');
+    return _ok(options, <String, Object?>{'status': 'deleted'});
   }
 
   // ---- handlers ----
@@ -1159,6 +1193,14 @@ class LocalApiInterceptor extends Interceptor {
       requestOptions: options,
       statusCode: 400,
       data: <String, Object?>{'code': 'bad_request', 'message': message},
+    );
+  }
+
+  Response<Object?> _notFound(RequestOptions options, String message) {
+    return Response<Object?>(
+      requestOptions: options,
+      statusCode: 404,
+      data: <String, Object?>{'code': 'not_found', 'message': message},
     );
   }
 

--- a/frontend/flutter/lib/features/diet/data/repositories/dio_diet_repository.dart
+++ b/frontend/flutter/lib/features/diet/data/repositories/dio_diet_repository.dart
@@ -40,4 +40,9 @@ class DioDietRepository implements DietRepository {
     );
     return DietAnalysisResult.fromResponse(res.data!);
   }
+
+  @override
+  Future<void> deleteEntry(String id) async {
+    await _dio.delete<Map<String, Object?>>('/diet/entries/$id');
+  }
 }

--- a/frontend/flutter/lib/features/diet/data/repositories/mock_diet_repository.dart
+++ b/frontend/flutter/lib/features/diet/data/repositories/mock_diet_repository.dart
@@ -74,4 +74,7 @@ class MockDietRepository implements DietRepository {
       aiCoachMessage: '오늘 점심에 나트륨이 많았어요. 저녁은 담백한 구이/샐러드로 균형을 맞춰봐요!',
     );
   }
+
+  @override
+  Future<void> deleteEntry(String id) async {}
 }

--- a/frontend/flutter/lib/features/diet/domain/repositories/diet_repository.dart
+++ b/frontend/flutter/lib/features/diet/domain/repositories/diet_repository.dart
@@ -14,4 +14,7 @@ abstract class DietRepository {
     required String filename,
     required String mealType,
   });
+
+  /// DELETE /diet/entries/{id} — remove a diet entry.
+  Future<void> deleteEntry(String id);
 }

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -17,6 +17,7 @@ import 'package:oncare/shared/widgets/error_view.dart';
 import 'package:oncare/shared/widgets/modals/right_slide_panel.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
 import 'package:oncare/shared/widgets/oncare_header.dart';
+import 'package:oncare/shared/widgets/swipe_to_delete.dart';
 
 class DietRecordPage extends ConsumerStatefulWidget {
   const DietRecordPage({super.key});
@@ -34,6 +35,18 @@ class _DietRecordPageState extends ConsumerState<DietRecordPage> {
     if (h < 15) return 'lunch';
     if (h < 21) return 'dinner';
     return 'snack';
+  }
+
+  Future<void> _deleteDietEntry(String id) async {
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref.read(dietRepositoryProvider).deleteEntry(id);
+      ref.invalidate(dietTodayProvider); // 삭제가 오늘 목록·요약에 반영
+    } catch (_) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('삭제에 실패했어요. 잠시 후 다시 시도해 주세요')),
+      );
+    }
   }
 
   Future<ImageSource?> _pickSource() {
@@ -139,7 +152,15 @@ class _DietRecordPageState extends ConsumerState<DietRecordPage> {
                         ),
                       ),
                       for (final entry in day.entries) ...<Widget>[
-                        MealCard(entry: entry),
+                        if (entry.id == null)
+                          MealCard(entry: entry)
+                        else
+                          SwipeToDelete(
+                            dismissKey: ValueKey<String>('diet-${entry.id}'),
+                            message: '이 식단 기록을 삭제할까요?',
+                            onDelete: () => _deleteDietEntry(entry.id!),
+                            child: MealCard(entry: entry),
+                          ),
                         const SizedBox(height: AppSpacing.sm),
                       ],
                     ],

--- a/frontend/flutter/lib/features/exercise/data/repositories/dio_exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/dio_exercise_repository.dart
@@ -33,4 +33,9 @@ class DioExerciseRepository implements ExerciseRepository {
     );
     return ExerciseSession.fromJson(res.data!);
   }
+
+  @override
+  Future<void> deleteSession(String id) async {
+    await _dio.delete<Map<String, Object?>>('/exercise/sessions/$id');
+  }
 }

--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
@@ -89,4 +89,7 @@ class MockExerciseRepository implements ExerciseRepository {
       ],
     );
   }
+
+  @override
+  Future<void> deleteSession(String id) async {}
 }

--- a/frontend/flutter/lib/features/exercise/domain/repositories/exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/domain/repositories/exercise_repository.dart
@@ -11,4 +11,7 @@ abstract class ExerciseRepository {
     required int calories,
     required String dayLabel,
   });
+
+  /// DELETE /exercise/sessions/{id} — remove a workout session.
+  Future<void> deleteSession(String id);
 }

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/workout_record_tab.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/workout_record_tab.dart
@@ -11,6 +11,7 @@ import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/shared/widgets/ai_coach_card.dart';
 import 'package:oncare/shared/widgets/error_view.dart';
+import 'package:oncare/shared/widgets/swipe_to_delete.dart';
 
 /// 운동 기록 tab body. Stat row → stacked weekly chart → AI feedback
 /// (unchanged AiCoachCard) → grouped session history. The FAB lives
@@ -34,12 +35,24 @@ class WorkoutRecordTab extends ConsumerWidget {
   }
 }
 
-class _Body extends StatelessWidget {
+class _Body extends ConsumerWidget {
   const _Body({required this.week});
   final ExerciseWeek week;
 
+  Future<void> _delete(BuildContext context, WidgetRef ref, String id) async {
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref.read(exerciseRepositoryProvider).deleteSession(id);
+      ref.invalidate(exerciseWeekProvider); // 삭제가 이번 주 집계에 반영
+    } catch (_) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('삭제에 실패했어요. 잠시 후 다시 시도해 주세요')),
+      );
+    }
+  }
+
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final hasStackedSeries =
         week.cardioMinutes.isNotEmpty ||
@@ -150,7 +163,15 @@ class _Body extends StatelessWidget {
         const SizedBox(height: AppSpacing.lg),
 
         for (final s in week.sessions) ...<Widget>[
-          _SessionCard(session: s),
+          if (s.id == null)
+            _SessionCard(session: s)
+          else
+            SwipeToDelete(
+              dismissKey: ValueKey<String>('ex-${s.id}'),
+              message: '이 운동 기록을 삭제할까요?',
+              onDelete: () => _delete(context, ref, s.id!),
+              child: _SessionCard(session: s),
+            ),
           const SizedBox(height: AppSpacing.sm),
         ],
       ],

--- a/frontend/flutter/lib/shared/widgets/swipe_to_delete.dart
+++ b/frontend/flutter/lib/shared/widgets/swipe_to_delete.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/design_system/tokens/radius.dart';
+import 'package:oncare/design_system/tokens/spacing.dart';
+
+/// Wraps [child] with swipe-to-delete (end→start) behind a confirm dialog.
+///
+/// [onDelete] performs the actual removal (repo call + provider
+/// invalidation). `confirmDismiss` always returns false: the deletion is
+/// reflected by re-rendering the list from its now-invalidated source, so
+/// the Dismissible never leaves the tree half-removed.
+class SwipeToDelete extends StatelessWidget {
+  const SwipeToDelete({
+    super.key,
+    required this.dismissKey,
+    required this.onDelete,
+    required this.child,
+    this.title = '삭제',
+    this.message = '이 기록을 삭제할까요?',
+  });
+
+  final Key dismissKey;
+  final Future<void> Function() onDelete;
+  final Widget child;
+  final String title;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dismissible(
+      key: dismissKey,
+      direction: DismissDirection.endToStart,
+      background: Container(
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: AppSpacing.lg),
+        decoration: const BoxDecoration(
+          color: AppColors.destructive,
+          borderRadius: BorderRadius.all(AppRadius.card),
+        ),
+        child: const Icon(Icons.delete_outline, color: Colors.white),
+      ),
+      confirmDismiss: (_) async {
+        final ok = await showDialog<bool>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: Text(title),
+            content: Text(message),
+            actions: <Widget>[
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(false),
+                child: const Text('취소'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(true),
+                style: TextButton.styleFrom(
+                  foregroundColor: AppColors.destructive,
+                ),
+                child: const Text('삭제'),
+              ),
+            ],
+          ),
+        );
+        if (ok != true) return false;
+        await onDelete();
+        return false; // the list re-renders from its invalidated source
+      },
+      child: child,
+    );
+  }
+}

--- a/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
@@ -276,4 +276,56 @@ void main() {
     );
     expect(res.statusCode, 400);
   });
+
+  test('DELETE /diet/entries/{id} deletes an entry; 404 once gone', () async {
+    await db
+        .into(db.dietEntries)
+        .insert(
+          DietEntriesCompanion.insert(
+            id: 'del-diet-1',
+            date: '2026-07-04',
+            mealType: 'lunch',
+            timeLabel: '12:00',
+            foodsJson: '[]',
+            totalCalories: 100,
+          ),
+        );
+
+    final ok = await dio.delete<Map<String, Object?>>('/diet/entries/del-diet-1');
+    expect(ok.statusCode, 200);
+    expect(ok.data!['status'], 'deleted');
+
+    final gone = await dio.delete<Map<String, Object?>>(
+      '/diet/entries/del-diet-1',
+      options: Options(validateStatus: (int? s) => true),
+    );
+    expect(gone.statusCode, 404);
+  });
+
+  test('DELETE /exercise/sessions/{id} deletes a session; 404 once gone', () async {
+    await db
+        .into(db.exerciseSessions)
+        .insert(
+          ExerciseSessionsCompanion.insert(
+            id: 'del-ex-1',
+            weekStart: '2026-06-29',
+            dayLabel: '월',
+            type: 'cardio',
+            minutes: 30,
+            calories: 200,
+          ),
+        );
+
+    final ok = await dio.delete<Map<String, Object?>>(
+      '/exercise/sessions/del-ex-1',
+    );
+    expect(ok.statusCode, 200);
+    expect(ok.data!['status'], 'deleted');
+
+    final gone = await dio.delete<Map<String, Object?>>(
+      '/exercise/sessions/del-ex-1',
+      options: Options(validateStatus: (int? s) => true),
+    );
+    expect(gone.statusCode, 404);
+  });
 }


### PR DESCRIPTION
## 요약
백엔드 삭제 API(#145) 위에 스택. 식단·운동 기록을 **스와이프로 삭제**하는 UI를 추가한다. 지금까지 추가만 되고 삭제가 없던 문제를 해결한다.

## 변경
- **공용 위젯** (`swipe_to_delete.dart`, 신규): 스와이프(→) + 확인 다이얼로그. `confirmDismiss`가 항상 false를 반환하고, 삭제는 소스 무효화로 재렌더해 Dismissible이 트리에 반쯤 남는 문제를 피한다.
- **API 배선**: `DietRepository.deleteEntry()` / `ExerciseRepository.deleteSession()` → `DELETE /diet/entries/{id}` / `DELETE /exercise/sessions/{id}`.
- **목 인터셉터**: **경로 파라미터 dispatch(`_paramRoute`)** 도입(현재 exact-match만 지원했음). drift에서 행 삭제, 없으면 404.
- **UI 적용**: 식단 `MealCard`·운동 세션 카드에 스와이프 삭제. 삭제 후 `dietTodayProvider`/`exerciseWeekProvider` 무효화 → 목록·집계 즉시 반영.

## 테스트
- 목 삭제(존재 → 200, 재삭제 → 404) diet/exercise 각 1건 — 신규 2건.
- `flutter analyze` 무경고 · `flutter test` **118 통과**. (실패 1건은 무관·기존 `app_button_golden_test` — 폰트 렌더링 환경차, CI 미포함.)

## 스택
base: `feature/backend-records-delete` (#145) — main 아님

Closes #146
