### PR TITLE
feat(trainer-clients): client detail — diet sub-tab with nutrition summary and AI comment

### DIFF
--- a/frontend/flutter_trainer/lib/design_system/tokens/colors.dart
+++ b/frontend/flutter_trainer/lib/design_system/tokens/colors.dart
@@ -28,6 +28,10 @@ class AppColors {
   /// Deeper blue — second stop of the client-avatar gradient.
   static const Color accentDark = Color(0xFF2A8FBD);
 
+  /// Purple used for the 당류(sugar) metric on the diet summary
+  /// (mock: App.tsx 식단 서브탭, `#9B8FD4`).
+  static const Color accentPurple = Color(0xFF9B8FD4);
+
   // --- Surface / text ---
   /// App canvas behind cards (mock uses `#F8FAFC`).
   static const Color background = Color(0xFFF8FAFC);

--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/client_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/client_repository.dart
@@ -4,6 +4,7 @@ import 'package:drift/drift.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare_trainer/core/storage/app_database.dart';
+import 'package:oncare_trainer/features/clients/domain/entities/client_diet_entry.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/trainer_client.dart';
 
 /// Reads client + schedule data from the local drift DB for the
@@ -37,6 +38,27 @@ class ClientRepository {
       ..addColumns(<Expression<Object>>[count])
       ..where(table.date.equals(today) & table.status.equals('공백').not());
     return query.map((row) => row.read(count) ?? 0).watchSingle();
+  }
+
+  /// A client's meals for the 식단 sub-tab, in seeded order (아침 → 저녁).
+  Stream<List<ClientDietEntry>> watchDiet(String clientId) {
+    final query = _db.select(_db.clientDietEntries)
+      ..where((t) => t.clientId.equals(clientId))
+      ..orderBy(<OrderingTerm Function($ClientDietEntriesTable)>[
+        (t) => OrderingTerm(expression: t.sortOrder),
+      ]);
+    return query.watch().map(
+      (rows) => rows
+          .map(
+            (row) => ClientDietEntry(
+              meal: row.meal,
+              items: row.items,
+              calories: row.calories,
+              sodiumMg: row.sodiumMg,
+            ),
+          )
+          .toList(),
+    );
   }
 
   static String _todayString() {
@@ -81,3 +103,9 @@ final clientsProvider = StreamProvider<List<TrainerClient>>((ref) {
 final todayReservationCountProvider = StreamProvider<int>((ref) {
   return ref.watch(clientRepositoryProvider).watchTodayReservationCount();
 });
+
+/// Streams a client's meals for the 식단 sub-tab.
+final clientDietProvider =
+    StreamProvider.family<List<ClientDietEntry>, String>((ref, clientId) {
+      return ref.watch(clientRepositoryProvider).watchDiet(clientId);
+    });

--- a/frontend/flutter_trainer/lib/features/clients/domain/entities/client_diet_entry.dart
+++ b/frontend/flutter_trainer/lib/features/clients/domain/entities/client_diet_entry.dart
@@ -1,0 +1,23 @@
+/// One meal in a client's day (아침/점심/저녁), as shown on the 식단
+/// sub-tab. Decoded from the drift `ClientDietEntries` row.
+class ClientDietEntry {
+  /// Creates a meal entry.
+  const ClientDietEntry({
+    required this.meal,
+    required this.items,
+    required this.calories,
+    required this.sodiumMg,
+  });
+
+  /// Meal label (아침 | 점심 | 저녁).
+  final String meal;
+
+  /// Foods eaten, comma-joined (e.g. "오트밀, 바나나").
+  final String items;
+
+  /// Calories for this meal (kcal).
+  final int calories;
+
+  /// Sodium for this meal (mg).
+  final int sodiumMg;
+}

--- a/frontend/flutter_trainer/lib/features/clients/domain/entities/trainer_client.dart
+++ b/frontend/flutter_trainer/lib/features/clients/domain/entities/trainer_client.dart
@@ -1,3 +1,10 @@
+/// Daily sodium target (mg). Over this, the list card metric, the diet
+/// summary tile, and the AI comment all flip to the warning case.
+const int sodiumTargetMg = 2000;
+
+/// Daily sugar target (g). Over this, the diet summary 당류 tile warns.
+const int sugarTargetG = 50;
+
 /// A trainer's client, as shown on the 고객 관리 list and detail screens.
 /// Decoded from the drift `TrainerClients` row (the `weekCompletionJson`
 /// column becomes a `List<int>` here).
@@ -54,7 +61,7 @@ class TrainerClient {
   /// This week's daily completion rates (7 entries, 월→일).
   final List<int> weekCompletion;
 
-  /// Sodium exceeds the 2000 mg daily target — surfaced as a warning on
-  /// the list card and counted by the AI summary.
-  bool get sodiumOverBudget => sodiumMg > 2000;
+  /// Sodium exceeds the [sodiumTargetMg] daily target — surfaced as a
+  /// warning on the list card and counted by the AI summary.
+  bool get sodiumOverBudget => sodiumMg > sodiumTargetMg;
 }

--- a/frontend/flutter_trainer/lib/features/clients/presentation/pages/client_detail_page.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/pages/client_detail_page.dart
@@ -10,6 +10,7 @@ import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/trainer_client.dart';
 import 'package:oncare_trainer/features/clients/presentation/widgets/chat_view.dart';
 import 'package:oncare_trainer/features/clients/presentation/widgets/client_avatar.dart';
+import 'package:oncare_trainer/features/clients/presentation/widgets/diet_view.dart';
 
 /// Client detail screen — header + 채팅/식단/운동기록 sub-tabs. This issue
 /// completes the 채팅 tab; 식단 and 운동기록 ship in their own issues.
@@ -59,7 +60,9 @@ class _ClientDetailPageState extends ConsumerState<ClientDetailPage> {
           clientName: client?.name ?? '고객',
         );
       case 1:
-        return const _ComingSoon(label: '식단');
+        return client == null
+            ? const Center(child: CircularProgressIndicator())
+            : DietView(client: client);
       default:
         return const _ComingSoon(label: '운동기록');
     }

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/diet_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/diet_view.dart
@@ -87,7 +87,9 @@ class _NutritionSummary extends StatelessWidget {
                 label: '나트륨',
                 value: client.sodiumMg,
                 unit: 'mg',
-                color: AppColors.warning,
+                // Neutral base like the other tiles — orange comes only
+                // from `warn` when the target is exceeded.
+                color: AppColors.accentDark,
                 warn: client.sodiumMg > sodiumTargetMg,
               ),
               const SizedBox(width: AppSpacing.sm),

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/diet_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/diet_view.dart
@@ -1,0 +1,289 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/radius.dart';
+import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/features/clients/data/repositories/client_repository.dart';
+import 'package:oncare_trainer/features/clients/domain/entities/client_diet_entry.dart';
+import 'package:oncare_trainer/features/clients/domain/entities/trainer_client.dart';
+
+/// The 식단 sub-tab: today's nutrition summary (칼로리/나트륨/당류),
+/// per-meal records, and a conditional AI comment.
+class DietView extends ConsumerWidget {
+  /// Creates the diet view for [client].
+  const DietView({super.key, required this.client});
+
+  /// The client whose diet is shown (carries today's totals).
+  final TrainerClient client;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final diet = ref.watch(clientDietProvider(client.id));
+
+    return diet.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => const Center(
+        child: Text(
+          '식단을 불러오지 못했어요',
+          style: TextStyle(color: AppColors.mutedForeground),
+        ),
+      ),
+      data: (meals) => ListView(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        children: <Widget>[
+          _NutritionSummary(client: client),
+          const SizedBox(height: AppSpacing.md),
+          for (final meal in meals) ...<Widget>[
+            _MealCard(entry: meal),
+            const SizedBox(height: AppSpacing.sm),
+          ],
+          const SizedBox(height: AppSpacing.xs),
+          _AiComment(client: client),
+        ],
+      ),
+    );
+  }
+}
+
+/// "오늘 영양 요약" — 칼로리 / 나트륨 / 당류 tiles, warning-styled when
+/// over target.
+class _NutritionSummary extends StatelessWidget {
+  const _NutritionSummary({required this.client});
+
+  final TrainerClient client;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.lg),
+      decoration: BoxDecoration(
+        color: AppColors.card,
+        borderRadius: const BorderRadius.all(AppRadius.card),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          const Text(
+            '오늘 영양 요약',
+            style: TextStyle(
+              fontSize: 12.5,
+              fontWeight: FontWeight.w700,
+              color: AppColors.foreground,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          Row(
+            children: <Widget>[
+              _MetricTile(
+                label: '칼로리',
+                value: client.calories,
+                unit: 'kcal',
+                color: AppColors.accent,
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              _MetricTile(
+                label: '나트륨',
+                value: client.sodiumMg,
+                unit: 'mg',
+                color: AppColors.warning,
+                warn: client.sodiumMg > sodiumTargetMg,
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              _MetricTile(
+                label: '당류',
+                value: client.sugarG,
+                unit: 'g',
+                color: AppColors.accentPurple,
+                warn: client.sugarG > sugarTargetG,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MetricTile extends StatelessWidget {
+  const _MetricTile({
+    required this.label,
+    required this.value,
+    required this.unit,
+    required this.color,
+    this.warn = false,
+  });
+
+  final String label;
+  final int value;
+  final String unit;
+  final Color color;
+  final bool warn;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+        decoration: BoxDecoration(
+          color: warn
+              ? AppColors.warning.withValues(alpha: 0.08)
+              : AppColors.accentSurface,
+          borderRadius: const BorderRadius.all(AppRadius.md),
+        ),
+        child: Column(
+          children: <Widget>[
+            Text(
+              label,
+              style: const TextStyle(
+                fontSize: 9.5,
+                fontWeight: FontWeight.w600,
+                color: AppColors.subtleForeground,
+              ),
+            ),
+            const SizedBox(height: 2),
+            Text(
+              '$value',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w800,
+                color: warn ? AppColors.warning : color,
+              ),
+            ),
+            Text(
+              warn ? '$unit ⚠ 초과' : unit,
+              style: TextStyle(
+                fontSize: 9,
+                fontWeight: warn ? FontWeight.w700 : FontWeight.w400,
+                color: warn ? AppColors.warning : AppColors.subtleForeground,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A single meal record card (아침/점심/저녁 badge, foods, kcal, sodium).
+class _MealCard extends StatelessWidget {
+  const _MealCard({required this.entry});
+
+  final ClientDietEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.lg,
+        vertical: AppSpacing.md,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.card,
+        borderRadius: const BorderRadius.all(AppRadius.card),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.sm,
+                  vertical: 2,
+                ),
+                decoration: const BoxDecoration(
+                  color: AppColors.accentSurface,
+                  borderRadius: BorderRadius.all(AppRadius.pill),
+                ),
+                child: Text(
+                  entry.meal,
+                  style: const TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.accent,
+                  ),
+                ),
+              ),
+              const Spacer(),
+              Text(
+                '${entry.calories} kcal',
+                style: const TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  color: AppColors.accent,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            entry.items,
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w500,
+              color: AppColors.mutedForeground,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            '나트륨 ${entry.sodiumMg}mg',
+            style: const TextStyle(
+              fontSize: 10.5,
+              color: AppColors.subtleForeground,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// "✦ AI 분석" comment — flips wording on the sodium target.
+class _AiComment extends StatelessWidget {
+  const _AiComment({required this.client});
+
+  final TrainerClient client;
+
+  @override
+  Widget build(BuildContext context) {
+    final over = client.sodiumOverBudget;
+    final sodiumMg = client.sodiumMg;
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.lg),
+      decoration: BoxDecoration(
+        color: AppColors.accentSurface,
+        borderRadius: const BorderRadius.all(AppRadius.card),
+        border: Border.all(color: AppColors.borderStrong),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          const Text(
+            '✦ AI 분석',
+            style: TextStyle(
+              fontSize: 10,
+              fontWeight: FontWeight.w700,
+              color: AppColors.accent,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            over
+                ? '나트륨이 목표치를 ${sodiumMg - sodiumTargetMg}mg 초과했어요. '
+                    '오늘 운동 루틴에 유산소를 추가하면 도움이 돼요.'
+                : '오늘 식단은 균형이 잘 맞아요. 현재 루틴을 유지하세요.',
+            style: const TextStyle(
+              fontSize: 12,
+              height: 1.55,
+              fontWeight: FontWeight.w500,
+              color: AppColors.foreground,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
+++ b/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
@@ -127,6 +127,32 @@ void main() {
       expect(thread.last.id, 'chat-runtime-order');
     });
 
+    test('per-meal sums match each client\'s daily totals', () async {
+      // The diet summary tiles read the client row's totals while the
+      // meal cards read ClientDietEntries — the two sources must agree.
+      await seedIfEmpty(db);
+
+      final clients = await db.select(db.trainerClients).get();
+      expect(clients, isNotEmpty);
+      for (final client in clients) {
+        final meals = await (db.select(
+          db.clientDietEntries,
+        )..where((t) => t.clientId.equals(client.id))).get();
+        final sodiumSum = meals.fold<int>(0, (s, m) => s + m.sodiumMg);
+        final kcalSum = meals.fold<int>(0, (s, m) => s + m.calories);
+        expect(
+          sodiumSum,
+          client.sodiumMg,
+          reason: '${client.name}: meal sodium must sum to the daily total',
+        );
+        expect(
+          kcalSum,
+          client.caloriesToday,
+          reason: '${client.name}: meal calories must sum to the daily total',
+        );
+      }
+    });
+
     test('user-added (non-seed) chat messages survive a re-seed', () async {
       await seedIfEmpty(db);
 

--- a/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
@@ -88,14 +88,14 @@ void main() {
       expect(find.text('다음 세션 때 봐요!'), findsOneWidget);
     });
 
-    testWidgets('switching sub-tabs shows the 식단/운동기록 placeholders', (
+    testWidgets('switching sub-tabs shows 식단 view and 운동기록 placeholder', (
       tester,
     ) async {
       await openDetail(tester);
 
       await tester.tap(find.text('식단'));
       await settle(tester);
-      expect(find.text('식단 화면은 곧 준비됩니다'), findsOneWidget);
+      expect(find.text('오늘 영양 요약'), findsOneWidget);
 
       await tester.tap(find.text('운동기록'));
       await settle(tester);

--- a/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
@@ -1,0 +1,82 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/core/storage/app_database.dart';
+import 'package:oncare_trainer/core/storage/seed_data.dart';
+import 'package:oncare_trainer/features/clients/data/repositories/client_repository.dart';
+
+import '../../helpers/pump_app.dart';
+
+void main() {
+  group('ClientRepository.watchDiet', () {
+    late AppDatabase db;
+
+    setUp(() async {
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      await seedIfEmpty(db);
+    });
+    tearDown(() => db.close());
+
+    test('returns the 3 meals in seeded order for a client', () async {
+      final meals =
+          await ClientRepository(db).watchDiet('seed-client-1').first;
+      expect(meals.map((m) => m.meal).toList(), <String>['아침', '점심', '저녁']);
+      expect(meals.first.items, '오트밀, 바나나');
+      expect(meals.first.calories, 315);
+      expect(meals.first.sodiumMg, 380);
+    });
+
+    test('returns per-client data (clients differ)', () async {
+      final repo = ClientRepository(db);
+      final jisu = await repo.watchDiet('seed-client-2').first;
+      final seongho = await repo.watchDiet('seed-client-3').first;
+      expect(jisu.first.items, '그릭요거트, 과일');
+      expect(seongho[1].items, '짜장면'); // 점심
+    });
+  });
+
+  group('DietView', () {
+    Future<void> openDiet(WidgetTester tester, String clientName) async {
+      await pumpTrainerApp(tester, token: 'demo-trainer-token');
+      await tester.tap(find.text(clientName));
+      await settle(tester);
+      await tester.tap(find.text('식단'));
+      await settle(tester);
+    }
+
+    testWidgets('김민수 (sodium over target) shows warning + over AI comment', (
+      tester,
+    ) async {
+      await openDiet(tester, '김민수');
+
+      expect(find.text('오늘 영양 요약'), findsOneWidget);
+      // Summary totals from the client row.
+      expect(find.text('2100'), findsOneWidget);
+      expect(find.text('mg ⚠ 초과'), findsOneWidget);
+      // 3 meals from the seed.
+      expect(find.text('아침'), findsOneWidget);
+      expect(find.text('점심'), findsOneWidget);
+      expect(find.text('저녁'), findsOneWidget);
+      expect(find.text('오트밀, 바나나'), findsOneWidget);
+      expect(find.text('315 kcal'), findsOneWidget);
+      // Over-target AI comment (2100 − 2000 = 100mg).
+      expect(
+        find.textContaining('나트륨이 목표치를 100mg 초과했어요'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('이지수 (sodium under target) shows the balanced AI comment', (
+      tester,
+    ) async {
+      await openDiet(tester, '이지수');
+
+      expect(find.text('그릭요거트, 과일'), findsOneWidget);
+      expect(find.text('mg ⚠ 초과'), findsNothing);
+      expect(
+        find.textContaining('오늘 식단은 균형이 잘 맞아요'),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- 고객 상세의 식단 placeholder를 실제 화면으로 교체 — 오늘 영양 요약(경고 스타일 포함), 끼니별 기록, 나트륨 조건부 AI 코멘트를 시드 데이터 기준으로 렌더링합니다.
- 나트륨/당류 임계값을 도메인 상수로 통합해 리스트·요약·코멘트가 단일 기준을 공유합니다.
- `/code-review` 반영 및 테스트 4종 추가, 전체 39개 테스트 통과.

---

## Changes

### ✨ Features
- `ClientDietEntry` + `watchDiet()` + `clientDietProvider`
- `DietView`(영양 요약 타일·끼니 카드·AI 코멘트)

### 🔧 Improvements
- `sodiumTargetMg`/`sugarTargetG` 도메인 상수 통합, `sodiumOverBudget` 재사용

### 🎨 UI/UX
- 초과 시 "⚠ 초과" 경고 타일, 당류 퍼플 토큰(`accentPurple`) 추가

### 📝 Docs
*(없음)*

### 🐛 Fixes
*(없음 — `/code-review` 반영분은 Improvements에 포함)*

---

## Commits

1. `f124d04` feat: client detail — 식단 sub-tab with nutrition summary and AI comment
2. `ce5bb2a` fix: neutral sodium tile base color and seed totals consistency test

---

## Notes

- 이슈 #177(고객 상세 — 채팅) 브랜치 위에 쌓은 **스택 PR**입니다. base를 `feature/177-client-detail-chat`로 설정하였다.
- 운동기록 서브탭은 후속 이슈 #181 범위 → placeholder 유지.
- 이슈 #177 테스트의 식단 placeholder 단언을 실제 화면 기준으로 갱신했습니다.

---

## Test Plan

- [x] 기능 정상 동작 확인
- [x] 예외 케이스 확인
- [x] UI 확인
- [x] 빌드 성공
- [x] 관련 테스트 통과

### Manual Test Steps

1. `cd frontend/flutter_trainer && flutter pub get`
2. `flutter test` → 39 passed / `flutter analyze` → No issues
3. `flutter run` → 고객 카드 탭 → 식단 탭: 김민수(초과 경고+코멘트) vs 이지수(정상 코멘트) 비교

---

## Related Issues

Closes #179

---

## Checklist

- [ ] 코드 리뷰 준비 완료
- [ ] 불필요한 코드 제거
- [ ] 하드코딩 값 점검
- [ ] Merge 충돌 없음
- [ ] 데모 시나리오 영향 확인