### PR TITLE
feat(trainer-clients): build client list from seeded drift data

### DIFF
--- a/frontend/flutter_trainer/lib/app/router/app_router.dart
+++ b/frontend/flutter_trainer/lib/app/router/app_router.dart
@@ -8,6 +8,7 @@ import 'package:oncare_trainer/features/ai_routine/presentation/pages/ai_routine
 import 'package:oncare_trainer/features/auth/domain/entities/session_state.dart';
 import 'package:oncare_trainer/features/auth/presentation/controllers/session_controller.dart';
 import 'package:oncare_trainer/features/auth/presentation/pages/trainer_sign_in_page.dart';
+import 'package:oncare_trainer/features/clients/presentation/pages/client_detail_page.dart';
 import 'package:oncare_trainer/features/clients/presentation/pages/clients_page.dart';
 import 'package:oncare_trainer/features/my/presentation/pages/my_page.dart';
 import 'package:oncare_trainer/features/schedule/presentation/pages/schedule_page.dart';
@@ -85,6 +86,12 @@ GoRouter buildAppRouter({
             ],
           ),
         ],
+      ),
+      // Full-screen client detail (over the shell — no bottom nav).
+      GoRoute(
+        path: AppRoutes.clientDetailPattern,
+        builder: (context, state) =>
+            ClientDetailPage(clientId: state.pathParameters['id']!),
       ),
       GoRoute(
         path: AppRoutes.signIn,

--- a/frontend/flutter_trainer/lib/app/router/routes.dart
+++ b/frontend/flutter_trainer/lib/app/router/routes.dart
@@ -20,4 +20,10 @@ class AppRoutes {
 
   /// MY — trainer profile.
   static const String my = '/my';
+
+  /// Client detail route pattern (full-screen, over the shell).
+  static const String clientDetailPattern = '/client/:id';
+
+  /// Builds the client detail path for [id].
+  static String clientDetail(String id) => '/client/$id';
 }

--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/client_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/client_repository.dart
@@ -1,0 +1,71 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare_trainer/core/storage/app_database.dart';
+import 'package:oncare_trainer/features/clients/domain/entities/trainer_client.dart';
+
+/// Reads client + schedule data from the local drift DB for the
+/// 고객 관리 tab. Returns reactive streams so the UI updates if the
+/// underlying rows change (e.g. a routine sent from another tab).
+class ClientRepository {
+  /// Creates the repository over [_db].
+  const ClientRepository(this._db);
+
+  final AppDatabase _db;
+
+  /// All clients, ordered as seeded (sortOrder).
+  Stream<List<TrainerClient>> watchClients() {
+    final query = _db.select(_db.trainerClients)
+      ..orderBy(<OrderingTerm Function($TrainerClientsTable)>[
+        (t) => OrderingTerm(expression: t.sortOrder),
+      ]);
+    return query.watch().map(
+      (rows) => rows.map(_toEntity).toList(),
+    );
+  }
+
+  /// Count of today's booked sessions — every schedule slot that isn't a
+  /// gap (`공백`). Drives the "오늘 N명 예약" header badge.
+  Stream<int> watchTodayReservationCount() {
+    final query = _db.select(_db.trainerScheduleEntries)
+      ..where((t) => t.status.equals('공백').not());
+    return query.watch().map((rows) => rows.length);
+  }
+
+  TrainerClient _toEntity(TrainerClientRow row) {
+    final week = (jsonDecode(row.weekCompletionJson) as List<Object?>)
+        .map((e) => e as int)
+        .toList();
+    return TrainerClient(
+      id: row.id,
+      name: row.name,
+      avatar: row.avatar,
+      goal: row.goal,
+      lastMessage: row.lastMessage,
+      lastTime: row.lastTime,
+      active: row.active,
+      calories: row.caloriesToday,
+      sodiumMg: row.sodiumMg,
+      sugarG: row.sugarG,
+      lastRoutine: row.lastRoutine,
+      weekCompletion: week,
+    );
+  }
+}
+
+/// Provides the [ClientRepository] wired to the app database.
+final clientRepositoryProvider = Provider<ClientRepository>((ref) {
+  return ClientRepository(ref.watch(appDatabaseProvider));
+});
+
+/// Streams the client list for the 고객 관리 tab.
+final clientsProvider = StreamProvider<List<TrainerClient>>((ref) {
+  return ref.watch(clientRepositoryProvider).watchClients();
+});
+
+/// Streams today's booked-session count for the header badge.
+final todayReservationCountProvider = StreamProvider<int>((ref) {
+  return ref.watch(clientRepositoryProvider).watchTodayReservationCount();
+});

--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/client_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/client_repository.dart
@@ -26,12 +26,24 @@ class ClientRepository {
     );
   }
 
