### PR TITLE
feat(diet): 식단·운동 기록 수정 UI

### DIFF
--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -116,6 +116,12 @@ class LocalApiInterceptor extends Interceptor {
     if (method == 'DELETE' && path.startsWith('/exercise/sessions/')) {
       return _exerciseDelete;
     }
+    if (method == 'PUT' && path.startsWith('/diet/entries/')) {
+      return _dietUpdate;
+    }
+    if (method == 'PUT' && path.startsWith('/exercise/sessions/')) {
+      return _exerciseUpdate;
+    }
     return null;
   }
 
@@ -135,6 +141,72 @@ class LocalApiInterceptor extends Interceptor {
     )..where((t) => t.id.equals(id))).go();
     if (n == 0) return _notFound(options, '운동 기록을 찾을 수 없습니다.');
     return _ok(options, <String, Object?>{'status': 'deleted'});
+  }
+
+  Future<Response<Object?>> _exerciseUpdate(RequestOptions options) async {
+    final id = options.path.split('/').last;
+    final existing = await (_db.select(
+      _db.exerciseSessions,
+    )..where((t) => t.id.equals(id))).getSingleOrNull();
+    if (existing == null) return _notFound(options, '운동 기록을 찾을 수 없습니다.');
+    final body = _jsonBody(options);
+    final type = (body['type'] as String? ?? existing.type).trim();
+    final minutes = (body['minutes'] as num?)?.toInt() ?? existing.minutes;
+    final calories = (body['calories'] as num?)?.toInt() ?? existing.calories;
+    final dayRaw = (body['day_label'] as String? ?? '').trim();
+    final dayLabel = dayRaw.isEmpty ? existing.dayLabel : dayRaw;
+    await (_db.update(
+      _db.exerciseSessions,
+    )..where((t) => t.id.equals(id))).write(
+      ExerciseSessionsCompanion(
+        type: Value(type),
+        minutes: Value(minutes),
+        calories: Value(calories),
+        dayLabel: Value(dayLabel),
+      ),
+    );
+    return _ok(options, <String, Object?>{
+      'id': id,
+      'day_label': dayLabel,
+      'type': type,
+      'minutes': minutes,
+      'calories': calories,
+      'date_label': _dateLabelForDayLabel(dayLabel),
+      'time_label': _defaultTimeLabel(type),
+      'items': _defaultItems(type),
+    });
+  }
+
+  Future<Response<Object?>> _dietUpdate(RequestOptions options) async {
+    final id = options.path.split('/').last;
+    final existing = await (_db.select(
+      _db.dietEntries,
+    )..where((t) => t.id.equals(id))).getSingleOrNull();
+    if (existing == null) return _notFound(options, '식단 기록을 찾을 수 없습니다.');
+    final body = _jsonBody(options);
+    final mealType = (body['meal_type'] as String?)?.trim();
+    final timeLabel = (body['time_label'] as String?)?.trim();
+    await (_db.update(_db.dietEntries)..where((t) => t.id.equals(id))).write(
+      DietEntriesCompanion(
+        mealType: (mealType == null || mealType.isEmpty)
+            ? const Value.absent()
+            : Value(mealType),
+        timeLabel: timeLabel == null ? const Value.absent() : Value(timeLabel),
+      ),
+    );
+    final row = await (_db.select(
+      _db.dietEntries,
+    )..where((t) => t.id.equals(id))).getSingle();
+    final foods = jsonDecode(row.foodsJson) as List<Object?>;
+    return _ok(options, <String, Object?>{
+      'id': row.id,
+      'meal_type': row.mealType,
+      'time_label': row.timeLabel,
+      'foods': foods,
+      'total_calories': row.totalCalories,
+      'sodium_mg': row.sodiumMg,
+      'sugar_g': row.sugarG,
+    });
   }
 
   // ---- handlers ----

