### PR TITLE
feat(trainer-clients): client detail — header, sub-tabs, and chat tab

### DIFF
--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/chat_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/chat_repository.dart
@@ -1,0 +1,71 @@
+import 'package:drift/drift.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare_trainer/core/storage/app_database.dart';
+import 'package:oncare_trainer/features/clients/domain/entities/client_chat_message.dart';
+
+/// Reads and appends messages in a client's chat thread (drift-backed).
+class ChatRepository {
+  /// Creates the repository over [_db].
+  const ChatRepository(this._db);
+
+  final AppDatabase _db;
+
+  /// Streams a client's messages in chronological order.
+  Stream<List<ClientChatMessage>> watchThread(String clientId) {
+    final query = _db.select(_db.clientChatMessages)
+      ..where((t) => t.clientId.equals(clientId))
+      ..orderBy(<OrderingTerm Function($ClientChatMessagesTable)>[
+        (t) => OrderingTerm(expression: t.createdAt),
+      ]);
+    return query.watch().map((rows) => rows.map(_toEntity).toList());
+  }
+
+  /// Appends a trainer message. The `chat-` id (no `seed-` prefix) means
+  /// it survives re-seeding, and `now()` sorts it after the seed thread.
+  Future<void> sendTrainerMessage({
+    required String clientId,
+    required String text,
+  }) async {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) return;
+    final now = DateTime.now();
+    await _db
+        .into(_db.clientChatMessages)
+        .insert(
+          ClientChatMessagesCompanion.insert(
+            id: 'chat-$clientId-${now.microsecondsSinceEpoch}',
+            clientId: clientId,
+            sender: 'trainer',
+            body: trimmed,
+            timeLabel: _timeLabel(now),
+            createdAt: now,
+          ),
+        );
+  }
+
+  ClientChatMessage _toEntity(ClientChatMessageRow row) {
+    return ClientChatMessage(
+      id: row.id,
+      sender: row.sender == 'trainer' ? ChatSender.trainer : ChatSender.client,
+      body: row.body,
+      timeLabel: row.timeLabel,
+      createdAt: row.createdAt,
+    );
+  }
+
+  static String _timeLabel(DateTime t) =>
+      '${t.hour.toString().padLeft(2, '0')}:'
+      '${t.minute.toString().padLeft(2, '0')}';
+}
+
+/// Provides the [ChatRepository].
+final chatRepositoryProvider = Provider<ChatRepository>((ref) {
+  return ChatRepository(ref.watch(appDatabaseProvider));
+});
+
+/// Streams a client's chat thread by client id.
+final chatThreadProvider =
+    StreamProvider.family<List<ClientChatMessage>, String>((ref, clientId) {
+      return ref.watch(chatRepositoryProvider).watchThread(clientId);
+    });

--- a/frontend/flutter_trainer/lib/features/clients/domain/entities/client_chat_message.dart
+++ b/frontend/flutter_trainer/lib/features/clients/domain/entities/client_chat_message.dart
@@ -1,0 +1,39 @@
+/// Who sent a chat message.
+enum ChatSender {
+  /// The trainer (right-aligned bubble).
+  trainer,
+
+  /// The client (left-aligned bubble).
+  client,
+}
+
+/// A single chat message in a client thread. Decoded from the drift
+/// `ClientChatMessages` row.
+class ClientChatMessage {
+  /// Creates a chat message.
+  const ClientChatMessage({
+    required this.id,
+    required this.sender,
+    required this.body,
+    required this.timeLabel,
+    required this.createdAt,
+  });
+
+  /// Row id (`seed-chat-…` for seeds, `chat-…` for runtime replies).
+  final String id;
+
+  /// Who sent it.
+  final ChatSender sender;
+
+  /// Message text.
+  final String body;
+
+  /// Display time label (e.g. 18:10).
+  final String timeLabel;
+
+  /// Ordering key.
+  final DateTime createdAt;
+
+  /// Whether this message was sent by the trainer.
+  bool get fromTrainer => sender == ChatSender.trainer;
+}

