### PR TITLE
feat(trainer-auth): add trainer sign-in screen wired to session logic

### DIFF
--- a/frontend/flutter_trainer/lib/app/router/app_router.dart
+++ b/frontend/flutter_trainer/lib/app/router/app_router.dart
@@ -2,17 +2,22 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/features/auth/presentation/pages/trainer_sign_in_page.dart';
 import 'package:oncare_trainer/features/placeholder/presentation/pages/scaffold_home_page.dart';
 
-/// GoRouter for the trainer app. Currently only the scaffold placeholder
-/// is registered; the auth gate and the four-tab shell replace this in
-/// later issues.
+/// GoRouter for the trainer app. Starts on the login screen; the
+/// dashboard route is a placeholder stand-in until the four-tab shell
+/// (and its auth-gate redirect) land in a later issue.
 final appRouterProvider = Provider<GoRouter>((ref) {
   return GoRouter(
-    initialLocation: AppRoutes.home,
+    initialLocation: AppRoutes.signIn,
     routes: <RouteBase>[
       GoRoute(
-        path: AppRoutes.home,
+        path: AppRoutes.signIn,
+        builder: (context, state) => const TrainerSignInPage(),
+      ),
+      GoRoute(
+        path: AppRoutes.dashboard,
         builder: (context, state) => const ScaffoldHomePage(),
       ),
     ],

--- a/frontend/flutter_trainer/lib/app/router/routes.dart
+++ b/frontend/flutter_trainer/lib/app/router/routes.dart
@@ -1,13 +1,13 @@
 /// Centralised route paths for the trainer app. Anything that needs to
 /// navigate imports this rather than another feature module
 /// (STRUCTURE.md §4).
-///
-/// Only the scaffold placeholder exists today; auth + the four trainer
-/// tabs (고객 / 스케줄 / AI루틴 / MY) are added in their own issues.
 class AppRoutes {
   AppRoutes._();
 
-  /// Temporary landing route for the scaffold. Replaced by the real
-  /// auth gate + tab shell in later issues.
-  static const String home = '/';
+  /// Trainer login screen (email/password + demo bypass).
+  static const String signIn = '/auth/sign-in';
+
+  /// Trainer home — the 고객(clients) tab. Currently a placeholder
+  /// stand-in; the four-tab shell replaces it in a later issue.
+  static const String dashboard = '/dashboard';
 }

--- a/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_in_page.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_in_page.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/radius.dart';
+import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/features/auth/domain/repositories/trainer_auth_repository.dart';
+import 'package:oncare_trainer/features/auth/presentation/controllers/session_controller.dart';
+import 'package:oncare_trainer/features/auth/presentation/widgets/auth_fields.dart';
+
+/// Trainer login screen — email/password login plus a "로그인 없이 데모
+/// 둘러보기" bypass. Layout follows the user app's sign-in page; the
+/// trainer app has no social login or self sign-up (accounts are 1:1),
+/// so those are intentionally omitted. Wired to [SessionController].
+class TrainerSignInPage extends ConsumerStatefulWidget {
+  /// Creates the trainer login screen.
+  const TrainerSignInPage({super.key});
+
+  @override
+  ConsumerState<TrainerSignInPage> createState() => _TrainerSignInPageState();
+}
+
+class _TrainerSignInPageState extends ConsumerState<TrainerSignInPage> {
+  final TextEditingController _email = TextEditingController();
+  final TextEditingController _password = TextEditingController();
+  bool _obscure = true;
+  bool _loading = false;
+
+  @override
+  void dispose() {
+    _email.dispose();
+    _password.dispose();
+    super.dispose();
+  }
+
+  void _enterDemo() {
+    ref.read(sessionControllerProvider.notifier).enterDemo();
+    context.go(AppRoutes.dashboard);
+  }
+
+  Future<void> _login() async {
+    if (_loading) return;
+    final messenger = ScaffoldMessenger.of(context);
+    final email = _email.text.trim();
+    final password = _password.text;
+    if (email.isEmpty || password.isEmpty) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('이메일과 비밀번호를 입력해 주세요')),
+      );
+      return;
+    }
+    setState(() => _loading = true);
+    try {
+      await ref
+          .read(sessionControllerProvider.notifier)
+          .login(email: email, password: password);
+      if (!mounted) return;
+      context.go(AppRoutes.dashboard);
+    } on AuthException catch (e) {
+      if (mounted) setState(() => _loading = false);
+      messenger.showSnackBar(SnackBar(content: Text(e.message)));
+    } catch (_) {
+      if (mounted) setState(() => _loading = false);
+      messenger.showSnackBar(
+        const SnackBar(content: Text('로그인에 실패했어요. 잠시 후 다시 시도해 주세요')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(AppSpacing.xl),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 400),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  // Brand — On-Care logo in a rounded card.
+                  Center(
+                    child: Container(
+                      width: 84,
+                      height: 84,
+                      padding: const EdgeInsets.all(AppSpacing.sm),
+                      decoration: BoxDecoration(
+                        color: AppColors.card,
+                        borderRadius: const BorderRadius.all(AppRadius.card),
+                        border: Border.all(color: AppColors.border),
+                      ),
+                      child: Image.asset(
+                        'assets/images/oncare-logo.png',
+                        fit: BoxFit.contain,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.lg),
+                  Text(
+                    '온케어 트레이너',
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.headlineSmall?.copyWith(
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    '고객 관리를 위한 트레이너 전용 앱',
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: AppColors.mutedForeground,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.xxl),
+
+                  AuthField(
+                    controller: _email,
+                    hint: '이메일',
+                    icon: Icons.mail_outline,
+                    keyboardType: TextInputType.emailAddress,
+                  ),
+                  const SizedBox(height: AppSpacing.md),
+                  AuthField(
+                    controller: _password,
+                    hint: '비밀번호',
+                    icon: Icons.lock_outline,
+                    obscure: _obscure,
+                    onSubmitted: (_) => _login(),
+                    trailing: IconButton(
+                      icon: Icon(
+                        _obscure ? Icons.visibility_off : Icons.visibility,
+                        size: 20,
+                        color: AppColors.subtleForeground,
+                      ),
+                      onPressed: () => setState(() => _obscure = !_obscure),
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.xl),
+
+                  AuthGradientButton(
+                    loading: _loading,
+                    label: '로그인',
+                    onTap: _login,
+                  ),
+                  const SizedBox(height: AppSpacing.lg),
+                  Center(
+                    child: TextButton(
+                      onPressed: _loading ? null : _enterDemo,
+                      style: TextButton.styleFrom(
+                        foregroundColor: AppColors.primary,
+                      ),
+                      child: const Text('로그인 없이 데모 둘러보기'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/flutter_trainer/lib/features/auth/presentation/widgets/auth_fields.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/widgets/auth_fields.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/radius.dart';
+import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+
+/// Trainer brand gradient (orange) used by the auth screens. Layout /
+/// widget shape mirrors the user app's auth fields, but every color is
+/// read from the trainer design tokens.
+const LinearGradient authBrandGradient = LinearGradient(
+  begin: Alignment.topLeft,
+  end: Alignment.bottomRight,
+  colors: <Color>[AppColors.primary, AppColors.secondary],
+);
+
+/// Filled, icon-prefixed text field used on the trainer login screen.
+class AuthField extends StatelessWidget {
+  /// Creates an auth text field.
+  const AuthField({
+    super.key,
+    required this.controller,
+    required this.hint,
+    required this.icon,
+    this.obscure = false,
+    this.keyboardType,
+    this.trailing,
+    this.onSubmitted,
+    this.textInputAction,
+  });
+
+  /// Field controller.
+  final TextEditingController controller;
+
+  /// Placeholder text.
+  final String hint;
+
+  /// Leading icon.
+  final IconData icon;
+
+  /// Whether to obscure input (passwords).
+  final bool obscure;
+
+  /// Keyboard type.
+  final TextInputType? keyboardType;
+
+  /// Optional trailing widget (e.g. obscure toggle).
+  final Widget? trailing;
+
+  /// Submit callback (keyboard action).
+  final ValueChanged<String>? onSubmitted;
+
+  /// Overrides the keyboard action button.
+  final TextInputAction? textInputAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      obscureText: obscure,
+      keyboardType: keyboardType,
+      textInputAction:
+          textInputAction ??
+          (onSubmitted != null ? TextInputAction.done : TextInputAction.next),
+      onSubmitted: onSubmitted,
+      decoration: InputDecoration(
+        hintText: hint,
+        prefixIcon: Icon(icon, color: AppColors.subtleForeground, size: 20),
+        suffixIcon: trailing,
+        filled: true,
+        fillColor: AppColors.inputBackground,
+        border: const OutlineInputBorder(
+          borderRadius: BorderRadius.all(AppRadius.lg),
+          borderSide: BorderSide.none,
+        ),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+          vertical: AppSpacing.md,
+        ),
+      ),
+    );
+  }
+}
+
+/// Full-width gradient CTA with an inline loading spinner, used by the
+/// trainer login screen.
+class AuthGradientButton extends StatelessWidget {
+  /// Creates the gradient button.
+  const AuthGradientButton({
+    super.key,
+    required this.label,
+    required this.onTap,
+    required this.loading,
+  });
+
+  /// Button label.
+  final String label;
+
+  /// Tap callback (ignored while [loading]).
+  final VoidCallback onTap;
+
+  /// Whether to show the spinner instead of the label.
+  final bool loading;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      borderRadius: const BorderRadius.all(AppRadius.lg),
+      child: InkWell(
+        onTap: loading ? null : onTap,
+        borderRadius: const BorderRadius.all(AppRadius.lg),
+        child: Ink(
+          height: 52,
+          decoration: BoxDecoration(
+            gradient: loading ? null : authBrandGradient,
+            color: loading ? AppColors.inputBackground : null,
+            borderRadius: const BorderRadius.all(AppRadius.lg),
+          ),
+          child: Center(
+            child: loading
+                ? const SizedBox(
+                    width: 22,
+                    height: 22,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      valueColor: AlwaysStoppedAnimation<Color>(
+                        AppColors.primary,
+                      ),
+                    ),
+                  )
+                : Text(
+                    label,
+                    style: const TextStyle(
+                      color: AppColors.primaryForeground,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/flutter_trainer/test/features/auth/trainer_sign_in_page_test.dart
+++ b/frontend/flutter_trainer/test/features/auth/trainer_sign_in_page_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:oncare_trainer/app/app.dart';
+import 'package:oncare_trainer/core/storage/prefs_provider.dart';
+import 'package:oncare_trainer/features/auth/domain/entities/session_state.dart';
+import 'package:oncare_trainer/features/auth/presentation/controllers/session_controller.dart';
+
+/// Pumps the full app (so GoRouter navigation works) with a fresh mock
+/// prefs override, and returns the ProviderContainer for assertions.
+Future<ProviderContainer> _pumpApp(WidgetTester tester) async {
+  SharedPreferences.setMockInitialValues(<String, Object>{});
+  final prefs = await SharedPreferences.getInstance();
+  final container = ProviderContainer(
+    overrides: <Override>[
+      sharedPreferencesProvider.overrideWithValue(prefs),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const OncareTrainerApp(),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return container;
+}
+
+void main() {
+  group('TrainerSignInPage', () {
+    testWidgets('shows a validation snackbar when fields are empty', (
+      tester,
+    ) async {
+      await _pumpApp(tester);
+
+      await tester.tap(find.widgetWithText(InkWell, '로그인'));
+      await tester.pump(); // let the snackbar appear
+
+      expect(find.text('이메일과 비밀번호를 입력해 주세요'), findsOneWidget);
+    });
+
+    testWidgets('demo bypass enters demo mode and leaves the login screen', (
+      tester,
+    ) async {
+      final container = await _pumpApp(tester);
+
+      await tester.tap(find.text('로그인 없이 데모 둘러보기'));
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(sessionControllerProvider).status,
+        SessionStatus.demo,
+      );
+      // Left the login screen (no more login button / demo link).
+      expect(find.text('로그인 없이 데모 둘러보기'), findsNothing);
+    });
+
+    testWidgets('login with credentials authenticates and navigates away', (
+      tester,
+    ) async {
+      final container = await _pumpApp(tester);
+
+      await tester.enterText(find.byType(TextField).at(0), 'trainer@oncare.com');
+      await tester.enterText(find.byType(TextField).at(1), 'pw');
+      await tester.tap(find.widgetWithText(InkWell, '로그인'));
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(sessionControllerProvider).status,
+        SessionStatus.authenticated,
+      );
+      expect(find.text('로그인 없이 데모 둘러보기'), findsNothing);
+    });
+  });
+}

--- a/frontend/flutter_trainer/test/widget_test.dart
+++ b/frontend/flutter_trainer/test/widget_test.dart
@@ -1,20 +1,29 @@
-// Scaffold smoke test — verifies the trainer app boots to its
-// placeholder landing screen with the design tokens wired up.
+// Boot smoke test — the trainer app now starts on the login screen.
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:oncare_trainer/app/app.dart';
+import 'package:oncare_trainer/core/storage/prefs_provider.dart';
 
 void main() {
-  testWidgets('boots to the trainer scaffold landing screen', (
-    WidgetTester tester,
-  ) async {
+  testWidgets('boots to the trainer login screen', (WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    final prefs = await SharedPreferences.getInstance();
+
     await tester.pumpWidget(
-      const ProviderScope(child: OncareTrainerApp()),
+      ProviderScope(
+        overrides: <Override>[
+          sharedPreferencesProvider.overrideWithValue(prefs),
+        ],
+        child: const OncareTrainerApp(),
+      ),
     );
     await tester.pumpAndSettle();
 
     expect(find.text('온케어 트레이너'), findsOneWidget);
+    expect(find.text('로그인'), findsOneWidget);
+    expect(find.text('로그인 없이 데모 둘러보기'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary

- 트레이너 전용 로그인 화면을 신규 제작하고 이슈 #164의 세션 로직(SessionController)에 연결했습니다.
- 레이아웃은 사용자 앱 sign_in_page.dart를 참고하되, 트레이너 계정은 1:1이라 소셜 로그인·회원가입은 제외하고 이메일/비밀번호 + 데모 바이패스만 두었습니다.
- 모든 색·간격·반지름을 트레이너 design_system 토큰으로만 구성(하드코딩 없음)했고, 위젯 테스트 3종 + 부트 스모크로 검증했습니다.

---

## Changes

### ✨ Features
- `TrainerSignInPage`(로그인/빈값 검증/데모 바이패스) — `SessionController`에 연결
- `auth_fields.dart`: 트레이너 오렌지 그라데이션 `AuthField`/`AuthGradientButton`

### 🔧 Improvements
- 라우터 초기 경로를 로그인으로 변경, `/dashboard` placeholder 라우트 추가

### 🎨 UI/UX
- 온케어 로고 + "온케어 트레이너" 헤더 + 오렌지 CTA + 데모 링크 (소셜/회원가입 없음)

---

## Commits

1. `7083dcc` feat: add trainer sign-in screen wired to session logic

---

## Notes

- 이슈 #164(세션 로직) 브랜치 위에 쌓은 스택 PR입니다 — `#163 → #164 → #169` 순으로 병합 권장.
- 라우터 인증 게이트(리다이렉트)와 실제 4탭 셸은 후속 앱 셸 이슈 범위입니다. 현재 로그인/데모 성공 시 `/dashboard` placeholder로 이동합니다.
- `auth_fields.dart`는 사용자 앱 위젯을 코드 공유 없이 패턴만 참고했습니다 (`package:oncare/` import 0건).

---

## Test Plan

- [ ] 기능 정상 동작 확인
- [ ] 예외 케이스 확인
- [ ] UI 확인
- [ ] 빌드 성공
- [ ] 관련 테스트 통과

### Manual Test Steps

1. `cd frontend/flutter_trainer && flutter pub get`
2. `flutter run` → 로그인 화면 확인 → 빈값으로 로그인 시 검증 스낵바
3. 이메일/비번 입력 후 로그인 → 대시보드 이동 / "로그인 없이 데모 둘러보기" → 대시보드 이동
4. `flutter analyze` (No issues) / `flutter test` (10 passed)

---

## Related Issues

Closes #169

---

## Checklist

- [ ] 코드 리뷰 준비 완료
- [ ] 불필요한 코드 제거
- [ ] 하드코딩 값 점검
- [ ] Merge 충돌 없음
- [ ] 데모 시나리오 영향 확인