--- a/frontend/flutter/lib/features/diet/data/repositories/dio_diet_repository.dart
+++ b/frontend/flutter/lib/features/diet/data/repositories/dio_diet_repository.dart
@@ -45,4 +45,20 @@ class DioDietRepository implements DietRepository {
   Future<void> deleteEntry(String id) async {
     await _dio.delete<Map<String, Object?>>('/diet/entries/$id');
   }
+
+  @override
+  Future<DietEntry> updateEntry({
+    required String id,
+    String? mealType,
+    String? timeLabel,
+  }) async {
+    final res = await _dio.put<Map<String, Object?>>(
+      '/diet/entries/$id',
+      data: <String, Object?>{
+        'meal_type': ?mealType,
+        'time_label': ?timeLabel,
+      },
+    );
+    return DietEntry.fromJson(res.data!);
+  }
 }

--- a/frontend/flutter/lib/features/diet/data/repositories/mock_diet_repository.dart
+++ b/frontend/flutter/lib/features/diet/data/repositories/mock_diet_repository.dart
@@ -77,4 +77,21 @@ class MockDietRepository implements DietRepository {
 
   @override
   Future<void> deleteEntry(String id) async {}
+
+  @override
+  Future<DietEntry> updateEntry({
+    required String id,
+    String? mealType,
+    String? timeLabel,
+  }) async {
+    return DietEntry(
+      id: id,
+      mealType: mealType != null
+          ? MealType.values.byName(mealType)
+          : MealType.lunch,
+      timeLabel: timeLabel ?? '',
+      totalCalories: 0,
+      foods: const <FoodItem>[],
+    );
+  }
 }

--- a/frontend/flutter/lib/features/diet/domain/repositories/diet_repository.dart
+++ b/frontend/flutter/lib/features/diet/domain/repositories/diet_repository.dart
@@ -17,4 +17,12 @@ abstract class DietRepository {
 
   /// DELETE /diet/entries/{id} — remove a diet entry.
   Future<void> deleteEntry(String id);
+
+  /// PUT /diet/entries/{id} — edit an entry's meal type / time. Foods and
+  /// nutrition come from analysis and are not edited here.
+  Future<DietEntry> updateEntry({
+    required String id,
+    String? mealType,
+    String? timeLabel,
+  });
 }

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -9,6 +9,7 @@ import 'package:oncare/features/diet/presentation/controllers/diet_controller.da
 import 'package:oncare/features/diet/presentation/pages/diet_analyze_page.dart';
 import 'package:oncare/features/diet/presentation/widgets/diet_summary_card.dart';
 import 'package:oncare/features/diet/presentation/widgets/diet_week_strip.dart';
+import 'package:oncare/features/diet/presentation/widgets/edit_meal_sheet.dart';
 import 'package:oncare/features/diet/presentation/widgets/meal_card.dart';
 import 'package:oncare/features/notification/presentation/widgets/notification_panel.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
@@ -159,7 +160,10 @@ class _DietRecordPageState extends ConsumerState<DietRecordPage> {
                             dismissKey: ValueKey<String>('diet-${entry.id}'),
                             message: '이 식단 기록을 삭제할까요?',
                             onDelete: () => _deleteDietEntry(entry.id!),
-                            child: MealCard(entry: entry),
+                            child: MealCard(
+                              entry: entry,
+                              onTap: () => showEditMealSheet(context, entry),
+                            ),
                           ),
                         const SizedBox(height: AppSpacing.sm),
                       ],