--- a/frontend/flutter_trainer/lib/features/clients/presentation/pages/client_detail_page.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/pages/client_detail_page.dart
@@ -1,14 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/features/clients/data/repositories/client_repository.dart';
+import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/features/clients/domain/entities/trainer_client.dart';
+import 'package:oncare_trainer/features/clients/presentation/widgets/chat_view.dart';
+import 'package:oncare_trainer/features/clients/presentation/widgets/client_avatar.dart';
 
-/// Client detail screen. The full 채팅/식단/운동기록 sub-tabs ship in
-/// their own issue; for now this confirms navigation + the selected
-/// client, keeping a full-screen (no bottom nav) presentation.
-class ClientDetailPage extends ConsumerWidget {
+/// Client detail screen — header + 채팅/식단/운동기록 sub-tabs. This issue
+/// completes the 채팅 tab; 식단 and 운동기록 ship in their own issues.
+class ClientDetailPage extends ConsumerStatefulWidget {
   /// Creates the detail screen for the client with [clientId].
   const ClientDetailPage({super.key, required this.clientId});
 
@@ -16,31 +21,185 @@ class ClientDetailPage extends ConsumerWidget {
   final String clientId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ClientDetailPage> createState() => _ClientDetailPageState();
+}
+
+class _ClientDetailPageState extends ConsumerState<ClientDetailPage> {
+  int _tab = 0; // 0 채팅 · 1 식단 · 2 운동기록
+
+  @override
+  Widget build(BuildContext context) {
     final clients = ref.watch(clientsProvider).valueOrNull ?? const [];
-    // (empty fallback keeps the header rendering while data loads)
-    final match = clients.where((c) => c.id == clientId);
-    final name = match.isNotEmpty ? match.first.name : '고객';
+    final match = clients.where((c) => c.id == widget.clientId);
+    final client = match.isNotEmpty ? match.first : null;
 
     return Scaffold(
       backgroundColor: AppColors.background,
-      appBar: AppBar(
-        backgroundColor: AppColors.card,
-        surfaceTintColor: Colors.transparent,
-        title: Text(
-          name,
-          style: const TextStyle(fontWeight: FontWeight.w700),
+      body: SafeArea(
+        child: Column(
+          children: <Widget>[
+            _Header(client: client),
+            _SubTabs(
+              current: _tab,
+              onChanged: (i) => setState(() => _tab = i),
+            ),
+            Expanded(child: _body(client)),
+          ],
         ),
       ),
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(AppSpacing.xl),
-          child: Text(
-            '$name님 상세(채팅·식단·운동기록) 화면은 곧 준비됩니다',
-            textAlign: TextAlign.center,
-            style: const TextStyle(color: AppColors.mutedForeground),
+    );
+  }
+
+  Widget _body(TrainerClient? client) {
+    switch (_tab) {
+      case 0:
+        return ChatView(
+          clientId: widget.clientId,
+          clientAvatar: client?.avatar ?? '',
+          clientName: client?.name ?? '고객',
+        );
+      case 1:
+        return const _ComingSoon(label: '식단');
+      default:
+        return const _ComingSoon(label: '운동기록');
+    }
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({required this.client});
+
+  final TrainerClient? client;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.lg,
+        vertical: AppSpacing.md,
+      ),
+      decoration: const BoxDecoration(
+        color: AppColors.card,
+        border: Border(bottom: BorderSide(color: AppColors.borderStrong)),
+      ),
+      child: Row(
+        children: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.arrow_back_ios_new, size: 18),
+            color: AppColors.accent,
+            // Fall back to the 고객 tab when there's nothing to pop (e.g.
+            // a web deep-link / refresh landed straight on the detail).
+            onPressed: () => context.canPop()
+                ? context.pop()
+                : context.go(AppRoutes.clients),
           ),
-        ),
+          ClientAvatar(label: client?.avatar ?? '', size: 36),
+          const SizedBox(width: AppSpacing.md),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  client?.name ?? '고객',
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.foreground,
+                  ),
+                ),
+                if (client != null)
+                  Text(
+                    client!.goal,
+                    style: const TextStyle(
+                      fontSize: 10.5,
+                      color: AppColors.subtleForeground,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          Container(
+            width: 10,
+            height: 10,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: (client?.active ?? false)
+                  ? AppColors.success
+                  : AppColors.disabledForeground,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SubTabs extends StatelessWidget {
+  const _SubTabs({required this.current, required this.onChanged});
+
+  final int current;
+  final ValueChanged<int> onChanged;
+
+  static const List<String> _labels = <String>['채팅', '식단', '운동기록'];
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: AppColors.card,
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.lg,
+        0,
+        AppSpacing.lg,
+        AppSpacing.md,
+      ),
+      child: Row(
+        children: <Widget>[
+          for (var i = 0; i < _labels.length; i++) ...<Widget>[
+            Expanded(
+              child: GestureDetector(
+                onTap: () => onChanged(i),
+                child: Container(
+                  height: 34,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: current == i
+                        ? AppColors.accent
+                        : AppColors.inputBackground,
+                    borderRadius: const BorderRadius.all(AppRadius.md),
+                  ),
+                  child: Text(
+                    _labels[i],
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      color: current == i
+                          ? AppColors.accentForeground
+                          : AppColors.subtleForeground,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            if (i < _labels.length - 1) const SizedBox(width: AppSpacing.xs),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _ComingSoon extends StatelessWidget {
+  const _ComingSoon({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        '$label 화면은 곧 준비됩니다',
+        style: const TextStyle(color: AppColors.mutedForeground),
       ),
     );
   }

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
@@ -47,10 +47,19 @@ class _ChatViewState extends ConsumerState<ChatView> {
   Future<void> _send() async {
     final text = _input.text;
     if (text.trim().isEmpty) return;
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref
+          .read(chatRepositoryProvider)
+          .sendTrainerMessage(clientId: widget.clientId, text: text);
+    } catch (_) {
+      // Keep the draft in the input and tell the user it didn't go out.
+      messenger.showSnackBar(
+        const SnackBar(content: Text('메시지 전송에 실패했어요. 다시 시도해 주세요')),
+      );
+      return;
+    }
     // Clear only after the insert succeeds so the text isn't lost on error.
-    await ref
-        .read(chatRepositoryProvider)
-        .sendTrainerMessage(clientId: widget.clientId, text: text);
     _input.clear();
     _scrollToBottom();
   }

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
@@ -1,0 +1,278 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/radius.dart';
+import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/features/clients/data/repositories/chat_repository.dart';
+import 'package:oncare_trainer/features/clients/domain/entities/client_chat_message.dart';
+import 'package:oncare_trainer/features/clients/presentation/widgets/client_avatar.dart';
+
+/// The 채팅 sub-tab: an AI-received system banner, the message thread
+/// (trainer right / client left), and an input bar that appends a
+/// trainer message to the local DB.
+class ChatView extends ConsumerStatefulWidget {
+  /// Creates the chat view for [clientId].
+  const ChatView({
+    super.key,
+    required this.clientId,
+    required this.clientAvatar,
+    required this.clientName,
+  });
+
+  /// Client whose thread is shown.
+  final String clientId;
+
+  /// Single-char avatar label for client bubbles.
+  final String clientAvatar;
+
+  /// Client display name (used in the system banner).
+  final String clientName;
+
+  @override
+  ConsumerState<ChatView> createState() => _ChatViewState();
+}
+
+class _ChatViewState extends ConsumerState<ChatView> {
+  final TextEditingController _input = TextEditingController();
+  final ScrollController _scroll = ScrollController();
+
+  @override
+  void dispose() {
+    _input.dispose();
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  Future<void> _send() async {
+    final text = _input.text;
+    if (text.trim().isEmpty) return;
+    // Clear only after the insert succeeds so the text isn't lost on error.
+    await ref
+        .read(chatRepositoryProvider)
+        .sendTrainerMessage(clientId: widget.clientId, text: text);
+    _input.clear();
+    _scrollToBottom();
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_scroll.hasClients) return;
+      _scroll.animateTo(
+        _scroll.position.maxScrollExtent,
+        duration: const Duration(milliseconds: 250),
+        curve: Curves.easeOut,
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final messages = ref.watch(chatThreadProvider(widget.clientId));
+
+    return Column(
+      children: <Widget>[
+        Expanded(
+          child: messages.when(
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (e, _) => const Center(
+              child: Text(
+                '대화를 불러오지 못했어요',
+                style: TextStyle(color: AppColors.mutedForeground),
+              ),
+            ),
+            data: (list) {
+              _scrollToBottom();
+              return ListView(
+                controller: _scroll,
+                padding: const EdgeInsets.all(AppSpacing.lg),
+                children: <Widget>[
+                  _SystemBanner(clientName: widget.clientName),
+                  const SizedBox(height: AppSpacing.md),
+                  for (final m in list) ...<Widget>[
+                    _Bubble(message: m, avatar: widget.clientAvatar),
+                    const SizedBox(height: AppSpacing.md),
+                  ],
+                ],
+              );
+            },
+          ),
+        ),
+        _InputBar(controller: _input, onSend: _send),
+      ],
+    );
+  }
+}
+
+class _SystemBanner extends StatelessWidget {
+  const _SystemBanner({required this.clientName});
+
+  final String clientName;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+          vertical: AppSpacing.sm,
+        ),
+        decoration: BoxDecoration(
+          color: AppColors.accentSurface,
+          borderRadius: const BorderRadius.all(AppRadius.card),
+          border: Border.all(color: AppColors.borderStrong),
+        ),
+        child: Column(
+          children: <Widget>[
+            Text(
+              '✦ AI가 $clientName님의 식단·운동 데이터를 분석했어요',
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                fontSize: 10.5,
+                fontWeight: FontWeight.w700,
+                color: AppColors.accent,
+              ),
+            ),
+            const SizedBox(height: 2),
+            const Text(
+              '트레이너님께 요약 리포트가 전송됐어요',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 9.5,
+                color: AppColors.mutedForeground,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Bubble extends StatelessWidget {
+  const _Bubble({required this.message, required this.avatar});
+
+  final ClientChatMessage message;
+  final String avatar;
+
+  @override
+  Widget build(BuildContext context) {
+    final fromTrainer = message.fromTrainer;
+    final bubble = Column(
+      crossAxisAlignment:
+          fromTrainer ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+      children: <Widget>[
+        Container(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.md,
+            vertical: AppSpacing.sm,
+          ),
+          decoration: BoxDecoration(
+            color: fromTrainer ? AppColors.accent : AppColors.card,
+            border: fromTrainer ? null : Border.all(color: AppColors.borderStrong),
+            borderRadius: BorderRadius.only(
+              topLeft: const Radius.circular(16),
+              topRight: const Radius.circular(16),
+              bottomLeft: Radius.circular(fromTrainer ? 16 : 4),
+              bottomRight: Radius.circular(fromTrainer ? 4 : 16),
+            ),
+          ),
+          child: Text(
+            message.body,
+            style: TextStyle(
+              fontSize: 12.5,
+              height: 1.4,
+              fontWeight: FontWeight.w500,
+              color: fromTrainer
+                  ? AppColors.accentForeground
+                  : AppColors.foreground,
+            ),
+          ),
+        ),
+        const SizedBox(height: 3),
+        Text(
+          message.timeLabel,
+          style: const TextStyle(
+            fontSize: 9,
+            color: AppColors.disabledForeground,
+          ),
+        ),
+      ],
+    );
+
+    return Row(
+      mainAxisAlignment:
+          fromTrainer ? MainAxisAlignment.end : MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: <Widget>[
+        if (!fromTrainer) ...<Widget>[
+          ClientAvatar(label: avatar, size: 28),
+          const SizedBox(width: AppSpacing.sm),
+        ],
+        Flexible(child: bubble),
+      ],
+    );
+  }
+}
+
+class _InputBar extends StatelessWidget {
+  const _InputBar({required this.controller, required this.onSend});
+
+  final TextEditingController controller;
+  final Future<void> Function() onSend;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.md,
+        AppSpacing.sm,
+        AppSpacing.md,
+        AppSpacing.md,
+      ),
+      decoration: const BoxDecoration(
+        color: AppColors.card,
+        border: Border(top: BorderSide(color: AppColors.borderStrong)),
+      ),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: TextField(
+              controller: controller,
+              textInputAction: TextInputAction.send,
+              onSubmitted: (_) => onSend(),
+              decoration: InputDecoration(
+                hintText: '메시지 입력...',
+                filled: true,
+                fillColor: AppColors.accentSurface,
+                isDense: true,
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.md,
+                  vertical: AppSpacing.sm,
+                ),
+                border: const OutlineInputBorder(
+                  borderRadius: BorderRadius.all(AppRadius.card),
+                  borderSide: BorderSide.none,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.sm),
+          Material(
+            color: AppColors.accent,
+            shape: const CircleBorder(),
+            child: InkWell(
+              customBorder: const CircleBorder(),
+              onTap: onSend,
+              child: const Padding(
+                padding: EdgeInsets.all(AppSpacing.sm),
+                child: Icon(Icons.send, size: 18, color: AppColors.accentForeground),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_avatar.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_avatar.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+
+/// The blue gradient circle + initial used for a client everywhere they
+/// appear (list card, detail header, chat bubbles). Optionally shows an
+/// active-status dot.
+class ClientAvatar extends StatelessWidget {
+  /// Creates an avatar showing [label]'s initial.
+  const ClientAvatar({
+    super.key,
+    required this.label,
+    this.size = 44,
+    this.showStatus = false,
+    this.active = false,
+  });
+
+  /// Single-char label (e.g. 김).
+  final String label;
+
+  /// Diameter in logical pixels.
+  final double size;
+
+  /// Whether to render the bottom-right active/inactive dot.
+  final bool showStatus;
+
+  /// Active (green) vs inactive (grey) — only used when [showStatus].
+  final bool active;
+
+  @override
+  Widget build(BuildContext context) {
+    final circle = Container(
+      width: size,
+      height: size,
+      alignment: Alignment.center,
+      decoration: const BoxDecoration(
+        shape: BoxShape.circle,
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: <Color>[AppColors.accent, AppColors.accentDark],
+        ),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: AppColors.accentForeground,
+          fontWeight: FontWeight.w800,
+          fontSize: size * 0.34,
+        ),
+      ),
+    );
+
+    if (!showStatus) return circle;
+
+    final dot = size * 0.27;
+    return SizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: <Widget>[
+          circle,
+          Positioned(
+            right: 0,
+            bottom: 0,
+            child: Container(
+              width: dot,
+              height: dot,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: active
+                    ? AppColors.success
+                    : AppColors.disabledForeground,
+                border: Border.all(color: AppColors.card, width: 2),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_card.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_card.dart
@@ -4,6 +4,7 @@ import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/trainer_client.dart';
+import 'package:oncare_trainer/features/clients/presentation/widgets/client_avatar.dart';
 
 /// A client row on the 고객 관리 list: avatar + active dot, name, goal,
 /// last message, and a quick-metric footer (칼로리 / 나트륨 / 마지막 루틴).
@@ -35,7 +36,11 @@ class ClientCard extends StatelessWidget {
             children: <Widget>[
               Row(
                 children: <Widget>[
-                  _Avatar(label: client.avatar, active: client.active),
+                  ClientAvatar(
+                    label: client.avatar,
+                    showStatus: true,
+                    active: client.active,
+                  ),
                   const SizedBox(width: AppSpacing.md),
                   Expanded(
                     child: Column(
@@ -110,60 +115,6 @@ class ClientCard extends StatelessWidget {
             ],
           ),
         ),
-      ),
-    );
-  }
-}
-
-class _Avatar extends StatelessWidget {
-  const _Avatar({required this.label, required this.active});
-
-  final String label;
-  final bool active;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: 44,
-      height: 44,
-      child: Stack(
-        clipBehavior: Clip.none,
-        children: <Widget>[
-          Container(
-            width: 44,
-            height: 44,
-            alignment: Alignment.center,
-            decoration: const BoxDecoration(
-              shape: BoxShape.circle,
-              gradient: LinearGradient(
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-                colors: <Color>[AppColors.accent, AppColors.accentDark],
-              ),
-            ),
-            child: Text(
-              label,
-              style: const TextStyle(
-                color: AppColors.accentForeground,
-                fontWeight: FontWeight.w800,
-                fontSize: 15,
-              ),
-            ),
-          ),
-          Positioned(
-            right: 0,
-            bottom: 0,
-            child: Container(
-              width: 12,
-              height: 12,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                color: active ? AppColors.success : AppColors.disabledForeground,
-                border: Border.all(color: AppColors.card, width: 2),
-              ),
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
@@ -1,0 +1,105 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/core/storage/app_database.dart';
+import 'package:oncare_trainer/core/storage/seed_data.dart';
+import 'package:oncare_trainer/features/clients/data/repositories/chat_repository.dart';
+import 'package:oncare_trainer/features/clients/domain/entities/client_chat_message.dart';
+
+import '../../helpers/pump_app.dart';
+
+void main() {
+  group('ChatRepository', () {
+    late AppDatabase db;
+
+    setUp(() async {
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      await seedIfEmpty(db);
+    });
+    tearDown(() => db.close());
+
+    test('watchThread returns a client thread in chronological order',
+        () async {
+      final thread =
+          await ChatRepository(db).watchThread('seed-client-1').first;
+      expect(thread, isNotEmpty);
+      // Seeded 김민수 thread opens with the trainer's sodium question.
+      expect(thread.first.sender, ChatSender.trainer);
+      expect(thread.first.body, contains('AI 식단 분석'));
+      // Sorted ascending by createdAt.
+      for (var i = 1; i < thread.length; i++) {
+        expect(
+          thread[i].createdAt.isBefore(thread[i - 1].createdAt),
+          isFalse,
+        );
+      }
+    });
+
+    test('sendTrainerMessage appends a trainer message that sorts last',
+        () async {
+      final repo = ChatRepository(db);
+      await repo.sendTrainerMessage(clientId: 'seed-client-1', text: '  안녕하세요  ');
+
+      final thread = await repo.watchThread('seed-client-1').first;
+      final last = thread.last;
+      expect(last.sender, ChatSender.trainer);
+      expect(last.body, '안녕하세요'); // trimmed
+      expect(last.id.startsWith('seed-'), isFalse); // survives re-seed
+    });
+
+    test('sendTrainerMessage ignores empty/whitespace input', () async {
+      final repo = ChatRepository(db);
+      final before = (await repo.watchThread('seed-client-1').first).length;
+      await repo.sendTrainerMessage(clientId: 'seed-client-1', text: '   ');
+      final after = (await repo.watchThread('seed-client-1').first).length;
+      expect(after, before);
+    });
+  });
+
+  group('ClientDetailPage chat', () {
+    Future<void> openDetail(WidgetTester tester) async {
+      await pumpTrainerApp(tester, token: 'demo-trainer-token');
+      await tester.tap(find.text('김민수'));
+      await settle(tester);
+    }
+
+    testWidgets('shows the header, sub-tabs, and seeded chat', (tester) async {
+      await openDetail(tester);
+
+      expect(find.text('채팅'), findsOneWidget);
+      expect(find.text('식단'), findsOneWidget);
+      expect(find.text('운동기록'), findsOneWidget);
+      expect(
+        find.textContaining('AI가 김민수님의'),
+        findsOneWidget,
+      );
+      // A seeded client reply is present.
+      expect(find.text('찌개 먹을 때 국물을 많이 마셨나봐요 😅'), findsOneWidget);
+    });
+
+    testWidgets('sending a message appends it to the thread', (tester) async {
+      await openDetail(tester);
+
+      await tester.enterText(find.byType(TextField), '다음 세션 때 봐요!');
+      await tester.tap(find.byIcon(Icons.send));
+      await settle(tester);
+
+      expect(find.text('다음 세션 때 봐요!'), findsOneWidget);
+    });
+
+    testWidgets('switching sub-tabs shows the 식단/운동기록 placeholders', (
+      tester,
+    ) async {
+      await openDetail(tester);
+
+      await tester.tap(find.text('식단'));
+      await settle(tester);
+      expect(find.text('식단 화면은 곧 준비됩니다'), findsOneWidget);
+
+      await tester.tap(find.text('운동기록'));
+      await settle(tester);
+      expect(find.text('운동기록 화면은 곧 준비됩니다'), findsOneWidget);
+    });
+  });
+}

--- a/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
@@ -84,7 +84,9 @@ void main() {
       await tester.tap(find.text('김민수'));
       await settle(tester);
 
-      expect(find.text('김민수님 상세(채팅·식단·운동기록) 화면은 곧 준비됩니다'), findsOneWidget);
+      // Detail screen opened — its 채팅/식단/운동기록 sub-tabs are unique to it.
+      expect(find.text('채팅'), findsOneWidget);
+      expect(find.text('운동기록'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary

- 이슈 #175(고객 리스트)의 상세 placeholder를 실제 고객 상세(헤더 + 채팅/식단/운동기록 서브탭 + 채팅 완성)로 교체했습니다.
- 시드 채팅을 시간순 렌더하고, 트레이너 메시지 전송을 로컬 drift에 append해 즉시 반영·영속화합니다.
- `/code-review` 3건(아바타 중복/pop 폴백/전송 입력 클리어)을 반영하고 35개 테스트를 통과했습니다.

---

## Changes

### ✨ Features
- `ChatRepository`(스트림 + 전송) + `ClientChatMessage` 엔티티
- `ClientDetailPage`(헤더+서브탭), `ChatView`(배너+말풍선+입력바)
- 공유 `ClientAvatar` 위젯

### 🔧 Improvements
- 뒤로가기 `canPop` 폴백, 전송 입력 클리어 순서, 아바타 위젯 DRY

### 🎨 UI/UX
- 좌우 정렬 채팅 말풍선, AI 수신 시스템 배너, 서브탭 전환

### 📝 Docs
*(없음)*

### 🐛 Fixes
*(없음 — `/code-review` 발견분은 Improvements에 반영, 아래 Notes 참고)*

---

## Commits

1. `c490edf` feat: client detail — header, sub-tabs, and 채팅 tab
2. `aa24685` fix: surface a snackbar when sending a chat message fails

---

## Notes

- 이슈 #175(고객 리스트) 브랜치 위에 쌓은 **스택 PR**입니다. base를 `feature/175-trainer-clients-list`로 설정하세요.
- 식단/운동기록 서브탭은 후속 이슈 #179/#181 범위 → 지금은 placeholder.
- `/code-review`(high effort) 실행·반영 완료: 아바타 위젯 중복 추출(DRY), 웹 딥링크 진입 시 `canPop` 폴백 처리, 전송 실패 시 입력 텍스트 보존.

---

## Test Plan

- [ ] 기능 정상 동작 확인
- [ ] 예외 케이스 확인
- [ ] UI 확인
- [ ] 빌드 성공
- [ ] 관련 테스트 통과

### Manual Test Steps

1. `cd frontend/flutter_trainer && flutter pub get`
2. `flutter test` → 35 passed
3. `flutter analyze` → No issues

---

## Related Issues

Closes #177

---

## Checklist

- [ ] 코드 리뷰 준비 완료
- [ ] 불필요한 코드 제거
- [ ] 하드코딩 값 점검
- [ ] Merge 충돌 없음
- [ ] 데모 시나리오 영향 확인