### PR TITLE
feat(trainer-auth): add trainer session/auth logic with mock login and demo bypass

### DIFF
--- a/frontend/flutter_trainer/lib/app/bootstrap.dart
+++ b/frontend/flutter_trainer/lib/app/bootstrap.dart
@@ -1,20 +1,29 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:oncare_trainer/app/app.dart';
+import 'package:oncare_trainer/core/storage/prefs_provider.dart';
 
-/// Single entry point used by `main.dart`. Initializes the binding and
-/// starts the app inside a [ProviderScope].
+/// Single entry point used by `main.dart`. Initializes the binding,
+/// resolves the async services the widget tree needs synchronously
+/// (SharedPreferences, for session restore), and starts the app inside
+/// a [ProviderScope].
 ///
-/// Kept intentionally thin for the scaffold — config, logging, and the
+/// Kept intentionally thin for now — config, logging, and the
 /// drift-backed local backend are added in their own issues (mirroring
 /// the user app's `bootstrap()` shape).
 Future<void> bootstrap() async {
   WidgetsFlutterBinding.ensureInitialized();
 
+  final prefs = await SharedPreferences.getInstance();
+
   runApp(
-    const ProviderScope(
-      child: OncareTrainerApp(),
+    ProviderScope(
+      overrides: <Override>[
+        sharedPreferencesProvider.overrideWithValue(prefs),
+      ],
+      child: const OncareTrainerApp(),
     ),
   );
 }

--- a/frontend/flutter_trainer/lib/core/storage/prefs_provider.dart
+++ b/frontend/flutter_trainer/lib/core/storage/prefs_provider.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Holds the app-wide [SharedPreferences] instance.
+///
+/// The real value is resolved asynchronously in `bootstrap()` and
+/// injected via an override, so the rest of the app can read prefs
+/// synchronously. Reading this provider without that override throws —
+/// that only happens in a misconfigured test.
+final sharedPreferencesProvider = Provider<SharedPreferences>((ref) {
+  throw UnimplementedError(
+    'sharedPreferencesProvider must be overridden in bootstrap() '
+    '(or in tests via SharedPreferences.setMockInitialValues).',
+  );
+});

--- a/frontend/flutter_trainer/lib/core/storage/session_token_store.dart
+++ b/frontend/flutter_trainer/lib/core/storage/session_token_store.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:oncare_trainer/core/storage/prefs_provider.dart';
+
+/// Persists the trainer session's access token across app restarts.
+///
+/// Backed by [SharedPreferences] for now — the token is a mock demo
+/// token until the real backend lands. The store is intentionally a
+/// thin abstraction so the backing implementation can be swapped for
+/// secure storage (Keychain / Keystore) when real credentials are
+/// introduced, without touching the session layer.
+class SessionTokenStore {
+  /// Creates a store over the given [SharedPreferences] instance.
+  const SessionTokenStore(this._prefs);
+
+  final SharedPreferences _prefs;
+
+  static const String _tokenKey = 'trainer_access_token';
+
+  /// Returns the persisted access token, or `null` if the trainer is
+  /// signed out.
+  String? readToken() {
+    final token = _prefs.getString(_tokenKey);
+    if (token == null || token.isEmpty) return null;
+    return token;
+  }
+
+  /// Persists [token] so the session survives an app restart.
+  Future<void> saveToken(String token) => _prefs.setString(_tokenKey, token);
+
+  /// Clears the persisted token (sign-out).
+  Future<void> clear() => _prefs.remove(_tokenKey);
+}
+
+/// Provides the [SessionTokenStore], wired to the app-wide prefs.
+final sessionTokenStoreProvider = Provider<SessionTokenStore>((ref) {
+  return SessionTokenStore(ref.watch(sharedPreferencesProvider));
+});

--- a/frontend/flutter_trainer/lib/features/auth/data/repositories/mock_trainer_auth_repository.dart
+++ b/frontend/flutter_trainer/lib/features/auth/data/repositories/mock_trainer_auth_repository.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare_trainer/features/auth/domain/repositories/trainer_auth_repository.dart';
+
+/// Pure in-memory mock used until the FastAPI backend exists.
+///
+/// Accepts any non-empty email/password (mirroring the user app's demo
+/// login) and issues a fake token. No network, no real validation —
+/// real credential checks arrive with the backend implementation.
+class MockTrainerAuthRepository implements TrainerAuthRepository {
+  /// Creates the mock repository.
+  const MockTrainerAuthRepository();
+
+  @override
+  Future<String> login({
+    required String email,
+    required String password,
+  }) async {
+    // Small delay so the UI's loading state is observable.
+    await Future<void>.delayed(const Duration(milliseconds: 400));
+
+    if (email.trim().isEmpty || password.isEmpty) {
+      throw const AuthException('이메일과 비밀번호를 입력해 주세요');
+    }
+
+    return 'demo-trainer-token-${DateTime.now().microsecondsSinceEpoch}';
+  }
+}
+
+/// Provides the trainer auth repository. Swapped for a real
+/// (dio-backed) implementation when the backend lands.
+final trainerAuthRepositoryProvider = Provider<TrainerAuthRepository>((ref) {
+  return const MockTrainerAuthRepository();
+});

--- a/frontend/flutter_trainer/lib/features/auth/domain/entities/session_state.dart
+++ b/frontend/flutter_trainer/lib/features/auth/domain/entities/session_state.dart
@@ -1,0 +1,41 @@
+import 'package:oncare_trainer/features/auth/domain/entities/trainer_profile.dart';
+
+/// Lifecycle of the trainer session.
+///
+/// Designed fresh for the trainer app (the user app's auth logic is not
+/// reused — it has no notion of a trainer account). Mirrors the same
+/// four-state shape so the two On-Care apps stay conceptually aligned.
+enum SessionStatus {
+  /// Session not yet resolved (during the initial restore).
+  unknown,
+
+  /// No session — the login screen is shown.
+  signedOut,
+
+  /// Skipped login — browsing with mock data, no token.
+  demo,
+
+  /// Logged in with a (mock) token and a trainer profile attached.
+  authenticated,
+}
+
+/// Immutable snapshot of the current session.
+class SessionState {
+  /// Creates a session snapshot. [profile] is non-null only when
+  /// [status] is [SessionStatus.authenticated].
+  const SessionState({this.status = SessionStatus.unknown, this.profile});
+
+  /// Current lifecycle state.
+  final SessionStatus status;
+
+  /// The signed-in trainer's profile, or `null` when not authenticated.
+  final TrainerProfile? profile;
+
+  /// Whether the trainer is logged in with a token.
+  bool get isAuthenticated => status == SessionStatus.authenticated;
+
+  /// Whether the app content is reachable — either a real (mock) login
+  /// or demo mode. The router's auth gate keys off this.
+  bool get canEnterApp =>
+      status == SessionStatus.authenticated || status == SessionStatus.demo;
+}

--- a/frontend/flutter_trainer/lib/features/auth/domain/entities/trainer_profile.dart
+++ b/frontend/flutter_trainer/lib/features/auth/domain/entities/trainer_profile.dart
@@ -1,0 +1,89 @@
+/// The trainer's gym / workplace details.
+class TrainerGym {
+  /// Creates gym details.
+  const TrainerGym({
+    required this.name,
+    required this.address,
+    required this.hours,
+    required this.phone,
+  });
+
+  /// Gym name (e.g. "온케어짐 신촌점").
+  final String name;
+
+  /// Street address.
+  final String address;
+
+  /// Operating hours label (e.g. "06:00 – 23:00").
+  final String hours;
+
+  /// Contact phone number.
+  final String phone;
+}
+
+/// A trainer account's profile.
+///
+/// Until the real backend exists, login attaches a single fixed
+/// [seedTrainerProfile] to the session (see the trainer-auth design in
+/// CLAUDE.local.md). Fields mirror the Figma trainer "MY" screen so the
+/// MY tab (a later issue) can render/edit them without reshaping data.
+class TrainerProfile {
+  /// Creates a trainer profile.
+  const TrainerProfile({
+    required this.name,
+    required this.email,
+    required this.phone,
+    required this.specialty,
+    required this.career,
+    required this.intro,
+    required this.certifications,
+    required this.gym,
+  });
+
+  /// Display name (e.g. "김트레이너").
+  final String name;
+
+  /// Login / contact email.
+  final String email;
+
+  /// Contact phone number.
+  final String phone;
+
+  /// Specialty label (e.g. "퍼스널 트레이너").
+  final String specialty;
+
+  /// Career length label (e.g. "7년").
+  final String career;
+
+  /// Short self-introduction shown on the MY screen.
+  final String intro;
+
+  /// Certifications / licenses.
+  final List<String> certifications;
+
+  /// Gym the trainer belongs to.
+  final TrainerGym gym;
+}
+
+/// The single fixed trainer profile attached on a successful (mock)
+/// login. Sourced from the On-Care Figma trainer mock (TrainerMyTab).
+const TrainerProfile seedTrainerProfile = TrainerProfile(
+  name: '김트레이너',
+  email: 'trainer@oncare.com',
+  phone: '010-1234-5678',
+  specialty: '퍼스널 트레이너',
+  career: '7년',
+  intro: '혈압 관리와 체중 감량 전문 트레이너입니다. 고객 맞춤형 AI 루틴으로 '
+      '안전하고 효과적인 운동을 도와드려요.',
+  certifications: <String>[
+    '생활스포츠지도사 2급',
+    '퍼스널트레이닝 CPT',
+    '스포츠 영양사',
+  ],
+  gym: TrainerGym(
+    name: '온케어짐 신촌점',
+    address: '서울 서대문구 신촌로 120',
+    hours: '06:00 – 23:00',
+    phone: '02-1234-5678',
+  ),
+);

--- a/frontend/flutter_trainer/lib/features/auth/domain/repositories/trainer_auth_repository.dart
+++ b/frontend/flutter_trainer/lib/features/auth/domain/repositories/trainer_auth_repository.dart
@@ -1,0 +1,24 @@
+/// Raised when a login attempt is rejected (e.g. empty credentials, or
+/// invalid credentials once the real backend validates them).
+class AuthException implements Exception {
+  /// Creates an auth failure with a user-facing [message].
+  const AuthException(this.message);
+
+  /// Human-readable, Korean, ready to surface in a snackbar.
+  final String message;
+
+  @override
+  String toString() => 'AuthException: $message';
+}
+
+/// Authenticates a trainer and returns a session access token.
+///
+/// Defined fresh for the trainer app — the user app's auth repository
+/// is not reused. The real implementation (POST /auth/login) replaces
+/// [MockTrainerAuthRepository] when the backend lands, keeping this
+/// contract.
+abstract class TrainerAuthRepository {
+  /// Exchanges email/password for an access token. Throws
+  /// [AuthException] on failure.
+  Future<String> login({required String email, required String password});
+}

--- a/frontend/flutter_trainer/lib/features/auth/presentation/controllers/session_controller.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/controllers/session_controller.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare_trainer/core/storage/session_token_store.dart';
+import 'package:oncare_trainer/features/auth/data/repositories/mock_trainer_auth_repository.dart';
+import 'package:oncare_trainer/features/auth/domain/entities/session_state.dart';
+import 'package:oncare_trainer/features/auth/domain/entities/trainer_profile.dart';
+import 'package:oncare_trainer/features/auth/domain/repositories/trainer_auth_repository.dart';
+
+/// Owns the trainer session lifecycle: restore-on-launch, mock login,
+/// demo bypass, and sign-out.
+///
+/// Designed fresh for the trainer app (the user app's SessionController
+/// is not reused — it has no trainer-account concept). On a successful
+/// login the single fixed [seedTrainerProfile] is attached to the
+/// session; the persisted token lets the session survive an app
+/// restart.
+class SessionController extends StateNotifier<SessionState> {
+  /// Creates the controller and kicks off session restore.
+  SessionController(this._authRepository, this._tokenStore)
+    : super(const SessionState()) {
+    _restore();
+  }
+
+  final TrainerAuthRepository _authRepository;
+  final SessionTokenStore _tokenStore;
+
+  /// Resolves the initial session from persisted state. A stored token
+  /// means the trainer stays logged in (with the seed profile);
+  /// otherwise they land signed out. Demo mode is never persisted.
+  void _restore() {
+    final token = _tokenStore.readToken();
+    if (token != null) {
+      state = const SessionState(
+        status: SessionStatus.authenticated,
+        profile: seedTrainerProfile,
+      );
+    } else {
+      state = const SessionState(status: SessionStatus.signedOut);
+    }
+  }
+
+  /// Logs in with email/password (mock: any non-empty credentials
+  /// succeed). Persists the token and attaches the seed profile.
+  /// Throws [AuthException] on failure.
+  Future<void> login({
+    required String email,
+    required String password,
+  }) async {
+    final token = await _authRepository.login(
+      email: email,
+      password: password,
+    );
+    await _tokenStore.saveToken(token);
+    state = const SessionState(
+      status: SessionStatus.authenticated,
+      profile: seedTrainerProfile,
+    );
+  }
+
+  /// Enters demo mode — skip login, no token, browse with mock data.
+  /// Not persisted, so a restart returns to the signed-out state.
+  void enterDemo() {
+    state = const SessionState(status: SessionStatus.demo);
+  }
+
+  /// Signs out — clears the persisted token and returns to the login
+  /// screen.
+  Future<void> signOut() async {
+    await _tokenStore.clear();
+    state = const SessionState(status: SessionStatus.signedOut);
+  }
+}
+
+/// Exposes the trainer session state + controller app-wide.
+final sessionControllerProvider =
+    StateNotifierProvider<SessionController, SessionState>((ref) {
+      return SessionController(
+        ref.watch(trainerAuthRepositoryProvider),
+        ref.watch(sessionTokenStoreProvider),
+      );
+    }, name: 'trainerSession');

--- a/frontend/flutter_trainer/pubspec.lock
+++ b/frontend/flutter_trainer/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -232,6 +240,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.2"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.3"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   petitparser:
     dependency: transitive
     description:
@@ -240,6 +272,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.2"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   posix:
     dependency: transitive
     description:
@@ -256,6 +304,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "0634e64bd719f89c012f392938e173521f535d3ecaf66558fa94a056d22b5cc7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.27"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -333,6 +437,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.2.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   xml:
     dependency: transitive
     description:
@@ -351,4 +471,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.22.0"
+  flutter: ">=3.44.0"

--- a/frontend/flutter_trainer/pubspec.yaml
+++ b/frontend/flutter_trainer/pubspec.yaml
@@ -22,6 +22,12 @@ dependencies:
   # --- Routing ---
   go_router: ^14.6.2
 
+  # --- Local persistence ---
+  # 세션 토큰(현재는 mock 데모 토큰)을 저장해 앱 재시작 시 세션을 복원한다.
+  # 실 백엔드 연동 시 secure storage 로 교체하기 쉽도록 SessionTokenStore
+  # 뒤에 감춰둔다.
+  shared_preferences: ^2.3.2
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/frontend/flutter_trainer/test/features/auth/session_controller_test.dart
+++ b/frontend/flutter_trainer/test/features/auth/session_controller_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:oncare_trainer/core/storage/prefs_provider.dart';
+import 'package:oncare_trainer/core/storage/session_token_store.dart';
+import 'package:oncare_trainer/features/auth/domain/entities/session_state.dart';
+import 'package:oncare_trainer/features/auth/domain/repositories/trainer_auth_repository.dart';
+import 'package:oncare_trainer/features/auth/presentation/controllers/session_controller.dart';
+
+/// Builds a ProviderContainer wired to a fresh mock SharedPreferences.
+Future<ProviderContainer> _makeContainer() async {
+  SharedPreferences.setMockInitialValues(<String, Object>{});
+  final prefs = await SharedPreferences.getInstance();
+  final container = ProviderContainer(
+    overrides: <Override>[
+      sharedPreferencesProvider.overrideWithValue(prefs),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('SessionController', () {
+    test('restores to signedOut when no token is persisted', () async {
+      final container = await _makeContainer();
+
+      final state = container.read(sessionControllerProvider);
+
+      expect(state.status, SessionStatus.signedOut);
+      expect(state.canEnterApp, isFalse);
+      expect(state.profile, isNull);
+    });
+
+    test('restores to authenticated when a token is persisted', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'trainer_access_token': 'demo-trainer-token-existing',
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: <Override>[
+          sharedPreferencesProvider.overrideWithValue(prefs),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final state = container.read(sessionControllerProvider);
+
+      expect(state.status, SessionStatus.authenticated);
+      expect(state.isAuthenticated, isTrue);
+      expect(state.profile?.name, '김트레이너');
+      expect(state.profile?.email, 'trainer@oncare.com');
+    });
+
+    test('login with non-empty credentials authenticates and persists',
+        () async {
+      final container = await _makeContainer();
+      final controller = container.read(sessionControllerProvider.notifier);
+
+      await controller.login(email: 'trainer@oncare.com', password: 'pw');
+
+      final state = container.read(sessionControllerProvider);
+      expect(state.status, SessionStatus.authenticated);
+      expect(state.canEnterApp, isTrue);
+      expect(state.profile, isNotNull);
+
+      // Token persisted → survives a "restart".
+      expect(
+        container.read(sessionTokenStoreProvider).readToken(),
+        isNotNull,
+      );
+    });
+
+    test('login with empty credentials throws and stays signed out',
+        () async {
+      final container = await _makeContainer();
+      final controller = container.read(sessionControllerProvider.notifier);
+
+      await expectLater(
+        controller.login(email: '   ', password: ''),
+        throwsA(isA<AuthException>()),
+      );
+
+      final state = container.read(sessionControllerProvider);
+      expect(state.status, SessionStatus.signedOut);
+      expect(
+        container.read(sessionTokenStoreProvider).readToken(),
+        isNull,
+      );
+    });
+
+    test('enterDemo grants app access without persisting a token',
+        () async {
+      final container = await _makeContainer();
+      final controller = container.read(sessionControllerProvider.notifier);
+
+      controller.enterDemo();
+
+      final state = container.read(sessionControllerProvider);
+      expect(state.status, SessionStatus.demo);
+      expect(state.canEnterApp, isTrue);
+      expect(state.isAuthenticated, isFalse);
+      // Demo is in-memory only — nothing persisted.
+      expect(
+        container.read(sessionTokenStoreProvider).readToken(),
+        isNull,
+      );
+    });
+
+    test('signOut clears the token and returns to signedOut', () async {
+      final container = await _makeContainer();
+      final controller = container.read(sessionControllerProvider.notifier);
+
+      await controller.login(email: 'trainer@oncare.com', password: 'pw');
+      expect(
+        container.read(sessionControllerProvider).status,
+        SessionStatus.authenticated,
+      );
+
+      await controller.signOut();
+
+      expect(
+        container.read(sessionControllerProvider).status,
+        SessionStatus.signedOut,
+      );
+      expect(
+        container.read(sessionTokenStoreProvider).readToken(),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- 트레이너 앱 전용 세션/인증 로직을 신규 설계했습니다 (사용자 앱의 `SessionController`/`LocalApiInterceptor`는 재사용하지 않음 — 역할 구분 불가 구조).
- 비어있지 않은 이메일/비밀번호면 성공하는 순수 mock 로그인, 성공 시 고정 시드 트레이너 프로필 연결, 토큰 없는 데모 바이패스, 앱 재시작 세션 복원을 구현했습니다.
- `SessionController` 단위 테스트 6종을 추가하고 `flutter analyze`/`flutter test`를 통과했습니다.

---

## Changes

### ✨ Features
- `SessionController`(로그인/데모/로그아웃/복원) + `SessionState`/`SessionStatus`
- `TrainerAuthRepository` 추상화 + `MockTrainerAuthRepository`(in-memory)
- `SessionTokenStore`(shared_preferences)로 토큰 영속화
- `seedTrainerProfile` 고정 시드 프로필 엔티티

### 🔧 Improvements
- `bootstrap`에서 SharedPreferences 초기화 및 provider 오버라이드 추가

---

## Commits

1. `990552d` feat: add trainer session/auth logic with mock login and demo bypass

---

## Notes

- **이 PR은 스캐폴딩(#163) 브랜치 위에 쌓은 스택 PR입니다.** base가 `feature/163-trainer-app-scaffold`로 설정돼 있으며, #163이 머지된 후 base를 `main`으로 재설정할 예정입니다.
- `SessionController`/`SessionState`는 사용자 앱과 개념적 형태만 맞췄고 코드는 공유하지 않습니다 (`package:oncare/` import 0건 확인).
- 데모 모드는 의도적으로 영속화하지 않습니다 — 재시작 시 `signedOut`으로 돌아갑니다 (사용자 앱 `enterDemo` 동작과 동일).
- 토큰은 현재 mock 데모 문자열이며, 실 백엔드 연동 시 `SessionTokenStore`를 secure storage 구현으로 교체하고 `MockTrainerAuthRepository`를 dio 기반으로 바꾸면 됩니다.
- 로그인 화면 UI, 라우터 인증 게이트는 각각 후속 이슈(로그인 화면 / 앱 셸)에서 이 `canEnterApp`·`sessionControllerProvider`에 연결합니다.

---

## Test Plan

- [ ] 기능 정상 동작 확인
- [ ] 예외 케이스 확인
- [ ] UI 확인 *(해당 없음 — 이번 PR엔 UI 없음)*
- [ ] 빌드 성공
- [ ] 관련 테스트 통과

### Manual Test Steps

1. `cd frontend/flutter_trainer && flutter pub get`
2. `flutter test test/features/auth/session_controller_test.dart` → 6 tests 통과 확인
3. `flutter analyze` → No issues 확인

---

## Related Issues

Closes #164

---

## Checklist

- [ ] 코드 리뷰 준비 완료
- [ ] 불필요한 코드 제거
- [ ] 하드코딩 값 점검
- [ ] Merge 충돌 없음
- [ ] 데모 시나리오 영향 확인