--- a/frontend/flutter/lib/features/diet/presentation/widgets/edit_meal_sheet.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/edit_meal_sheet.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/design_system/tokens/radius.dart';
+import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
+
+const Map<MealType, String> _mealLabels = <MealType, String>{
+  MealType.breakfast: '아침',
+  MealType.lunch: '점심',
+  MealType.dinner: '저녁',
+  MealType.snack: '간식',
+};
+
+/// Bottom sheet to edit a diet entry's meal type + time. Foods and
+/// nutrition come from photo analysis and are not edited here.
+Future<void> showEditMealSheet(BuildContext context, DietEntry entry) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: AppColors.background,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+    ),
+    builder: (BuildContext ctx) => Padding(
+      padding: const EdgeInsets.only(top: AppSpacing.sm),
+      child: _EditMealForm(entry: entry),
+    ),
+  );
+}
+
+class _EditMealForm extends ConsumerStatefulWidget {
+  const _EditMealForm({required this.entry});
+  final DietEntry entry;
+
+  @override
+  ConsumerState<_EditMealForm> createState() => _EditMealFormState();
+}
+
+class _EditMealFormState extends ConsumerState<_EditMealForm> {
+  late MealType _mealType = widget.entry.mealType;
+  late final TextEditingController _time = TextEditingController(
+    text: widget.entry.timeLabel,
+  );
+  bool _saving = false;
+
+  @override
+  void dispose() {
+    _time.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    if (_saving) return;
+    final id = widget.entry.id;
+    if (id == null) return;
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+    setState(() => _saving = true);
+    try {
+      await ref
+          .read(dietRepositoryProvider)
+          .updateEntry(
+            id: id,
+            mealType: _mealType.name,
+            timeLabel: _time.text.trim(),
+          );
+      ref.invalidate(dietTodayProvider);
+      navigator.pop();
+      messenger.showSnackBar(
+        const SnackBar(content: Text('식단 기록이 수정되었어요')),
+      );
+    } catch (_) {
+      if (mounted) setState(() => _saving = false);
+      messenger.showSnackBar(
+        const SnackBar(content: Text('수정에 실패했어요. 잠시 후 다시 시도해 주세요')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final viewInsets = MediaQuery.of(context).viewInsets;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        AppSpacing.lg,
+        AppSpacing.md,
+        AppSpacing.lg,
+        AppSpacing.lg + viewInsets.bottom,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: Text(
+                  '식단 기록 수정',
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              IconButton(
+                tooltip: '닫기',
+                onPressed: () => Navigator.of(context).pop(),
+                icon: const Icon(Icons.close),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.md),
+          Text('끼니', style: theme.textTheme.bodySmall),
+          const SizedBox(height: AppSpacing.sm),
+          Wrap(
+            spacing: AppSpacing.sm,
+            children: <Widget>[
+              for (final MealType m in MealType.values)
+                ChoiceChip(
+                  label: Text(_mealLabels[m]!),
+                  selected: _mealType == m,
+                  onSelected: (_) => setState(() => _mealType = m),
+                  selectedColor: AppColors.accent,
+                ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.md),
+          Text('시간', style: theme.textTheme.bodySmall),
+          const SizedBox(height: AppSpacing.sm),
+          TextField(
+            controller: _time,
+            keyboardType: TextInputType.datetime,
+            decoration: const InputDecoration(
+              hintText: '예: 12:40',
+              filled: true,
+              fillColor: AppColors.inputBackground,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.all(AppRadius.lg),
+                borderSide: BorderSide.none,
+              ),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          SizedBox(
+            height: 48,
+            child: FilledButton(
+              onPressed: _saving ? null : _save,
+              style: FilledButton.styleFrom(
+                backgroundColor: AppColors.primary,
+                shape: const RoundedRectangleBorder(
+                  borderRadius: BorderRadius.all(AppRadius.lg),
+                ),
+              ),
+              child: _saving
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: Colors.white,
+                      ),
+                    )
+                  : const Text('수정하기'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/flutter/lib/features/diet/presentation/widgets/meal_card.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/meal_card.dart
@@ -13,14 +13,16 @@ String _mealLabel(MealType m) => switch (m) {
 };
 
 class MealCard extends StatelessWidget {
-  const MealCard({required this.entry, super.key});
+  const MealCard({required this.entry, this.onTap, super.key});
   final DietEntry entry;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return AppCard(
       outlined: true,
+      onTap: onTap,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[

--- a/frontend/flutter/lib/features/exercise/data/repositories/dio_exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/dio_exercise_repository.dart
@@ -38,4 +38,24 @@ class DioExerciseRepository implements ExerciseRepository {
   Future<void> deleteSession(String id) async {
     await _dio.delete<Map<String, Object?>>('/exercise/sessions/$id');
   }
+
+  @override
+  Future<ExerciseSession> updateSession({
+    required String id,
+    required ExerciseType type,
+    required int minutes,
+    required int calories,
+    required String dayLabel,
+  }) async {
+    final res = await _dio.put<Map<String, Object?>>(
+      '/exercise/sessions/$id',
+      data: <String, Object?>{
+        'type': type.name,
+        'minutes': minutes,
+        'calories': calories,
+        'day_label': dayLabel,
+      },
+    );
+    return ExerciseSession.fromJson(res.data!);
+  }
 }

--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
@@ -92,4 +92,22 @@ class MockExerciseRepository implements ExerciseRepository {
 
   @override
   Future<void> deleteSession(String id) async {}
+
+  @override
+  Future<ExerciseSession> updateSession({
+    required String id,
+    required ExerciseType type,
+    required int minutes,
+    required int calories,
+    required String dayLabel,
+  }) async {
+    return ExerciseSession(
+      id: id,
+      dayLabel: dayLabel,
+      type: type,
+      minutes: minutes,
+      calories: calories,
+      dateLabel: '오늘',
+    );
+  }
 }

--- a/frontend/flutter/lib/features/exercise/domain/repositories/exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/domain/repositories/exercise_repository.dart
@@ -14,4 +14,13 @@ abstract class ExerciseRepository {
 
   /// DELETE /exercise/sessions/{id} — remove a workout session.
   Future<void> deleteSession(String id);
+
+  /// PUT /exercise/sessions/{id} — edit a workout session.
+  Future<ExerciseSession> updateSession({
+    required String id,
+    required ExerciseType type,
+    required int minutes,
+    required int calories,
+    required String dayLabel,
+  });
 }

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/add_session_sheet.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/add_session_sheet.dart
@@ -11,11 +11,14 @@ import 'package:oncare/features/exercise/presentation/controllers/exercise_contr
 const List<String> _weekdayLabels = <String>['월', '화', '수', '목', '금', '토', '일'];
 
 /// Bottom-sheet form mirroring the prototype's "운동 기록 추가" modal:
-/// type chips (유산소 / 근력 / 스트레칭 / 기타), minutes, free-text
-/// items, save button. On save, appends the new session to the local
-/// [addedSessionsProvider] overlay so it appears at the top of the
-/// list immediately.
-Future<void> showAddSessionSheet(BuildContext context) {
+/// type chips (유산소 / 근력 / 스트레칭 / 기타), minutes, free-text items,
+/// save button. Pass [session] to open in edit mode (pre-filled → PUT);
+/// omit it to add a new session (POST). On save the weekly data is
+/// invalidated so stats/chart/list all reflect the change.
+Future<void> showAddSessionSheet(
+  BuildContext context, {
+  ExerciseSession? session,
+}) {
   return showModalBottomSheet<void>(
     context: context,
     isScrollControlled: true,
@@ -23,25 +26,32 @@ Future<void> showAddSessionSheet(BuildContext context) {
     shape: const RoundedRectangleBorder(
       borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
     ),
-    builder: (BuildContext ctx) => const Padding(
-      padding: EdgeInsets.only(top: AppSpacing.sm),
-      child: _AddSessionForm(),
+    builder: (BuildContext ctx) => Padding(
+      padding: const EdgeInsets.only(top: AppSpacing.sm),
+      child: _AddSessionForm(session: session),
     ),
   );
 }
 
 class _AddSessionForm extends ConsumerStatefulWidget {
-  const _AddSessionForm();
+  const _AddSessionForm({this.session});
+  final ExerciseSession? session;
 
   @override
   ConsumerState<_AddSessionForm> createState() => _AddSessionFormState();
 }
 
 class _AddSessionFormState extends ConsumerState<_AddSessionForm> {
-  ExerciseType _type = ExerciseType.cardio;
-  final TextEditingController _minutesController = TextEditingController();
-  final TextEditingController _itemsController = TextEditingController();
+  late ExerciseType _type = widget.session?.type ?? ExerciseType.cardio;
+  late final TextEditingController _minutesController = TextEditingController(
+    text: widget.session != null ? '${widget.session!.minutes}' : '',
+  );
+  late final TextEditingController _itemsController = TextEditingController(
+    text: widget.session?.items.join(', ') ?? '',
+  );
   bool _saving = false;
+
+  bool get _isEdit => widget.session != null;
 
   @override
   void dispose() {
@@ -60,18 +70,37 @@ class _AddSessionFormState extends ConsumerState<_AddSessionForm> {
       return;
     }
     setState(() => _saving = true);
-    final dayLabel = _weekdayLabels[DateTime.now().weekday - 1];
+    final calories = _estimateCalories(_type, minutes);
     try {
       // 서버(mock 모드는 drift)에 저장 → 주간 데이터 무효화로 통계·차트·목록 모두 반영.
-      await ref.read(exerciseRepositoryProvider).addSession(
-        type: _type,
-        minutes: minutes,
-        calories: _estimateCalories(_type, minutes),
-        dayLabel: dayLabel,
-      );
+      final session = widget.session;
+      if (session != null) {
+        await ref
+            .read(exerciseRepositoryProvider)
+            .updateSession(
+              id: session.id!,
+              type: _type,
+              minutes: minutes,
+              calories: calories,
+              dayLabel: session.dayLabel,
+            );
+      } else {
+        await ref
+            .read(exerciseRepositoryProvider)
+            .addSession(
+              type: _type,
+              minutes: minutes,
+              calories: calories,
+              dayLabel: _weekdayLabels[DateTime.now().weekday - 1],
+            );
+      }
       ref.invalidate(exerciseWeekProvider);
       navigator.pop();
-      messenger.showSnackBar(const SnackBar(content: Text('운동 기록이 추가되었어요')));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(_isEdit ? '운동 기록이 수정되었어요' : '운동 기록이 추가되었어요'),
+        ),
+      );
     } catch (_) {
       if (mounted) setState(() => _saving = false);
       messenger.showSnackBar(
@@ -99,7 +128,7 @@ class _AddSessionFormState extends ConsumerState<_AddSessionForm> {
             children: <Widget>[
               Expanded(
                 child: Text(
-                  '운동 기록 추가',
+                  _isEdit ? '운동 기록 수정' : '운동 기록 추가',
                   style: theme.textTheme.titleLarge?.copyWith(
                     fontWeight: FontWeight.w600,
                   ),
@@ -201,7 +230,7 @@ class _AddSessionFormState extends ConsumerState<_AddSessionForm> {
                         color: Colors.white,
                       ),
                     )
-                  : const Text('저장하기'),
+                  : Text(_isEdit ? '수정하기' : '저장하기'),
             ),
           ),
         ],

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/workout_record_tab.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/workout_record_tab.dart
@@ -9,6 +9,7 @@ import 'package:oncare/design_system/tokens/radius.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
 import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/features/exercise/presentation/widgets/add_session_sheet.dart';
 import 'package:oncare/shared/widgets/ai_coach_card.dart';
 import 'package:oncare/shared/widgets/error_view.dart';
 import 'package:oncare/shared/widgets/swipe_to_delete.dart';
@@ -170,7 +171,10 @@ class _Body extends ConsumerWidget {
               dismissKey: ValueKey<String>('ex-${s.id}'),
               message: '이 운동 기록을 삭제할까요?',
               onDelete: () => _delete(context, ref, s.id!),
-              child: _SessionCard(session: s),
+              child: _SessionCard(
+                session: s,
+                onTap: () => showAddSessionSheet(context, session: s),
+              ),
             ),
           const SizedBox(height: AppSpacing.sm),
         ],
@@ -314,8 +318,9 @@ String _typeLabel(ExerciseType t) => switch (t) {
 };
 
 class _SessionCard extends StatelessWidget {
-  const _SessionCard({required this.session});
+  const _SessionCard({required this.session, this.onTap});
   final ExerciseSession session;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -324,6 +329,7 @@ class _SessionCard extends StatelessWidget {
     final timeLabel = session.timeLabel;
     return AppCard(
       outlined: true,
+      onTap: onTap,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[

--- a/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_aux_test.dart
@@ -328,4 +328,69 @@ void main() {
     );
     expect(gone.statusCode, 404);
   });
+
+  test('PUT /diet/entries/{id} updates meal type + time; 404 when missing', () async {
+    await db
+        .into(db.dietEntries)
+        .insert(
+          DietEntriesCompanion.insert(
+            id: 'edit-diet-1',
+            date: '2026-07-04',
+            mealType: 'lunch',
+            timeLabel: '12:00',
+            foodsJson: '[]',
+            totalCalories: 100,
+          ),
+        );
+
+    final r = await dio.put<Map<String, Object?>>(
+      '/diet/entries/edit-diet-1',
+      data: <String, Object?>{'meal_type': 'dinner', 'time_label': '19:30'},
+    );
+    expect(r.statusCode, 200);
+    expect(r.data!['meal_type'], 'dinner');
+    expect(r.data!['time_label'], '19:30');
+
+    final gone = await dio.put<Map<String, Object?>>(
+      '/diet/entries/nope',
+      data: <String, Object?>{'meal_type': 'dinner'},
+      options: Options(validateStatus: (int? s) => true),
+    );
+    expect(gone.statusCode, 404);
+  });
+
+  test('PUT /exercise/sessions/{id} updates the session; 404 when missing', () async {
+    await db
+        .into(db.exerciseSessions)
+        .insert(
+          ExerciseSessionsCompanion.insert(
+            id: 'edit-ex-1',
+            weekStart: '2026-06-29',
+            dayLabel: '월',
+            type: 'cardio',
+            minutes: 30,
+            calories: 150,
+          ),
+        );
+
+    final r = await dio.put<Map<String, Object?>>(
+      '/exercise/sessions/edit-ex-1',
+      data: <String, Object?>{
+        'type': 'strength',
+        'minutes': 50,
+        'calories': 250,
+        'day_label': '화',
+      },
+    );
+    expect(r.statusCode, 200);
+    expect(r.data!['type'], 'strength');
+    expect(r.data!['minutes'], 50);
+
+    final gone = await dio.put<Map<String, Object?>>(
+      '/exercise/sessions/nope',
+      data: <String, Object?>{'type': 'cardio', 'minutes': 10},
+      options: Options(validateStatus: (int? s) => true),
+    );
+    expect(gone.statusCode, 404);
+  });
 }


### PR DESCRIPTION
## 요약
백엔드 수정 API(#149) 위에 스택. 식단·운동 기록을 **탭해서 수정**하는 UI를 추가한다. 추가·삭제에 이어 수정까지 완성된다.

## 변경
- **운동**: `add_session_sheet`를 **수정 모드로 확장**(`session` 전달 시 pre-fill → `PUT`, 없으면 기존 `POST`). 세션 카드 탭 → 편집 시트. 타이틀/버튼이 모드에 따라 바뀜.
- **식단**: `edit_meal_sheet`(신규) — 끼니 칩 + 시간 편집. 식단 카드 탭 → 편집 시트. (음식/영양은 분석 결과라 제외.)
- **API 배선**: `ExerciseRepository.updateSession()` / `DietRepository.updateEntry()` → `PUT /...`.
- **목 인터셉터**: 경로 파라미터 dispatch에 **PUT** 추가, drift 행 갱신, 없으면 404.
- 저장 후 `exerciseWeekProvider`/`dietTodayProvider` 무효화 → 집계·목록 즉시 반영.

## 테스트
- 목 수정(diet 끼니·시간 / exercise 유형·시간, 각 404 포함) — 신규 2건.
- `flutter analyze` 무경고 · `flutter test` **120 통과**. (실패 1건은 무관·기존 `app_button_golden_test` — 폰트 렌더링 환경차, CI 미포함.)

## 스택
base: `feature/backend-records-edit` (#149) — main 아님

Closes #150