-  /// Count of today's booked sessions — every schedule slot that isn't a
-  /// gap (`공백`). Drives the "오늘 N명 예약" header badge.
+  /// Count of today's booked sessions — every schedule slot dated today
+  /// that isn't a gap (`공백`). Drives the "오늘 N명 예약" header badge.
+  /// Uses a SQL `COUNT(*)` aggregate rather than loading every row.
   Stream<int> watchTodayReservationCount() {
-    final query = _db.select(_db.trainerScheduleEntries)
-      ..where((t) => t.status.equals('공백').not());
-    return query.watch().map((rows) => rows.length);
+    final today = _todayString();
+    final table = _db.trainerScheduleEntries;
+    final count = countAll();
+    final query = _db.selectOnly(table)
+      ..addColumns(<Expression<Object>>[count])
+      ..where(table.date.equals(today) & table.status.equals('공백').not());
+    return query.map((row) => row.read(count) ?? 0).watchSingle();
+  }
+
+  static String _todayString() {
+    final now = DateTime.now();
+    return '${now.year.toString().padLeft(4, '0')}-'
+        '${now.month.toString().padLeft(2, '0')}-'
+        '${now.day.toString().padLeft(2, '0')}';
   }
 
   TrainerClient _toEntity(TrainerClientRow row) {

--- a/frontend/flutter_trainer/lib/features/clients/domain/entities/trainer_client.dart
+++ b/frontend/flutter_trainer/lib/features/clients/domain/entities/trainer_client.dart
@@ -1,0 +1,60 @@
+/// A trainer's client, as shown on the 고객 관리 list and detail screens.
+/// Decoded from the drift `TrainerClients` row (the `weekCompletionJson`
+/// column becomes a `List<int>` here).
+class TrainerClient {
+  /// Creates a client.
+  const TrainerClient({
+    required this.id,
+    required this.name,
+    required this.avatar,
+    required this.goal,
+    required this.lastMessage,
+    required this.lastTime,
+    required this.active,
+    required this.calories,
+    required this.sodiumMg,
+    required this.sugarG,
+    required this.lastRoutine,
+    required this.weekCompletion,
+  });
+
+  /// Row id (e.g. `seed-client-1`).
+  final String id;
+
+  /// Display name (e.g. 김민수).
+  final String name;
+
+  /// Single-char avatar label (e.g. 김).
+  final String avatar;
+
+  /// Goal label (e.g. 혈압 관리 · 체중 감량).
+  final String goal;
+
+  /// Preview of the most recent chat message.
+  final String lastMessage;
+
+  /// Relative time label for [lastMessage] (e.g. 방금).
+  final String lastTime;
+
+  /// Whether the client is currently active.
+  final bool active;
+
+  /// Today's total calories (kcal).
+  final int calories;
+
+  /// Today's sodium (mg).
+  final int sodiumMg;
+
+  /// Today's sugar (g).
+  final int sugarG;
+
+  /// Label for the last routine sent (e.g. 오늘 / 어제 / 5일 전).
+  final String lastRoutine;
+
+  /// This week's daily completion rates (7 entries, 월→일).
+  final List<int> weekCompletion;
+
+  /// Sodium exceeds the 2000 mg daily target — surfaced as a warning on
+  /// the list card and counted by the AI summary.
+  bool get sodiumOverBudget => sodiumMg > 2000;
+}

--- a/frontend/flutter_trainer/lib/features/clients/presentation/pages/client_detail_page.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/pages/client_detail_page.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/features/clients/data/repositories/client_repository.dart';
+
+/// Client detail screen. The full 채팅/식단/운동기록 sub-tabs ship in
+/// their own issue; for now this confirms navigation + the selected
+/// client, keeping a full-screen (no bottom nav) presentation.
+class ClientDetailPage extends ConsumerWidget {
+  /// Creates the detail screen for the client with [clientId].
+  const ClientDetailPage({super.key, required this.clientId});
+
+  /// Id of the client being viewed (from the route path).
+  final String clientId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clients = ref.watch(clientsProvider).valueOrNull ?? const [];
+    // (empty fallback keeps the header rendering while data loads)
+    final match = clients.where((c) => c.id == clientId);
+    final name = match.isNotEmpty ? match.first.name : '고객';
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.card,
+        surfaceTintColor: Colors.transparent,
+        title: Text(
+          name,
+          style: const TextStyle(fontWeight: FontWeight.w700),
+        ),
+      ),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.xl),
+          child: Text(
+            '$name님 상세(채팅·식단·운동기록) 화면은 곧 준비됩니다',
+            textAlign: TextAlign.center,
+            style: const TextStyle(color: AppColors.mutedForeground),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/flutter_trainer/lib/features/clients/presentation/pages/clients_page.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/pages/clients_page.dart
@@ -1,15 +1,180 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
-import 'package:oncare_trainer/shared/widgets/tab_placeholder.dart';
+import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/radius.dart';
+import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/features/clients/data/repositories/client_repository.dart';
+import 'package:oncare_trainer/features/clients/domain/entities/trainer_client.dart';
+import 'package:oncare_trainer/features/clients/presentation/widgets/client_card.dart';
 
-/// 고객 관리 tab. Real client list ships in its own issue; a placeholder
-/// keeps the shell navigable for now.
-class ClientsPage extends StatelessWidget {
+/// 고객 관리 tab — reservation badge, AI summary, and the client list.
+class ClientsPage extends ConsumerWidget {
   /// Creates the clients tab.
   const ClientsPage({super.key});
 
   @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final clients = ref.watch(clientsProvider);
+    final reservations = ref.watch(todayReservationCountProvider).valueOrNull;
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        child: clients.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => Center(
+            child: Text(
+              '고객 정보를 불러오지 못했어요',
+              style: TextStyle(color: AppColors.mutedForeground),
+            ),
+          ),
+          data: (list) => _ClientsView(clients: list, reservations: reservations),
+        ),
+      ),
+    );
+  }
+}
+
+class _ClientsView extends StatelessWidget {
+  const _ClientsView({required this.clients, required this.reservations});
+
+  final List<TrainerClient> clients;
+  final int? reservations;
+
+  @override
   Widget build(BuildContext context) {
-    return const TabPlaceholder(title: '고객 관리', emoji: '👥');
+    final theme = Theme.of(context);
+    final sodiumOver = clients.where((c) => c.sodiumOverBudget).length;
+
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.xl,
+        AppSpacing.lg,
+        AppSpacing.xl,
+        AppSpacing.xxl,
+      ),
+      children: <Widget>[
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: <Widget>[
+            Expanded(
+              child: Text(
+                '고객 관리',
+                style: theme.textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+            ),
+            if (reservations != null)
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.sm,
+                  vertical: 4,
+                ),
+                decoration: BoxDecoration(
+                  color: AppColors.accentSurface,
+                  borderRadius: const BorderRadius.all(AppRadius.pill),
+                ),
+                child: Text(
+                  '오늘 $reservations명 예약',
+                  style: const TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.accent,
+                  ),
+                ),
+              ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.lg),
+        _AiSummaryCard(sodiumOver: sodiumOver),
+        const SizedBox(height: AppSpacing.lg),
+        for (final client in clients) ...<Widget>[
+          ClientCard(
+            client: client,
+            onTap: () => context.push(AppRoutes.clientDetail(client.id)),
+          ),
+          const SizedBox(height: AppSpacing.md),
+        ],
+      ],
+    );
+  }
+}
+
+/// The "✦ AI 요약" card summarising how many clients are over their
+/// sodium target today.
+class _AiSummaryCard extends StatelessWidget {
+  const _AiSummaryCard({required this.sodiumOver});
+
+  final int sodiumOver;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.lg),
+      decoration: BoxDecoration(
+        color: AppColors.accentSurface,
+        borderRadius: const BorderRadius.all(AppRadius.card),
+        border: Border.all(color: AppColors.borderStrong),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            decoration: const BoxDecoration(
+              color: AppColors.accent,
+              borderRadius: BorderRadius.all(AppRadius.pill),
+            ),
+            child: const Text(
+              '✦ AI 요약',
+              style: TextStyle(
+                fontSize: 9.5,
+                fontWeight: FontWeight.w700,
+                color: AppColors.accentForeground,
+              ),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.md),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text.rich(
+                  TextSpan(
+                    children: <InlineSpan>[
+                      const TextSpan(text: '오늘 나트륨 초과 고객 '),
+                      TextSpan(
+                        text: '$sodiumOver명',
+                        style: const TextStyle(color: AppColors.warning),
+                      ),
+                    ],
+                    style: const TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w700,
+                      color: AppColors.foreground,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  sodiumOver > 0
+                      ? '루틴 조정이 필요할 수 있어요.'
+                      : '모든 고객이 목표 범위 안에 있어요.',
+                  style: const TextStyle(
+                    fontSize: 11.5,
+                    color: AppColors.mutedForeground,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_card.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_card.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/radius.dart';
+import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/features/clients/domain/entities/trainer_client.dart';
+
+/// A client row on the 고객 관리 list: avatar + active dot, name, goal,
+/// last message, and a quick-metric footer (칼로리 / 나트륨 / 마지막 루틴).
+class ClientCard extends StatelessWidget {
+  /// Creates a card for [client]; [onTap] opens the detail screen.
+  const ClientCard({super.key, required this.client, required this.onTap});
+
+  /// The client to render.
+  final TrainerClient client;
+
+  /// Called when the card is tapped.
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.card,
+      borderRadius: const BorderRadius.all(AppRadius.card),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: const BorderRadius.all(AppRadius.card),
+        child: Container(
+          padding: const EdgeInsets.all(AppSpacing.lg),
+          decoration: BoxDecoration(
+            borderRadius: const BorderRadius.all(AppRadius.card),
+            border: Border.all(color: AppColors.border),
+          ),
+          child: Column(
+            children: <Widget>[
+              Row(
+                children: <Widget>[
+                  _Avatar(label: client.avatar, active: client.active),
+                  const SizedBox(width: AppSpacing.md),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Row(
+                          children: <Widget>[
+                            Expanded(
+                              child: Text(
+                                client.name,
+                                style: const TextStyle(
+                                  fontSize: 15,
+                                  fontWeight: FontWeight.w700,
+                                  color: AppColors.foreground,
+                                ),
+                              ),
+                            ),
+                            Text(
+                              client.lastTime,
+                              style: const TextStyle(
+                                fontSize: 11,
+                                color: AppColors.disabledForeground,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          client.goal,
+                          style: const TextStyle(
+                            fontSize: 11.5,
+                            color: AppColors.subtleForeground,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          client.lastMessage,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            fontSize: 12,
+                            color: AppColors.mutedForeground,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const Icon(
+                    Icons.chevron_right,
+                    size: 20,
+                    color: AppColors.disabledForeground,
+                  ),
+                ],
+              ),
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: AppSpacing.md),
+                child: Divider(height: 1, color: AppColors.borderStrong),
+              ),
+              Row(
+                children: <Widget>[
+                  _Metric(label: '칼로리', value: '${client.calories}kcal'),
+                  _Metric(
+                    label: '나트륨',
+                    value: '${client.sodiumMg}mg',
+                    warn: client.sodiumOverBudget,
+                  ),
+                  _Metric(label: '마지막 루틴', value: client.lastRoutine),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Avatar extends StatelessWidget {
+  const _Avatar({required this.label, required this.active});
+
+  final String label;
+  final bool active;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 44,
+      height: 44,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: <Widget>[
+          Container(
+            width: 44,
+            height: 44,
+            alignment: Alignment.center,
+            decoration: const BoxDecoration(
+              shape: BoxShape.circle,
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: <Color>[AppColors.accent, AppColors.accentDark],
+              ),
+            ),
+            child: Text(
+              label,
+              style: const TextStyle(
+                color: AppColors.accentForeground,
+                fontWeight: FontWeight.w800,
+                fontSize: 15,
+              ),
+            ),
+          ),
+          Positioned(
+            right: 0,
+            bottom: 0,
+            child: Container(
+              width: 12,
+              height: 12,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: active ? AppColors.success : AppColors.disabledForeground,
+                border: Border.all(color: AppColors.card, width: 2),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Metric extends StatelessWidget {
+  const _Metric({required this.label, required this.value, this.warn = false});
+
+  final String label;
+  final String value;
+  final bool warn;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Column(
+        children: <Widget>[
+          Text(
+            label,
+            style: const TextStyle(
+              fontSize: 10,
+              color: AppColors.subtleForeground,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            value,
+            style: TextStyle(
+              fontSize: 11.5,
+              fontWeight: FontWeight.w700,
+              color: warn ? AppColors.warning : AppColors.foreground,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/flutter_trainer/test/app/router/app_router_test.dart
+++ b/frontend/flutter_trainer/test/app/router/app_router_test.dart
@@ -1,30 +1,10 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
-import 'package:oncare_trainer/app/app.dart';
 import 'package:oncare_trainer/app/router/app_router.dart';
 import 'package:oncare_trainer/app/router/routes.dart';
-import 'package:oncare_trainer/core/storage/prefs_provider.dart';
 import 'package:oncare_trainer/features/auth/domain/entities/session_state.dart';
 
-/// Pumps the app with a prefs override (optionally pre-seeded with a
-/// token so the session restores as authenticated).
-Future<void> _pumpApp(WidgetTester tester, {String? token}) async {
-  final values = <String, Object>{};
-  if (token != null) values['trainer_access_token'] = token;
-  SharedPreferences.setMockInitialValues(values);
-  final prefs = await SharedPreferences.getInstance();
-  await tester.pumpWidget(
-    ProviderScope(
-      overrides: <Override>[
-        sharedPreferencesProvider.overrideWithValue(prefs),
-      ],
-      child: const OncareTrainerApp(),
-    ),
-  );
-  await tester.pumpAndSettle();
-}
+import '../../helpers/pump_app.dart';
 
 void main() {
   group('sessionRedirect', () {
@@ -69,14 +49,14 @@ void main() {
     testWidgets('unauthenticated boot lands on the login screen', (
       tester,
     ) async {
-      await _pumpApp(tester);
+      await pumpTrainerApp(tester);
       expect(find.text('로그인 없이 데모 둘러보기'), findsOneWidget);
     });
 
     testWidgets('restored session boots into the shell (고객 tab)', (
       tester,
     ) async {
-      await _pumpApp(tester, token: 'demo-trainer-token-existing');
+      await pumpTrainerApp(tester, token: 'demo-trainer-token-existing');
 
       // Auth gate redirected past sign-in into the shell.
       expect(find.text('로그인 없이 데모 둘러보기'), findsNothing);
@@ -89,14 +69,14 @@ void main() {
     });
 
     testWidgets('tapping a tab switches the branch', (tester) async {
-      await _pumpApp(tester, token: 'demo-trainer-token-existing');
+      await pumpTrainerApp(tester, token: 'demo-trainer-token-existing');
 
       await tester.tap(find.text('스케줄'));
-      await tester.pumpAndSettle();
+      await settle(tester);
       expect(find.text('스케줄 화면은 곧 준비됩니다'), findsOneWidget);
 
       await tester.tap(find.text('MY'));
-      await tester.pumpAndSettle();
+      await settle(tester);
       expect(find.text('MY 화면은 곧 준비됩니다'), findsOneWidget);
     });
   });

--- a/frontend/flutter_trainer/test/features/auth/trainer_sign_in_page_test.dart
+++ b/frontend/flutter_trainer/test/features/auth/trainer_sign_in_page_test.dart
@@ -1,41 +1,17 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
-import 'package:oncare_trainer/app/app.dart';
-import 'package:oncare_trainer/core/storage/prefs_provider.dart';
 import 'package:oncare_trainer/features/auth/domain/entities/session_state.dart';
 import 'package:oncare_trainer/features/auth/presentation/controllers/session_controller.dart';
 
-/// Pumps the full app (so GoRouter navigation works) with a fresh mock
-/// prefs override, and returns the ProviderContainer for assertions.
-Future<ProviderContainer> _pumpApp(WidgetTester tester) async {
-  SharedPreferences.setMockInitialValues(<String, Object>{});
-  final prefs = await SharedPreferences.getInstance();
-  final container = ProviderContainer(
-    overrides: <Override>[
-      sharedPreferencesProvider.overrideWithValue(prefs),
-    ],
-  );
-  addTearDown(container.dispose);
-
-  await tester.pumpWidget(
-    UncontrolledProviderScope(
-      container: container,
-      child: const OncareTrainerApp(),
-    ),
-  );
-  await tester.pumpAndSettle();
-  return container;
-}
+import '../../helpers/pump_app.dart';
 
 void main() {
   group('TrainerSignInPage', () {
     testWidgets('shows a validation snackbar when fields are empty', (
       tester,
     ) async {
-      await _pumpApp(tester);
+      await pumpTrainerApp(tester);
 
       await tester.tap(find.widgetWithText(InkWell, '로그인'));
       await tester.pump(); // let the snackbar appear
@@ -46,10 +22,10 @@ void main() {
     testWidgets('demo bypass enters demo mode and leaves the login screen', (
       tester,
     ) async {
-      final container = await _pumpApp(tester);
+      final container = await pumpTrainerApp(tester);
 
       await tester.tap(find.text('로그인 없이 데모 둘러보기'));
-      await tester.pumpAndSettle();
+      await settle(tester);
 
       expect(
         container.read(sessionControllerProvider).status,
@@ -62,12 +38,12 @@ void main() {
     testWidgets('login with credentials authenticates and navigates away', (
       tester,
     ) async {
-      final container = await _pumpApp(tester);
+      final container = await pumpTrainerApp(tester);
 
       await tester.enterText(find.byType(TextField).at(0), 'trainer@oncare.com');
       await tester.enterText(find.byType(TextField).at(1), 'pw');
       await tester.tap(find.widgetWithText(InkWell, '로그인'));
-      await tester.pumpAndSettle();
+      await settle(tester);
 
       expect(
         container.read(sessionControllerProvider).status,

--- a/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
@@ -1,3 +1,4 @@
+import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -34,6 +35,23 @@ void main() {
       final count =
           await ClientRepository(db).watchTodayReservationCount().first;
       expect(count, 4); // 6 slots − 2 공백
+    });
+
+    test('reservation count excludes non-today schedule rows', () async {
+      // A booked session on a different date must NOT inflate today's badge.
+      await db.into(db.trainerScheduleEntries).insert(
+            TrainerScheduleEntriesCompanion.insert(
+              id: 'schedule-other-day',
+              date: '2020-01-01',
+              time: '10:00',
+              status: '예정',
+              clientName: const Value('과거 고객'),
+            ),
+          );
+
+      final count =
+          await ClientRepository(db).watchTodayReservationCount().first;
+      expect(count, 4); // still 4 — the 2020 row is excluded
     });
   });
 

--- a/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
@@ -1,0 +1,72 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/core/storage/app_database.dart';
+import 'package:oncare_trainer/core/storage/seed_data.dart';
+import 'package:oncare_trainer/features/clients/data/repositories/client_repository.dart';
+
+import '../../helpers/pump_app.dart';
+
+void main() {
+  group('ClientRepository', () {
+    late AppDatabase db;
+
+    setUp(() async {
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      await seedIfEmpty(db);
+    });
+    tearDown(() => db.close());
+
+    test('watchClients returns the 3 seeded clients in order', () async {
+      final clients = await ClientRepository(db).watchClients().first;
+      expect(clients.map((c) => c.name).toList(), <String>['김민수', '이지수', '박성호']);
+    });
+
+    test('sodiumOverBudget flags only clients above 2000mg', () async {
+      final clients = await ClientRepository(db).watchClients().first;
+      expect(
+        clients.where((c) => c.sodiumOverBudget).map((c) => c.name).toSet(),
+        <String>{'김민수', '박성호'}, // 2100, 2400; 이지수 1800 is under
+      );
+    });
+
+    test('reservation count excludes 공백 slots', () async {
+      final count =
+          await ClientRepository(db).watchTodayReservationCount().first;
+      expect(count, 4); // 6 slots − 2 공백
+    });
+  });
+
+  group('ClientsPage', () {
+    testWidgets('renders the 3 clients, AI summary count, and badge', (
+      tester,
+    ) async {
+      await pumpTrainerApp(tester, token: 'demo-trainer-token');
+
+      expect(find.text('고객 관리'), findsWidgets);
+      expect(find.text('김민수'), findsOneWidget);
+      expect(find.text('이지수'), findsOneWidget);
+      expect(find.text('박성호'), findsOneWidget);
+
+      // 2 clients over the sodium target (김민수 2100, 박성호 2400).
+      // The AI summary is a Text.rich, so match with findRichText.
+      expect(
+        find.textContaining('나트륨 초과 고객 2명', findRichText: true),
+        findsOneWidget,
+      );
+      // 4 booked sessions today (6 slots − 2 gaps).
+      expect(find.text('오늘 4명 예약'), findsOneWidget);
+    });
+
+    testWidgets('tapping a client card opens the detail screen', (
+      tester,
+    ) async {
+      await pumpTrainerApp(tester, token: 'demo-trainer-token');
+
+      await tester.tap(find.text('김민수'));
+      await settle(tester);
+
+      expect(find.text('김민수님 상세(채팅·식단·운동기록) 화면은 곧 준비됩니다'), findsOneWidget);
+    });
+  });
+}

--- a/frontend/flutter_trainer/test/helpers/pump_app.dart
+++ b/frontend/flutter_trainer/test/helpers/pump_app.dart
@@ -1,0 +1,62 @@
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:oncare_trainer/app/app.dart';
+import 'package:oncare_trainer/core/storage/app_database.dart';
+import 'package:oncare_trainer/core/storage/prefs_provider.dart';
+import 'package:oncare_trainer/core/storage/seed_data.dart';
+
+/// Pumps the full trainer app for a widget test, backed by a fresh
+/// in-memory (seeded) drift DB and an optional persisted session token.
+///
+/// Returns the [ProviderContainer] so tests can read providers directly.
+///
+/// NOTE: uses bounded `pump()`s rather than `pumpAndSettle()` — pages
+/// backed by a drift `.watch()` stream keep a live subscription, so
+/// `pumpAndSettle` never reaches an idle frame and times out. Two pumps
+/// (one to build, one to let the stream emit + route transition finish)
+/// are enough for the seeded data to render.
+Future<ProviderContainer> pumpTrainerApp(
+  WidgetTester tester, {
+  String? token,
+  bool seed = true,
+}) async {
+  final values = <String, Object>{};
+  if (token != null) values['trainer_access_token'] = token;
+  SharedPreferences.setMockInitialValues(values);
+  final prefs = await SharedPreferences.getInstance();
+
+  final db = AppDatabase.forTesting(NativeDatabase.memory());
+  if (seed) await seedIfEmpty(db);
+  addTearDown(() async => db.close());
+
+  final container = ProviderContainer(
+    overrides: <Override>[
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      appDatabaseProvider.overrideWithValue(db),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const OncareTrainerApp(),
+    ),
+  );
+  await settle(tester);
+  return container;
+}
+
+/// Bounded settle for drift-stream-backed pages. `pumpAndSettle` never
+/// idles here (a live `.watch()` subscription keeps a frame scheduled),
+/// so instead we pump a fixed number of frames — enough for async chains
+/// like mock-login delay → redirect → route transition → stream emit to
+/// complete, without the infinite wait.
+Future<void> settle(WidgetTester tester) async {
+  for (var i = 0; i < 8; i++) {
+    await tester.pump(const Duration(milliseconds: 250));
+  }
+}


### PR DESCRIPTION
## Summary

- 이슈 #173(앱 셸)의 고객 탭 placeholder를 실제 "고객 관리" 리스트 화면으로 교체하고, 이슈 #170의 시드 drift 데이터를 읽어 렌더링합니다.
- 예약 배지, AI 나트륨 초과 요약, 고객 카드(퀵 지표·경고색), 카드 탭 → 상세 이동을 구현했습니다.
- drift 스트림 화면용 테스트 헬퍼를 도입해 `pumpAndSettle` timeout을 해결하고, 유닛 3종 + 위젯 2종을 추가했습니다.

---

## Changes

### ✨ Features
- `ClientRepository` + `TrainerClient` 엔티티 (drift `.watch` 스트림, 예약 수 집계)
- `ClientsPage`(예약 배지 + AI 요약 + 리스트), `ClientCard`, `ClientDetailPage`(placeholder)
- `/client/:id` 풀스크린 상세 라우트

### 🔧 Improvements
- `test/helpers/pump_app.dart` 공용 헬퍼로 drift 백엔드 위젯 테스트 안정화 (기존 셸/로그인 테스트 이관)

### 🎨 UI/UX
- 고객 카드(아바타·활성 상태·퀵 지표), 나트륨 초과 경고색, AI 요약 카드

---

## Commits

1. `cd71525` feat: build 고객 관리 client list from seeded drift data
2. `e0b7d1d` fix: scope reservation count to today via SQL COUNT aggregate
---

## Notes

- 이슈 #173(앱 셸) 브랜치 위에 쌓은 **스택 PR**입니다. main으로 merge되어 main을 base로 설정하였습니다.
- 상세 화면 본체(채팅·식단·운동기록)는 후속 이슈(이슈 #177) 범위 → 지금은 placeholder만 연결.
- 웹 런타임에서 고객 데이터를 보려면 `sqlite3.wasm`+`drift_worker.js`가 `web/`에 필요합니다(배포 CI 담당). 로컬 검증은 위젯 테스트로 수행했습니다.

---

## Test Plan

- [ ] 기능 정상 동작 확인
- [ ] 예외 케이스 확인
- [ ] UI 확인
- [ ] 빌드 성공
- [ ] 관련 테스트 통과

### Manual Test Steps

1. `cd frontend/flutter_trainer && flutter pub get`
2. `flutter test` → 28 passed
3. `flutter analyze` → No issues / `flutter build web` 성공

---

## Related Issues

Closes #175

---

## Checklist

- [ ] 코드 리뷰 준비 완료
- [ ] 불필요한 코드 제거
- [ ] 하드코딩 값 점검
- [ ] Merge 충돌 없음
- [ ] 데모 시나리오 영향 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 고객 관리 화면에 실제 고객 목록과 고객별 주요 지표를 표시합니다.
  * 오늘 예약 인원과 나트륨 목표 초과 고객 수를 요약해 제공합니다.
  * 고객 카드를 선택하면 고객 상세 화면으로 이동합니다.
  * 고객 상세 화면의 기본 안내 페이지를 추가했습니다.
* **버그 수정**
  * 고객 및 예약 정보가 저장된 데이터와 실시간으로 동기화됩니다.
* **테스트**
  * 고객 목록, 예약 수, 요약 정보 및 상세 화면 이동을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->