### PR TITLE
fix(rag): 임베딩 모델 미설정 시 해시 폴백으로 RAG 복구

### DIFF
--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -7,12 +7,16 @@ DB 초기화 + 데모 데이터 시드.
 """
 from __future__ import annotations
 
+import logging
+
 from sqlalchemy import select, text
 from sqlalchemy.orm import Session
 
 from app.core.config import get_settings
 from app.db.session import Base, SessionLocal, engine
 from app.models import models  # noqa: F401
+
+logger = logging.getLogger(__name__)
 
 DEMO_USER_ID = "user-demo"
 
@@ -110,7 +114,7 @@ def _seed_food_nutrients() -> None:
 
 
 def _seed_public_coach_docs() -> None:
-    """공공 코칭 가이드라인을 RAG 공공 문서로 적재(멱등). 임베딩 불가 시 조용히 스킵."""
+    """공공 코칭 가이드라인을 RAG 공공 문서로 적재(멱등). 임베딩 불가 시 경고 로그 후 스킵."""
     from app.data.coach_public_docs import PUBLIC_DOCS
     from app.services.coach.rag import ingest_document
 
@@ -128,6 +132,12 @@ def _seed_public_coach_docs() -> None:
                     domain=doc["domain"], source="public", title=doc["title"],
                 )
             except Exception:  # noqa: BLE001 — 적재 실패가 기동을 막지 않도록
+                # 조용히 삼키면 RAG 가 빈 채로 코치가 규칙 폴백에 갇혀 원인 파악이 어렵다.
+                logger.warning(
+                    "공공 코칭 문서 적재 실패 — 임베딩 제공자(EMBEDDER) 설정 확인 필요: %s",
+                    doc.get("title"),
+                    exc_info=True,
+                )
                 db.rollback()
     finally:
         db.close()

--- a/backend/app/services/embedder/factory.py
+++ b/backend/app/services/embedder/factory.py
@@ -31,12 +31,20 @@ def _build(name: str) -> Embedder:
 
 
 def get_embedder(name: str | None = None) -> Embedder:
-    """설정된 임베더를 반환. 선택된 provider 의 API 키가 없으면 오프라인 해시
-    임베더로 폴백한다(개발/CI/데모에서도 RAG 가 동작하도록)."""
+    """설정된 임베더를 반환. 선택된 provider 의 API 키(또는 LiteLLM 임베딩 모델)가
+    없으면 오프라인 해시 임베더로 폴백한다(개발/CI/데모에서도 RAG 가 동작하도록)."""
     s = get_settings()
     chosen = (name or s.embedder).lower()
     if chosen == "openai" and not s.openai_api_key:
         chosen = "hash"
     elif chosen == "gemini" and not s.gemini_api_key:
+        chosen = "hash"
+    elif chosen == "litellm" and not (
+        s.litellm_base_url and s.litellm_api_key and s.litellm_embed_model
+    ):
+        # LiteLLM 프록시에 임베딩 모델이 없으면 LiteLLMEmbedder 가 기동 중
+        # RuntimeError 를 던져, 공공/개인 문서가 하나도 적재되지 않는다 → RAG 검색이
+        # 비고 코치가 규칙 기반 폴백에 갇힌다. 해시 임베더로 폴백해 오프라인에서도
+        # 적재·검색·코칭 경로가 동작하게 한다.
         chosen = "hash"
     return _build(chosen)

--- a/backend/tests/test_rag.py
+++ b/backend/tests/test_rag.py
@@ -36,6 +36,19 @@ def test_hash_embedder_similarity_orders_related_higher():
     assert related > unrelated
 
 
+def test_litellm_embedder_falls_back_to_hash_without_embed_model():
+    """LiteLLM 프록시에 임베딩 모델이 없으면(기본 설정) 해시 임베더로 폴백한다.
+
+    그러지 않으면 LiteLLMEmbedder 가 기동 중 RuntimeError 를 던져 공공/개인 문서가
+    하나도 적재되지 않고, RAG 검색이 비어 코치가 규칙 기반 폴백에 갇힌다(#155).
+    """
+    from app.services.embedder.factory import get_embedder
+    from app.services.embedder.hash_embedder import HashEmbedder
+
+    # 기본 설정엔 LITELLM_BASE_URL/API_KEY/EMBED_MODEL 이 비어 있음 → 해시로 폴백
+    assert isinstance(get_embedder("litellm"), HashEmbedder)
+
+
 # ---------- DB(CI): 적재·검색·격리 ----------
 
 def test_public_guidelines_seeded_and_retrieved(client, db_session):

--- a/backend/tests/test_rag.py
+++ b/backend/tests/test_rag.py
@@ -36,16 +36,22 @@ def test_hash_embedder_similarity_orders_related_higher():
     assert related > unrelated
 
 
-def test_litellm_embedder_falls_back_to_hash_without_embed_model():
-    """LiteLLM 프록시에 임베딩 모델이 없으면(기본 설정) 해시 임베더로 폴백한다.
+def test_litellm_embedder_falls_back_to_hash_without_embed_model(monkeypatch):
+    """LiteLLM 프록시에 임베딩 모델이 없으면 해시 임베더로 폴백한다.
 
     그러지 않으면 LiteLLMEmbedder 가 기동 중 RuntimeError 를 던져 공공/개인 문서가
     하나도 적재되지 않고, RAG 검색이 비어 코치가 규칙 기반 폴백에 갇힌다(#155).
     """
+    from app.core.config import get_settings
     from app.services.embedder.factory import get_embedder
     from app.services.embedder.hash_embedder import HashEmbedder
 
-    # 기본 설정엔 LITELLM_BASE_URL/API_KEY/EMBED_MODEL 이 비어 있음 → 해시로 폴백
+    # 로컬 .env / CI 환경변수에 값이 있어도 결정적이도록, LiteLLM 설정을 직접 비운다.
+    settings = get_settings()
+    monkeypatch.setattr(settings, "litellm_base_url", "")
+    monkeypatch.setattr(settings, "litellm_api_key", "")
+    monkeypatch.setattr(settings, "litellm_embed_model", "")
+
     assert isinstance(get_embedder("litellm"), HashEmbedder)
 
 


### PR DESCRIPTION
## Summary

* `EMBEDDER=litellm` 인데 LiteLLM 프록시에 임베딩 모델이 없으면 RAG 문서 적재가 전부 실패해, AI 코치가 **규칙 기반 폴백에만 갇히는 문제**를 고칩니다.
* 임베더 factory 가 litellm 미설정(base_url/api_key/embed_model 부재) 시 **오프라인 해시 임베더로 폴백**하도록 해, 키 없이도 적재→검색→코칭 경로가 동작하게 합니다.
* 공공문서 적재 실패를 조용히 삼키지 않고 **경고 로그로 노출**합니다.

---

## Changes

### ✨ Features

* (없음)

### 🔧 Improvements

* `factory.get_embedder`: `EMBEDDER=litellm` 이 선택됐지만 `LITELLM_BASE_URL`·`LITELLM_API_KEY`·`LITELLM_EMBED_MODEL` 중 하나라도 없으면 오프라인 해시 임베더로 폴백 (기존 openai/gemini 무키 폴백과 동일 패턴)
* `init_db._seed_public_coach_docs`: 적재 실패 시 `logger.warning` 로 원인(임베딩 제공자 설정)을 노출 — 지금까진 조용히 스킵해 RAG 가 왜 비었는지 파악이 어려웠음

### 🎨 UI/UX

* (없음 — 백엔드 전용)

### 📝 Docs

* (없음)

### 🐛 Fixes

* `EMBEDDER=litellm` + 임베딩 모델 부재 시 `LiteLLMEmbedder` 가 기동 중 `RuntimeError` → 공공/개인 문서 미적재 → RAG 검색 0건 → 코치가 규칙 폴백에 갇히던 문제 해결

---

## Commits

1. `444cfe5` fix(rag): 임베딩 모델 미설정 시 해시 폴백으로 RAG 복구

---

## Notes

* 이 PR은 **#155(RAG 임베딩 제공자 확보)의 STEP 1 — 오프라인 파이프라인 복구**입니다. 실 Gemini/OpenAI 임베딩 연동·차원(`EMBED_DIM`) 정렬·재임베딩은 #155 에서 후속 진행합니다.
* hash 임베더는 텍스트 해시 기반이라 **의미 검색 품질은 낮습니다**(파이프라인이 "동작"은 하되 관련도는 약함). 실 제공자 연동 전까지 코치가 규칙 폴백에 갇히지 않게 하는 것이 목적입니다.
* **백엔드만** 변경했고, 프론트/README/다이어그램은 건드리지 않았습니다.
* LiteLLM 을 실제로 쓰는 설정(3개 env 모두 존재)에서는 기존대로 실 LiteLLM 임베더를 씁니다 — 폴백은 미설정일 때만 동작합니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| `EMBEDDER=litellm` → 적재 실패 → RAG 0건 → 코치 규칙 폴백 | 미설정 시 hash 폴백 → 공공문서 적재 → 검색 → RAG 근거 코칭 |

---

## Test Plan

* [x] 관련 테스트 통과 — `test_rag.py::test_litellm_embedder_falls_back_to_hash_without_embed_model` (신규) + 기존 hash/seed/검색 테스트
* [x] 예외 케이스 확인 — litellm 미설정 시 `RuntimeError` 대신 hash 폴백
* [x] 빌드 성공 — `ruff` clean, `py_compile` OK
* [ ] UI 확인 (해당 없음 — 백엔드)

### Manual Test Steps

1. `.env` 에 `EMBEDDER=litellm` 설정(단 `LITELLM_EMBED_MODEL` 은 비움).
2. `docker compose up --build` 로 기동.
3. `SELECT count(*) FROM coach_documents;` → 공공문서가 적재됨(0 아님) 확인.
4. `POST /v1/ai-coach/chat {"message":"나트륨 줄이려면?"}` → 규칙 폴백이 아닌 공공문서 근거(DASH·저염) 응답 확인.

---

## Related Issues

Closes #158
Refs #155

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * LiteLLM 설정이 일부 누락된 경우에도 자동으로 대체 임베더를 사용해 검색/적재가 중단되지 않도록 개선했습니다.
  * 문서 적재 실패 시 조용히 넘어가지 않고 경고 로그를 남겨 문제를 더 쉽게 확인할 수 있게 했습니다.

* **Tests**
  * LiteLLM 임베딩 설정 누락 시 대체 동작을 검증하는 회귀 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->