### PR TITLE
feat(backend): 식단·운동 기록 수정 API

### DIFF
--- a/backend/app/api/v1/diet.py
+++ b/backend/app/api/v1/diet.py
@@ -23,7 +23,7 @@ from app.core.config import get_settings
 from app.db.session import get_db
 from app.models.models import DietEntry
 from app.schemas.diet_api import (
-    DietAnalyzeResponse, DietEntryOut, DietTodayResponse, Macros,
+    DietAnalyzeResponse, DietEntryOut, DietEntryUpdate, DietTodayResponse, Macros,
 )
 from app.services.coach.personal_ingest import record_diet
 from app.services.nutrition.enrich import enrich_analysis
@@ -140,6 +140,35 @@ async def diet_analyze(
     )
 
     return DietAnalyzeResponse(entry_id=entry.id, analysis=analysis)
+
+
+@router.put("/diet/entries/{entry_id}", response_model=DietEntryOut)
+def update_entry(
+    entry_id: str,
+    payload: DietEntryUpdate,
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> DietEntryOut:
+    """식단 기록의 끼니 분류/시간 수정(본인 소유만, 아니면 404)."""
+    row = db.scalar(
+        select(DietEntry)
+        .where(DietEntry.id == entry_id)
+        .where(DietEntry.user_id == current_user.id)
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="식단 기록을 찾을 수 없습니다.")
+    if payload.meal_type is not None:
+        row.meal_type = payload.meal_type
+    if payload.time_label is not None:
+        row.time_label = payload.time_label
+    db.commit()
+    db.refresh(row)
+    foods = json.loads(row.foods_json) if row.foods_json else []
+    return DietEntryOut(
+        id=row.id, meal_type=row.meal_type, time_label=row.time_label,
+        foods=foods, total_calories=row.total_calories,
+        sodium_mg=row.sodium_mg, sugar_g=row.sugar_g,
+    )
 
 
 @router.delete("/diet/entries/{entry_id}")

--- a/backend/app/api/v1/exercise.py
+++ b/backend/app/api/v1/exercise.py
@@ -80,6 +80,42 @@ def add_session(
     return ExerciseSessionOut(**one)
 
 
+@router.put("/exercise/sessions/{session_id}", response_model=ExerciseSessionOut)
+def update_session(
+    session_id: str,
+    payload: ExerciseSessionCreate,
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> ExerciseSessionOut:
+    """운동 기록 수정(본인 소유만, 아니면 404). 유형/시간/칼로리/요일 갱신."""
+    if payload.type not in _ALLOWED_TYPES:
+        raise HTTPException(status_code=400, detail=f"허용되지 않는 운동 타입: {payload.type}")
+    if payload.minutes <= 0:
+        raise HTTPException(status_code=400, detail="minutes 는 1 이상이어야 합니다.")
+
+    row = db.scalar(
+        select(ExerciseSession)
+        .where(ExerciseSession.id == session_id)
+        .where(ExerciseSession.user_id == current_user.id)
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="운동 기록을 찾을 수 없습니다.")
+
+    day_label = payload.day_label or row.day_label
+    if day_label not in WEEKDAY_LABELS:
+        raise HTTPException(status_code=400, detail=f"잘못된 요일 라벨: {day_label}")
+
+    row.type = payload.type
+    row.minutes = payload.minutes
+    row.calories = payload.calories
+    row.day_label = day_label
+    db.commit()
+    db.refresh(row)
+
+    one = build_current_week([row])["sessions"][0]
+    return ExerciseSessionOut(**one)
+
+
 @router.delete("/exercise/sessions/{session_id}")
 def delete_session(
     session_id: str,

--- a/backend/app/schemas/diet_api.py
+++ b/backend/app/schemas/diet_api.py
@@ -29,6 +29,13 @@ class DietEntryOut(BaseModel):
     sugar_g: int
 
 
+class DietEntryUpdate(BaseModel):
+    """PUT /diet/entries/{id} — 끼니 분류/시간 수정(부분 저장). 음식/영양은
+    분석 결과라 여기서 바꾸지 않는다."""
+    meal_type: str | None = None
+    time_label: str | None = None
+
+
 class DietTodayResponse(BaseModel):
     entries: list[DietEntryOut]
     total_calories: int

--- a/backend/tests/test_diet.py
+++ b/backend/tests/test_diet.py
@@ -69,3 +69,29 @@ def test_delete_entry_removes_from_today(client):
 def test_delete_entry_404_when_missing(client):
     r = client.delete("/v1/diet/entries/diet-nope")
     assert r.status_code == 404
+
+
+def test_update_entry_changes_meal_type(client):
+    entry_id = client.post(
+        "/v1/diet/analyze",
+        files={"image": ("food.jpg", _JPEG, "image/jpeg")},
+        data={"meal_type": "lunch"},
+    ).json()["entry_id"]
+
+    r = client.put(
+        f"/v1/diet/entries/{entry_id}",
+        json={"meal_type": "dinner", "time_label": "19:30"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["meal_type"] == "dinner"
+    assert r.json()["time_label"] == "19:30"
+
+    # 공유 데모 사용자라 전역 합계 대신 id 로 확인.
+    today = client.get("/v1/diet/days/today").json()["entries"]
+    mine = next(e for e in today if e["id"] == entry_id)
+    assert mine["meal_type"] == "dinner"
+
+
+def test_update_entry_404_when_missing(client):
+    r = client.put("/v1/diet/entries/diet-nope", json={"meal_type": "dinner"})
+    assert r.status_code == 404

--- a/backend/tests/test_exercise.py
+++ b/backend/tests/test_exercise.py
@@ -59,3 +59,49 @@ def test_delete_session_404_when_missing(client):
     h = _login(client)
     r = client.delete("/v1/exercise/sessions/ex-nope", headers=h)
     assert r.status_code == 404
+
+
+def test_update_session_changes_week(client):
+    h = _login(client)
+    sid = client.post(
+        "/v1/exercise/sessions",
+        json={"type": "cardio", "minutes": 30, "calories": 150, "day_label": "월"},
+        headers=h,
+    ).json()["id"]
+
+    r = client.put(
+        f"/v1/exercise/sessions/{sid}",
+        json={"type": "strength", "minutes": 50, "calories": 250, "day_label": "화"},
+        headers=h,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["type"] == "strength"
+    assert r.json()["minutes"] == 50
+
+    week = client.get("/v1/exercise/weeks/current", headers=h)
+    assert week.json()["total_minutes"] == 50
+
+
+def test_update_session_404_when_missing(client):
+    h = _login(client)
+    r = client.put(
+        "/v1/exercise/sessions/ex-nope",
+        json={"type": "cardio", "minutes": 20},
+        headers=h,
+    )
+    assert r.status_code == 404
+
+
+def test_update_session_rejects_bad_type(client):
+    h = _login(client)
+    sid = client.post(
+        "/v1/exercise/sessions",
+        json={"type": "cardio", "minutes": 30, "day_label": "월"},
+        headers=h,
+    ).json()["id"]
+    r = client.put(
+        f"/v1/exercise/sessions/{sid}",
+        json={"type": "flying", "minutes": 20},
+        headers=h,
+    )
+    assert r.status_code == 400


### PR DESCRIPTION
## 요약
삭제 UI(#147) 위에 스택. 식단·운동 기록 **수정 API**를 추가한다. (프론트 수정 UI는 이 위에 스택될 별도 PR.)

## 변경
- `PUT /exercise/sessions/{id}` (`exercise.py`) — 유형·시간·칼로리·요일 수정. `ExerciseSessionCreate` 재사용, 타입/시간 검증.
- `PUT /diet/entries/{id}` (`diet.py`) — 끼니 분류·시간 수정. 신규 `DietEntryUpdate`(부분 저장). 음식/영양은 분석 결과라 제외.
- 둘 다 **user_id 스코프** 소유 검증. 없으면 **404**, 잘못된 운동 타입/시간은 **400**. 수정은 집계·조회에 반영.

## 테스트
- `test_exercise.py`: 수정→주간 반영, 404, 잘못된 타입 400 (신규 3건).
- `test_diet.py`: 끼니 수정→조회 반영(id 기준), 404 (신규 2건).
- DB 필요라 로컬 skip, **CI(pgvector)에서 실행**. 로컬 ruff 통과.

## 스택
base: `feature/frontend-records-delete` (#147) — main 아님

Closes #148
