### PR TITLE
feat(ui): On-Care 사용자 앱을 새 Figma 디자인으로 재구성

### DIFF
--- a/frontend/flutter/lib/app/router/main_shell.dart
+++ b/frontend/flutter/lib/app/router/main_shell.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/features/diet/presentation/widgets/diet_flows.dart';
+import 'package:oncare/features/exercise/presentation/widgets/exercise_flows.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/coaching_sheet.dart';
+import 'package:oncare/shared/widgets/oni_fab.dart';
 
 /// Persistent `Scaffold` hosting the bottom navigation bar. Icons and
 /// labels mirror the original React `BottomNav.tsx` (Home / 식단 /
@@ -15,52 +20,80 @@ class MainShell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
+    final double bottomInset = MediaQuery.of(context).padding.bottom;
+    const double barHeight = 64;
+    const double lift = 24; // headroom so the + button floats above the bar
     return Scaffold(
       body: navigationShell,
-      bottomNavigationBar: Container(
-        decoration: const BoxDecoration(
-          color: AppColors.background,
-          border: Border(top: BorderSide(color: AppColors.border)),
-        ),
-        child: SafeArea(
-          top: false,
-          child: SizedBox(
-            height: 64,
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 672),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceAround,
-                children: <Widget>[
-                  _Destination(
-                    icon: Icons.home_outlined,
-                    activeIcon: Icons.home,
-                    label: l.navDashboard,
-                    selected: navigationShell.currentIndex == 0,
-                    onTap: () => _onTap(0),
+      floatingActionButton: OniFab(onTap: () => showCoachingSheet(context)),
+      bottomNavigationBar: SizedBox(
+        height: barHeight + lift + bottomInset,
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 672),
+            child: Stack(
+              clipBehavior: Clip.none,
+              children: <Widget>[
+                // Nav bar pinned to the bottom. The middle slot is left empty
+                // so the floating + button has room between 식단 and 운동.
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  child: Container(
+                    height: barHeight + bottomInset,
+                    padding: EdgeInsets.only(bottom: bottomInset),
+                    decoration: const BoxDecoration(
+                      color: AppColors.background,
+                      border: Border(top: BorderSide(color: AppColors.border)),
+                    ),
+                    child: Row(
+                      children: <Widget>[
+                        _Destination(
+                          icon: Icons.home_outlined,
+                          activeIcon: Icons.home,
+                          label: l.navDashboard,
+                          selected: navigationShell.currentIndex == 0,
+                          onTap: () => _onTap(0),
+                        ),
+                        _Destination(
+                          icon: Icons.restaurant_outlined,
+                          activeIcon: Icons.restaurant,
+                          label: l.navDiet,
+                          selected: navigationShell.currentIndex == 1,
+                          onTap: () => _onTap(1),
+                        ),
+                        const SizedBox(width: 64),
+                        _Destination(
+                          icon: Icons.fitness_center_outlined,
+                          activeIcon: Icons.fitness_center,
+                          label: l.navExercise,
+                          selected: navigationShell.currentIndex == 2,
+                          onTap: () => _onTap(2),
+                        ),
+                        _Destination(
+                          icon: Icons.person_outline,
+                          activeIcon: Icons.person,
+                          label: l.navMyHealth,
+                          selected: navigationShell.currentIndex == 3,
+                          onTap: () => _onTap(3),
+                        ),
+                      ],
+                    ),
                   ),
-                  _Destination(
-                    icon: Icons.restaurant_outlined,
-                    activeIcon: Icons.restaurant,
-                    label: l.navDiet,
-                    selected: navigationShell.currentIndex == 1,
-                    onTap: () => _onTap(1),
+                ),
+                // Floating + button straddling the bar's top edge.
+                Positioned(
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  child: Center(
+                    child: _NavAddButton(
+                      onTap: () => _showRecordAddSheet(context),
+                    ),
                   ),
-                  _Destination(
-                    icon: Icons.fitness_center_outlined,
-                    activeIcon: Icons.fitness_center,
-                    label: l.navExercise,
-                    selected: navigationShell.currentIndex == 2,
-                    onTap: () => _onTap(2),
-                  ),
-                  _Destination(
-                    icon: Icons.person_outline,
-                    activeIcon: Icons.person,
-                    label: l.navMyHealth,
-                    selected: navigationShell.currentIndex == 3,
-                    onTap: () => _onTap(3),
-                  ),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
         ),
@@ -111,6 +144,246 @@ class _Destination extends StatelessWidget {
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The circular "+" button docked in the centre of the bottom nav bar, between
+/// 식단 and 운동. Opens the "새 기록 추가" chooser. Mirrors the Figma bottom-nav FAB.
+class _NavAddButton extends StatelessWidget {
+  const _NavAddButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: Container(
+        width: 56,
+        height: 56,
+        decoration: const BoxDecoration(
+          color: FigmaColors.primary,
+          shape: BoxShape.circle,
+        ),
+        child: const Icon(Icons.add, color: Colors.white, size: 28),
+      ),
+    );
+  }
+}
+
+/// "새 기록 추가" chooser opened by the bottom-nav + button. Routes to the diet
+/// or exercise add flow. Mirrors the Figma add sheet.
+Future<void> _showRecordAddSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    barrierColor: FigmaColors.sheetScrim,
+    builder: (BuildContext ctx) => _RecordAddSheet(
+      onDiet: () {
+        Navigator.of(ctx).pop();
+        showDietAddSheet(context);
+      },
+      onExercise: () {
+        Navigator.of(ctx).pop();
+        showExerciseAddSheet(context);
+      },
+    ),
+  );
+}
+
+class _RecordAddSheet extends StatelessWidget {
+  const _RecordAddSheet({required this.onDiet, required this.onExercise});
+
+  final VoidCallback onDiet;
+  final VoidCallback onExercise;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 480),
+        child: Container(
+          decoration: const BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              const SizedBox(height: 12),
+              Container(
+                width: 36,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: const Color(0xFFDDE3EA),
+                  borderRadius: BorderRadius.circular(999),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 16, 20, 4),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    const Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Text(
+                            '새 기록 추가',
+                            style: TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.w800,
+                              color: FigmaColors.ink,
+                            ),
+                          ),
+                          SizedBox(height: 2),
+                          Text(
+                            '식단 또는 운동을 선택해 주세요',
+                            style: TextStyle(
+                              fontSize: 13,
+                              color: FigmaColors.textSub,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    _SheetCloseButton(onTap: () => Navigator.of(context).pop()),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 12, 20, 24),
+                child: Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: _RecordOption(
+                        icon: Icons.restaurant,
+                        iconColor: FigmaColors.primary,
+                        iconBg: FigmaColors.softBlue,
+                        borderColor: FigmaColors.primary.withValues(
+                          alpha: 0.35,
+                        ),
+                        title: '식단',
+                        subtitle: '사진으로 영양 분석',
+                        onTap: onDiet,
+                      ),
+                    ),
+                    const SizedBox(width: 14),
+                    Expanded(
+                      child: _RecordOption(
+                        icon: Icons.fitness_center,
+                        iconColor: FigmaColors.green,
+                        iconBg: const Color(0xFFEAF8F2),
+                        borderColor: FigmaColors.green.withValues(alpha: 0.35),
+                        title: '운동',
+                        subtitle: '종류와 시간 기록',
+                        onTap: onExercise,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RecordOption extends StatelessWidget {
+  const _RecordOption({
+    required this.icon,
+    required this.iconColor,
+    required this.iconBg,
+    required this.borderColor,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final Color iconColor;
+  final Color iconBg;
+  final Color borderColor;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.white,
+      borderRadius: BorderRadius.circular(18),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: Container(
+          padding: const EdgeInsets.symmetric(vertical: 22),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(18),
+            border: Border.all(color: borderColor),
+          ),
+          child: Column(
+            children: <Widget>[
+              Container(
+                width: 56,
+                height: 56,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: iconBg,
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Icon(icon, color: iconColor, size: 26),
+              ),
+              const SizedBox(height: 14),
+              Text(
+                title,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w800,
+                  color: FigmaColors.ink,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                subtitle,
+                style: const TextStyle(
+                  fontSize: 12,
+                  color: FigmaColors.textSub,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SheetCloseButton extends StatelessWidget {
+  const _SheetCloseButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: const Color(0xFFF4F6F8),
+      shape: const CircleBorder(),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: const SizedBox(
+          width: 32,
+          height: 32,
+          child: Icon(Icons.close, size: 16, color: FigmaColors.textSub),
         ),
       ),
     );

--- a/frontend/flutter/lib/design_system/figma/figma_kit.dart
+++ b/frontend/flutter/lib/design_system/figma/figma_kit.dart
@@ -1,0 +1,280 @@
+import 'package:flutter/material.dart';
+
+/// Exact colour tokens lifted from the On-Care Figma (TypeScript) source so the
+/// Flutter screens reproduce the redesign 1:1.
+///
+/// [AppColors] keeps the shared/semantic brand tokens; this palette adds the
+/// precise inline tints the Figma uses (label greys, macro-bar colours, delta
+/// greens/oranges, banner gradients). Prefer these when matching a screen to
+/// the mockup pixel-for-pixel.
+class FigmaColors {
+  FigmaColors._();
+
+  // Text / ink
+  static const Color ink = Color(0xFF1A1A1A); // headings, near-black
+  static const Color textMuted = Color(0xFFA0A8B5); // labels / greeting
+  static const Color textFaint = Color(0xFFC0CDD6); // inactive tab / minutes
+  static const Color textSub = Color(0xFF8A8A9A); // subtitles
+  static const Color textBody = Color(0xFF5A6A7A); // coaching body copy
+
+  // Brand
+  static const Color primary = Color(0xFF3EAFDF);
+  static const Color primaryDeep = Color(0xFF2A8FBD); // FAB gradient end
+  static const Color primaryStripe = Color(0xFF2190C4); // card top stripe end
+  static const Color oniEnd = Color(0xFF2A9BCA); // Oni avatar gradient end
+
+  // Semantic accents
+  static const Color green = Color(0xFF34C9A0); // protein / good bar
+  static const Color greenText = Color(0xFF22A882); // good delta text
+  static const Color greenTag = Color(0xFF34C782); // coaching 운동 tag
+  static const Color orange = Color(0xFFFF953C); // fat bar / warn fill
+  static const Color orangeText = Color(0xFFE8760A); // warn text
+  static const Color heartOrange = Color(0xFFFF7A45); // spark / trainer accent
+  static const Color sugarPurple = Color(0xFF9B8FD4); // 당류 chart
+  static const Color sleepPurple = Color(0xFF6B7FE0); // 수면 chart
+
+  // Dots / status
+  static const Color redDot = Color(0xFFFF3B5C);
+  static const Color statusGreen = Color(0xFF34C759);
+  static const Color onlineGreen = Color(0xFF4ADE80);
+
+  // Surfaces
+  static const Color softBlue = Color(0xFFF2F9FB); // pill / accent bg
+  static const Color iconTint = Color(0xFFEDF7FC); // icon chip / soft button bg
+  static const Color bannerStart = Color(0xFFEDF7FC);
+  static const Color bannerEnd = Color(0xFFD6EEF8);
+  static const Color track = Color(0xFFF2F4F7); // progress track
+  static const Color statBg = Color(0xFFF8FAFB);
+  static const Color hairline = Color(0x14000000); // rgba(0,0,0,0.08)
+  static const Color sheetScrim = Color(0x8008121C); // rgba(8,18,28,0.5)
+
+  static Color primaryA(double a) => primary.withValues(alpha: a);
+  static Color greenA(double a) => green.withValues(alpha: a);
+  static Color orangeA(double a) => orange.withValues(alpha: a);
+}
+
+/// The On-Care mascot ("Oni") — a teal gradient disc with two eyes and a
+/// smile. Used in the coaching banner, coaching sheet, chat and the FAB.
+class OniAvatar extends StatelessWidget {
+  const OniAvatar({super.key, this.size = 36, this.shadow = true});
+
+  final double size;
+  final bool shadow;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        gradient: const LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: <Color>[FigmaColors.primary, FigmaColors.oniEnd],
+        ),
+        boxShadow: shadow
+            ? <BoxShadow>[
+                BoxShadow(
+                  color: FigmaColors.primary.withValues(alpha: 0.35),
+                  blurRadius: 8,
+                  offset: const Offset(0, 2),
+                ),
+              ]
+            : null,
+      ),
+      child: Center(
+        child: CustomPaint(
+          size: Size.square(size * 0.58),
+          painter: _OniFacePainter(Colors.white),
+        ),
+      ),
+    );
+  }
+}
+
+class _OniFacePainter extends CustomPainter {
+  _OniFacePainter(this.color);
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final double s = size.width / 24.0; // viewBox is 24×24
+    final Paint fill = Paint()
+      ..color = color
+      ..style = PaintingStyle.fill
+      ..isAntiAlias = true;
+    canvas.drawCircle(Offset(8.5 * s, 10 * s), 1.5 * s, fill);
+    canvas.drawCircle(Offset(15.5 * s, 10 * s), 1.5 * s, fill);
+    final Paint stroke = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.6 * s
+      ..strokeCap = StrokeCap.round
+      ..isAntiAlias = true;
+    final Path smile = Path()
+      ..moveTo(8.5 * s, 14.5 * s)
+      ..quadraticBezierTo(12 * s, 17 * s, 15.5 * s, 14.5 * s);
+    canvas.drawPath(smile, stroke);
+  }
+
+  @override
+  bool shouldRepaint(covariant _OniFacePainter oldDelegate) =>
+      oldDelegate.color != color;
+}
+
+/// The small "✦ AI 코칭 / ✦ AI 분석 …" pill badge used across the redesign.
+class AiPill extends StatelessWidget {
+  const AiPill(
+    this.text, {
+    super.key,
+    this.color = FigmaColors.primary,
+    this.background,
+    this.fontSize = 8.5,
+  });
+
+  final String text;
+  final Color color;
+  final Color? background;
+  final double fontSize;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: background ?? color.withValues(alpha: 0.12),
+        borderRadius: const BorderRadius.all(Radius.circular(999)),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(
+          fontSize: fontSize,
+          fontWeight: FontWeight.w700,
+          color: color,
+          height: 1.1,
+        ),
+      ),
+    );
+  }
+}
+
+/// A filled heart in the brand colour — the On-Care wordmark logo used in the
+/// Home header.
+class HeartLogo extends StatelessWidget {
+  const HeartLogo({super.key, this.size = 20, this.color = FigmaColors.primary});
+
+  final double size;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Icon(Icons.favorite, size: size, color: color);
+  }
+}
+
+/// A soft round icon button (36×36, `#F2F9FB` fill, brand-blue glyph) used in
+/// the tab headers, with an optional status dot.
+class FigmaCircleButton extends StatelessWidget {
+  const FigmaCircleButton({
+    super.key,
+    required this.icon,
+    this.onTap,
+    this.showDot = false,
+    this.dotColor = FigmaColors.orange,
+    this.size = 36,
+    this.iconSize = 18,
+  });
+
+  final IconData icon;
+  final VoidCallback? onTap;
+  final bool showDot;
+  final Color dotColor;
+  final double size;
+  final double iconSize;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: <Widget>[
+          Material(
+            color: FigmaColors.softBlue,
+            shape: const CircleBorder(),
+            clipBehavior: Clip.antiAlias,
+            child: InkWell(
+              onTap: onTap,
+              child: Center(
+                child: Icon(icon, size: iconSize, color: FigmaColors.primary),
+              ),
+            ),
+          ),
+          if (showDot)
+            Positioned(
+              top: 6,
+              right: 6,
+              child: Container(
+                width: 8,
+                height: 8,
+                decoration: BoxDecoration(
+                  color: dotColor,
+                  shape: BoxShape.circle,
+                  border: Border.all(color: Colors.white),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The sticky title header used by the 식단 / 운동 / MY tabs: an extrabold
+/// title on the left, bell + calendar circle buttons on the right.
+class FigmaTabHeader extends StatelessWidget {
+  const FigmaTabHeader({
+    super.key,
+    required this.title,
+    this.onBell,
+    this.onCalendar,
+  });
+
+  final String title;
+  final VoidCallback? onBell;
+  final VoidCallback? onCalendar;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 12, 24, 12),
+      child: Row(
+        children: <Widget>[
+          Text(
+            title,
+            style: const TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.w800,
+              color: FigmaColors.ink,
+              letterSpacing: -0.5,
+            ),
+          ),
+          const Spacer(),
+          FigmaCircleButton(
+            icon: Icons.notifications_none_rounded,
+            showDot: true,
+            onTap: onBell,
+          ),
+          const SizedBox(width: 10),
+          FigmaCircleButton(
+            icon: Icons.calendar_today_outlined,
+            iconSize: 16,
+            onTap: onCalendar,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/flutter/lib/design_system/figma/figma_kit.dart
+++ b/frontend/flutter/lib/design_system/figma/figma_kit.dart
@@ -201,14 +201,16 @@ class FigmaCircleButton extends StatelessWidget {
       child: Stack(
         clipBehavior: Clip.none,
         children: <Widget>[
-          Material(
-            color: FigmaColors.softBlue,
-            shape: const CircleBorder(),
-            clipBehavior: Clip.antiAlias,
-            child: InkWell(
-              onTap: onTap,
-              child: Center(
-                child: Icon(icon, size: iconSize, color: FigmaColors.primary),
+          Positioned.fill(
+            child: Material(
+              color: FigmaColors.softBlue,
+              shape: const CircleBorder(),
+              clipBehavior: Clip.antiAlias,
+              child: InkWell(
+                onTap: onTap,
+                child: Center(
+                  child: Icon(icon, size: iconSize, color: FigmaColors.primary),
+                ),
               ),
             ),
           ),

--- a/frontend/flutter/lib/features/ai_coach/presentation/pages/ai_coach_page.dart
+++ b/frontend/flutter/lib/features/ai_coach/presentation/pages/ai_coach_page.dart
@@ -1,23 +1,22 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/features/ai_coach/domain/entities/chat_message.dart';
+import 'package:oncare/features/ai_coach/presentation/controllers/chat_controller.dart';
 
 /// The AI 코치 chat screen, rebuilt to the On-Care Figma design. Opened from the
-/// coaching sheet's "AI와 대화하기" CTA.
-class AICoachPage extends StatefulWidget {
+/// coaching sheet's "AI와 대화하기" CTA. Replies are served by
+/// [chatControllerProvider] (the real coach repository, mock-RAG in demo mode),
+/// so questions get grounded answers with source chips instead of a canned line.
+class AICoachPage extends ConsumerStatefulWidget {
   const AICoachPage({super.key});
 
   @override
-  State<AICoachPage> createState() => _AICoachPageState();
-}
-
-class _ChatMsg {
-  const _ChatMsg(this.text, {required this.fromUser, this.time});
-  final String text;
-  final bool fromUser;
-  final String? time;
+  ConsumerState<AICoachPage> createState() => _AICoachPageState();
 }
 
 const List<String> _quickReplies = <String>[
@@ -26,18 +25,9 @@ const List<String> _quickReplies = <String>[
   '내 혈당 기록은 괜찮아?',
 ];
 
-class _AICoachPageState extends State<AICoachPage> {
+class _AICoachPageState extends ConsumerState<AICoachPage> {
   final TextEditingController _controller = TextEditingController();
   final ScrollController _scroll = ScrollController();
-  final List<_ChatMsg> _messages = <_ChatMsg>[
-    const _ChatMsg(
-      '안녕하세요, 민수님!\n오늘 기록을 바탕으로 건강 관리를 함께 도와드릴게요.',
-      fromUser: false,
-      time: '오후 2:10',
-    ),
-  ];
-
-  bool get _hasConversation => _messages.any((_ChatMsg m) => m.fromUser);
 
   @override
   void dispose() {
@@ -46,22 +36,9 @@ class _AICoachPageState extends State<AICoachPage> {
     super.dispose();
   }
 
-  void _send([String? preset]) {
-    final String text = (preset ?? _controller.text).trim();
-    if (text.isEmpty) return;
-    setState(() {
-      _messages.add(_ChatMsg(text, fromUser: true));
-      _messages.add(
-        const _ChatMsg(
-          '좋은 질문이에요! 오늘 기록을 살펴보면 나트륨이 조금 높은 편이라, '
-          '저녁은 담백한 구이나 샐러드를 추천해요. 식후 20분 가벼운 산책도 함께 해보세요. 🙂',
-          fromUser: false,
-        ),
-      );
-      _controller.clear();
-    });
+  void _scrollToBottom() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_scroll.hasClients) {
+      if (mounted && _scroll.hasClients) {
         _scroll.animateTo(
           _scroll.position.maxScrollExtent,
           duration: const Duration(milliseconds: 250),
@@ -71,8 +48,24 @@ class _AICoachPageState extends State<AICoachPage> {
     });
   }
 
+  void _send([String? preset]) {
+    final String text = (preset ?? _controller.text).trim();
+    if (text.isEmpty) return;
+    _controller.clear();
+    ref.read(chatControllerProvider.notifier).send(text);
+    _scrollToBottom();
+  }
+
   @override
   Widget build(BuildContext context) {
+    final ChatState chat = ref.watch(chatControllerProvider);
+    // Auto-scroll whenever the conversation grows / the typing bubble toggles.
+    ref.listen<ChatState>(chatControllerProvider, (_, _) => _scrollToBottom());
+
+    // The starter prompts only make sense before the user has said anything.
+    final bool showQuickReplies =
+        !chat.messages.any((ChatMessage m) => m.isUser) && !chat.sending;
+
     return Scaffold(
       backgroundColor: const Color(0xFFF5F7FA),
       body: SafeArea(
@@ -108,15 +101,15 @@ class _AICoachPageState extends State<AICoachPage> {
                         ),
                       ),
                       const SizedBox(height: 24),
-                      for (final _ChatMsg m in _messages) ...<Widget>[
+                      for (final ChatMessage m in chat.messages) ...<Widget>[
                         _bubble(m),
                         const SizedBox(height: 16),
                       ],
-                      if (!_hasConversation) _quickReplySection(),
+                      if (showQuickReplies) _quickReplySection(),
                     ],
                   ),
                 ),
-                _inputBar(),
+                _inputBar(sending: chat.sending),
               ],
             ),
           ),
@@ -208,8 +201,8 @@ class _AICoachPageState extends State<AICoachPage> {
     );
   }
 
-  Widget _bubble(_ChatMsg m) {
-    if (m.fromUser) {
+  Widget _bubble(ChatMessage m) {
+    if (m.isUser) {
       return Row(
         mainAxisAlignment: MainAxisAlignment.end,
         children: <Widget>[
@@ -227,7 +220,7 @@ class _AICoachPageState extends State<AICoachPage> {
                 ),
               ),
               child: Text(
-                m.text,
+                m.content,
                 style: const TextStyle(
                   fontSize: 14,
                   height: 1.4,
@@ -272,30 +265,62 @@ class _AICoachPageState extends State<AICoachPage> {
                     ),
                   ],
                 ),
-                child: Text(
-                  m.text,
-                  style: const TextStyle(
-                    fontSize: 14,
-                    height: 1.5,
-                    fontWeight: FontWeight.w500,
-                    color: FigmaColors.ink,
-                  ),
-                ),
+                child: m.pending
+                    ? const _TypingDots()
+                    : Text(
+                        m.content,
+                        style: const TextStyle(
+                          fontSize: 14,
+                          height: 1.5,
+                          fontWeight: FontWeight.w500,
+                          color: FigmaColors.ink,
+                        ),
+                      ),
               ),
-              if (m.time != null)
+              if (!m.pending && m.sources.isNotEmpty)
                 Padding(
-                  padding: const EdgeInsets.only(top: 6, left: 4),
-                  child: Text(
-                    m.time!,
-                    style: const TextStyle(
-                      fontSize: 11,
-                      color: FigmaColors.textFaint,
-                    ),
-                  ),
+                  padding: const EdgeInsets.only(top: 8, left: 4),
+                  child: _sourceChips(m.sources),
                 ),
             ],
           ),
         ),
+      ],
+    );
+  }
+
+  Widget _sourceChips(List<String> sources) {
+    return Wrap(
+      spacing: 6,
+      runSpacing: 6,
+      children: <Widget>[
+        for (final String s in sources)
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+            decoration: BoxDecoration(
+              color: FigmaColors.softBlue,
+              borderRadius: BorderRadius.circular(999),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                const Icon(
+                  Icons.menu_book_outlined,
+                  size: 12,
+                  color: FigmaColors.primary,
+                ),
+                const SizedBox(width: 4),
+                Text(
+                  s,
+                  style: const TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w500,
+                    color: FigmaColors.primary,
+                  ),
+                ),
+              ],
+            ),
+          ),
       ],
     );
   }
@@ -330,7 +355,10 @@ class _AICoachPageState extends State<AICoachPage> {
                 ),
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(16),
-                  border: Border.all(color: FigmaColors.primaryA(0.3), width: 1.5),
+                  border: Border.all(
+                    color: FigmaColors.primaryA(0.3),
+                    width: 1.5,
+                  ),
                 ),
                 child: Text(
                   q,
@@ -349,7 +377,7 @@ class _AICoachPageState extends State<AICoachPage> {
     );
   }
 
-  Widget _inputBar() {
+  Widget _inputBar({required bool sending}) {
     return Container(
       color: Colors.white,
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
@@ -368,7 +396,10 @@ class _AICoachPageState extends State<AICoachPage> {
               decoration: BoxDecoration(
                 color: Colors.white,
                 shape: BoxShape.circle,
-                border: Border.all(color: FigmaColors.primaryA(0.25), width: 1.5),
+                border: Border.all(
+                  color: FigmaColors.primaryA(0.25),
+                  width: 1.5,
+                ),
               ),
               child: const Icon(Icons.add, size: 16, color: FigmaColors.primary),
             ),
@@ -376,7 +407,7 @@ class _AICoachPageState extends State<AICoachPage> {
             Expanded(
               child: TextField(
                 controller: _controller,
-                onSubmitted: (_) => _send(),
+                onSubmitted: sending ? null : (_) => _send(),
                 style: const TextStyle(fontSize: 14, color: FigmaColors.ink),
                 decoration: const InputDecoration(
                   isDense: true,
@@ -391,7 +422,7 @@ class _AICoachPageState extends State<AICoachPage> {
             ),
             const SizedBox(width: 8),
             GestureDetector(
-              onTap: () => _send(),
+              onTap: sending ? null : () => _send(),
               child: Container(
                 width: 32,
                 height: 32,
@@ -406,16 +437,69 @@ class _AICoachPageState extends State<AICoachPage> {
                     ),
                   ],
                 ),
-                child: const Icon(
-                  Icons.arrow_upward,
-                  size: 16,
-                  color: Colors.white,
-                ),
+                child: sending
+                    ? const Padding(
+                        padding: EdgeInsets.all(8),
+                        child: SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            valueColor: AlwaysStoppedAnimation<Color>(
+                              Colors.white,
+                            ),
+                          ),
+                        ),
+                      )
+                    : const Icon(
+                        Icons.arrow_upward,
+                        size: 16,
+                        color: Colors.white,
+                      ),
               ),
             ),
           ],
         ),
       ),
+    );
+  }
+}
+
+/// Three-dot "typing…" indicator shown inside the coach bubble while a reply
+/// is in flight (mirrors the pending [ChatMessage] placeholder).
+class _TypingDots extends StatelessWidget {
+  const _TypingDots();
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        for (int i = 0; i < 3; i++)
+          Padding(
+            padding: EdgeInsets.only(right: i < 2 ? 5 : 0),
+            child:
+                Container(
+                      width: 7,
+                      height: 7,
+                      decoration: const BoxDecoration(
+                        color: FigmaColors.textFaint,
+                        shape: BoxShape.circle,
+                      ),
+                    )
+                    .animate(
+                      onPlay: (AnimationController c) => c.repeat(reverse: true),
+                    )
+                    .fade(
+                      begin: 0.35,
+                      end: 1,
+                      duration: 500.ms,
+                      delay: (i * 150).ms,
+                      curve: Curves.easeInOut,
+                    )
+                    .scaleXY(begin: 0.8, end: 1),
+          ),
+      ],
     );
   }
 }

--- a/frontend/flutter/lib/features/ai_coach/presentation/pages/ai_coach_page.dart
+++ b/frontend/flutter/lib/features/ai_coach/presentation/pages/ai_coach_page.dart
@@ -301,24 +301,30 @@ class _AICoachPageState extends ConsumerState<AICoachPage> {
               color: FigmaColors.softBlue,
               borderRadius: BorderRadius.circular(999),
             ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                const Icon(
-                  Icons.menu_book_outlined,
-                  size: 12,
-                  color: FigmaColors.primary,
-                ),
-                const SizedBox(width: 4),
-                Text(
-                  s,
-                  style: const TextStyle(
-                    fontSize: 11,
-                    fontWeight: FontWeight.w500,
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 220),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  const Icon(
+                    Icons.menu_book_outlined,
+                    size: 12,
                     color: FigmaColors.primary,
                   ),
-                ),
-              ],
+                  const SizedBox(width: 4),
+                  Flexible(
+                    child: Text(
+                      s,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w500,
+                        color: FigmaColors.primary,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
       ],

--- a/frontend/flutter/lib/features/ai_coach/presentation/pages/ai_coach_page.dart
+++ b/frontend/flutter/lib/features/ai_coach/presentation/pages/ai_coach_page.dart
@@ -1,92 +1,421 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
-import 'package:oncare/core/errors/app_error.dart';
-import 'package:oncare/design_system/atoms/app_badge.dart';
-import 'package:oncare/design_system/atoms/app_card.dart';
-import 'package:oncare/design_system/tokens/colors.dart';
-import 'package:oncare/design_system/tokens/spacing.dart';
-import 'package:oncare/features/ai_coach/domain/entities/ai_coach_state.dart';
-import 'package:oncare/features/ai_coach/presentation/controllers/ai_coach_controller.dart';
-import 'package:oncare/gen/l10n/app_localizations.dart';
-import 'package:oncare/shared/widgets/error_view.dart';
+import 'package:oncare/app/router/routes.dart';
+import 'package:oncare/design_system/figma/figma_kit.dart';
 
-({String label, AppBadgeTone tone}) _tagDisplay(AiSuggestionTag t) =>
-    switch (t) {
-      AiSuggestionTag.diet => (label: '식단', tone: AppBadgeTone.warning),
-      AiSuggestionTag.exercise => (label: '운동', tone: AppBadgeTone.success),
-      AiSuggestionTag.sleep => (label: '수면', tone: AppBadgeTone.info),
-      AiSuggestionTag.hydration => (label: '수분', tone: AppBadgeTone.info),
-    };
-
-class AICoachPage extends ConsumerWidget {
+/// The AI 코치 chat screen, rebuilt to the On-Care Figma design. Opened from the
+/// coaching sheet's "AI와 대화하기" CTA.
+class AICoachPage extends StatefulWidget {
   const AICoachPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final l = AppLocalizations.of(context);
-    final async = ref.watch(aiCoachStateProvider);
+  State<AICoachPage> createState() => _AICoachPageState();
+}
+
+class _ChatMsg {
+  const _ChatMsg(this.text, {required this.fromUser, this.time});
+  final String text;
+  final bool fromUser;
+  final String? time;
+}
+
+const List<String> _quickReplies = <String>[
+  '오늘 저녁 메뉴 추천해줘',
+  '오늘 운동은 얼마나 하면 좋을까?',
+  '내 혈당 기록은 괜찮아?',
+];
+
+class _AICoachPageState extends State<AICoachPage> {
+  final TextEditingController _controller = TextEditingController();
+  final ScrollController _scroll = ScrollController();
+  final List<_ChatMsg> _messages = <_ChatMsg>[
+    const _ChatMsg(
+      '안녕하세요, 민수님!\n오늘 기록을 바탕으로 건강 관리를 함께 도와드릴게요.',
+      fromUser: false,
+      time: '오후 2:10',
+    ),
+  ];
+
+  bool get _hasConversation => _messages.any((_ChatMsg m) => m.fromUser);
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  void _send([String? preset]) {
+    final String text = (preset ?? _controller.text).trim();
+    if (text.isEmpty) return;
+    setState(() {
+      _messages.add(_ChatMsg(text, fromUser: true));
+      _messages.add(
+        const _ChatMsg(
+          '좋은 질문이에요! 오늘 기록을 살펴보면 나트륨이 조금 높은 편이라, '
+          '저녁은 담백한 구이나 샐러드를 추천해요. 식후 20분 가벼운 산책도 함께 해보세요. 🙂',
+          fromUser: false,
+        ),
+      );
+      _controller.clear();
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scroll.hasClients) {
+        _scroll.animateTo(
+          _scroll.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 250),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(l.pageAiCoachTitle)),
-      body: async.when(
-        data: (s) => _Body(state: s),
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (Object e, _) => ErrorView(
-          error: e is AppError ? e : UnknownError(message: e.toString()),
-          onRetry: () => ref.invalidate(aiCoachStateProvider),
+      backgroundColor: const Color(0xFFF5F7FA),
+      body: SafeArea(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 720),
+            child: Column(
+              children: <Widget>[
+                _header(context),
+                Expanded(
+                  child: ListView(
+                    controller: _scroll,
+                    padding: const EdgeInsets.fromLTRB(16, 24, 16, 16),
+                    children: <Widget>[
+                      Center(
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 4,
+                          ),
+                          decoration: BoxDecoration(
+                            color: const Color(0xFFE8EEF4),
+                            borderRadius: BorderRadius.circular(999),
+                          ),
+                          child: const Text(
+                            '오늘',
+                            style: TextStyle(
+                              fontSize: 11,
+                              fontWeight: FontWeight.w600,
+                              color: FigmaColors.textSub,
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+                      for (final _ChatMsg m in _messages) ...<Widget>[
+                        _bubble(m),
+                        const SizedBox(height: 16),
+                      ],
+                      if (!_hasConversation) _quickReplySection(),
+                    ],
+                  ),
+                ),
+                _inputBar(),
+              ],
+            ),
+          ),
         ),
       ),
     );
   }
-}
 
-class _Body extends StatelessWidget {
-  const _Body({required this.state});
-  final AiCoachState state;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return ListView(
-      padding: const EdgeInsets.all(AppSpacing.lg),
-      children: <Widget>[
-        AppCard(
-          color: AppColors.primary.withValues(alpha: 0.12),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              const Icon(Icons.smart_toy_outlined, color: AppColors.primary),
-              const SizedBox(width: AppSpacing.md),
-              Expanded(
-                child: Text(state.greeting, style: theme.textTheme.bodyLarge),
-              ),
-            ],
+  Widget _header(BuildContext context) {
+    return Container(
+      color: Colors.white,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      child: Row(
+        children: <Widget>[
+          _circle(
+            Icons.chevron_left,
+            () => context.canPop()
+                ? context.pop()
+                : context.go(AppRoutes.dashboard),
           ),
-        ),
-        const SizedBox(height: AppSpacing.lg),
-        for (final s in state.suggestions) ...<Widget>[
-          AppCard(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+          Expanded(
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
-                Row(
+                Stack(
+                  clipBehavior: Clip.none,
                   children: <Widget>[
-                    AppBadge(
-                      label: _tagDisplay(s.tag).label,
-                      tone: _tagDisplay(s.tag).tone,
+                    const OniAvatar(size: 38),
+                    Positioned(
+                      right: 0,
+                      bottom: 0,
+                      child: Container(
+                        width: 10,
+                        height: 10,
+                        decoration: BoxDecoration(
+                          color: FigmaColors.onlineGreen,
+                          shape: BoxShape.circle,
+                          border: Border.all(color: Colors.white, width: 2),
+                        ),
+                      ),
                     ),
                   ],
                 ),
-                const SizedBox(height: AppSpacing.sm),
-                Text(s.title, style: theme.textTheme.titleMedium),
-                const SizedBox(height: AppSpacing.xs),
-                Text(s.body, style: theme.textTheme.bodyMedium),
+                const SizedBox(width: 10),
+                const Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    Text(
+                      'AI 코치',
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w700,
+                        color: FigmaColors.ink,
+                      ),
+                    ),
+                    Text(
+                      '언제든 물어보세요',
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w500,
+                        color: FigmaColors.primary,
+                      ),
+                    ),
+                  ],
+                ),
               ],
             ),
           ),
-          const SizedBox(height: AppSpacing.sm),
+          _circle(Icons.more_horiz, () {}),
+        ],
+      ),
+    );
+  }
+
+  Widget _circle(IconData icon, VoidCallback onTap) {
+    return Material(
+      color: FigmaColors.softBlue,
+      shape: const CircleBorder(),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: SizedBox(
+          width: 36,
+          height: 36,
+          child: Icon(icon, size: 20, color: FigmaColors.primary),
+        ),
+      ),
+    );
+  }
+
+  Widget _bubble(_ChatMsg m) {
+    if (m.fromUser) {
+      return Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: <Widget>[
+          Flexible(
+            child: Container(
+              constraints: const BoxConstraints(maxWidth: 260),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              decoration: const BoxDecoration(
+                color: FigmaColors.primary,
+                borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(16),
+                  topRight: Radius.circular(16),
+                  bottomLeft: Radius.circular(16),
+                  bottomRight: Radius.circular(4),
+                ),
+              ),
+              child: Text(
+                m.text,
+                style: const TextStyle(
+                  fontSize: 14,
+                  height: 1.4,
+                  fontWeight: FontWeight.w500,
+                  color: Colors.white,
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: <Widget>[
+        const OniAvatar(size: 34),
+        const SizedBox(width: 10),
+        Flexible(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Container(
+                constraints: const BoxConstraints(maxWidth: 255),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 13,
+                ),
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: const BorderRadius.only(
+                    topLeft: Radius.circular(16),
+                    topRight: Radius.circular(16),
+                    bottomLeft: Radius.circular(4),
+                    bottomRight: Radius.circular(16),
+                  ),
+                  border: Border.all(color: FigmaColors.hairline),
+                  boxShadow: <BoxShadow>[
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.07),
+                      blurRadius: 14,
+                      offset: const Offset(0, 2),
+                    ),
+                  ],
+                ),
+                child: Text(
+                  m.text,
+                  style: const TextStyle(
+                    fontSize: 14,
+                    height: 1.5,
+                    fontWeight: FontWeight.w500,
+                    color: FigmaColors.ink,
+                  ),
+                ),
+              ),
+              if (m.time != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 6, left: 4),
+                  child: Text(
+                    m.time!,
+                    style: const TextStyle(
+                      fontSize: 11,
+                      color: FigmaColors.textFaint,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _quickReplySection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        const Padding(
+          padding: EdgeInsets.only(left: 4, bottom: 12),
+          child: Text(
+            '이런 걸 물어보세요',
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: FigmaColors.textSub,
+            ),
+          ),
+        ),
+        for (final String q in _quickReplies) ...<Widget>[
+          Material(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(16),
+            child: InkWell(
+              onTap: () => _send(q),
+              borderRadius: BorderRadius.circular(16),
+              child: Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 13,
+                ),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(color: FigmaColors.primaryA(0.3), width: 1.5),
+                ),
+                child: Text(
+                  q,
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                    color: FigmaColors.primary,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 10),
         ],
       ],
+    );
+  }
+
+  Widget _inputBar() {
+    return Container(
+      color: Colors.white,
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+      child: Container(
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          color: FigmaColors.softBlue,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: FigmaColors.primaryA(0.22), width: 1.5),
+        ),
+        child: Row(
+          children: <Widget>[
+            Container(
+              width: 32,
+              height: 32,
+              decoration: BoxDecoration(
+                color: Colors.white,
+                shape: BoxShape.circle,
+                border: Border.all(color: FigmaColors.primaryA(0.25), width: 1.5),
+              ),
+              child: const Icon(Icons.add, size: 16, color: FigmaColors.primary),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: TextField(
+                controller: _controller,
+                onSubmitted: (_) => _send(),
+                style: const TextStyle(fontSize: 14, color: FigmaColors.ink),
+                decoration: const InputDecoration(
+                  isDense: true,
+                  border: InputBorder.none,
+                  hintText: 'AI에게 무엇이든 물어보세요',
+                  hintStyle: TextStyle(
+                    fontSize: 13,
+                    color: FigmaColors.textFaint,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            GestureDetector(
+              onTap: () => _send(),
+              child: Container(
+                width: 32,
+                height: 32,
+                decoration: BoxDecoration(
+                  color: FigmaColors.primary,
+                  shape: BoxShape.circle,
+                  boxShadow: <BoxShadow>[
+                    BoxShadow(
+                      color: FigmaColors.primaryA(0.45),
+                      blurRadius: 10,
+                      offset: const Offset(0, 2),
+                    ),
+                  ],
+                ),
+                child: const Icon(
+                  Icons.arrow_upward,
+                  size: 16,
+                  color: Colors.white,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/frontend/flutter/lib/features/dashboard/presentation/pages/dashboard_page.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/pages/dashboard_page.dart
@@ -1,75 +1,27 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:oncare/core/errors/app_error.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
-import 'package:oncare/features/ai_coach/presentation/widgets/ai_coach_panel.dart';
-import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
 import 'package:oncare/features/dashboard/presentation/widgets/dashboard_content.dart';
 import 'package:oncare/features/notification/presentation/widgets/notification_panel.dart';
-import 'package:oncare/gen/l10n/app_localizations.dart';
-import 'package:oncare/shared/widgets/error_view.dart';
-import 'package:oncare/shared/widgets/modals/quick_input_dialog.dart';
 import 'package:oncare/shared/widgets/modals/right_slide_panel.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
-import 'package:oncare/shared/widgets/oncare_header.dart';
 
-class DashboardPage extends ConsumerWidget {
+/// Home tab. The header now scrolls with the content (per the Figma redesign),
+/// so the page is just a surface that hosts [DashboardContent]; the floating
+/// Oni assistant lives globally in [MainShell].
+class DashboardPage extends StatelessWidget {
   const DashboardPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final l = AppLocalizations.of(context);
-    final summary = ref.watch(dashboardSummaryProvider);
-
+  Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.background,
-      body: Column(
-        children: <Widget>[
-          OncareHeader(
-            title: l.pageDashboardTitle,
-            onNotificationTap: () => showRightSlidePanel<void>(
-              context,
-              content: const NotificationPanelBody(),
-            ),
-            onCalendarTap: () => showScheduleCalendarSheet(context),
-          ),
-          Expanded(
-            child: summary.when(
-              data: (s) => DashboardContent(
-                summary: s,
-                onQuickInputWeight: () =>
-                    showQuickInputDialog(context, kind: QuickInputKind.weight),
-                onQuickInputBloodPressure: () => showQuickInputDialog(
-                  context,
-                  kind: QuickInputKind.bloodPressure,
-                ),
-                onQuickInputBloodSugar: () => showQuickInputDialog(
-                  context,
-                  kind: QuickInputKind.bloodSugar,
-                ),
-                onOpenSchedule: () => showScheduleCalendarSheet(context),
-              ),
-              loading: () => const Center(child: CircularProgressIndicator()),
-              error: (Object error, StackTrace _) => ErrorView(
-                error: error is AppError
-                    ? error
-                    : UnknownError(message: error.toString()),
-                onRetry: () => ref.invalidate(dashboardSummaryProvider),
-              ),
-            ),
-          ),
-        ],
-      ),
-      floatingActionButton: FloatingActionButton(
-        backgroundColor: AppColors.primary,
-        foregroundColor: AppColors.primaryForeground,
-        tooltip: 'AI 코치',
-        onPressed: () => showRightSlidePanel<void>(
+      body: DashboardContent(
+        onNotificationTap: () => showRightSlidePanel<void>(
           context,
-          content: const AiCoachPanelBody(),
+          content: const NotificationPanelBody(),
         ),
-        child: const Icon(Icons.smart_toy_outlined),
+        onCalendarTap: () => showScheduleCalendarSheet(context),
       ),
     );
   }

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -1,75 +1,90 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
-import 'package:flutter_animate/flutter_animate.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
 
-import 'package:oncare/design_system/atoms/app_card.dart';
-import 'package:oncare/design_system/tokens/colors.dart';
-import 'package:oncare/design_system/tokens/radius.dart';
-import 'package:oncare/design_system/tokens/spacing.dart';
-import 'package:oncare/features/ai_coach/presentation/widgets/coach_chat_card.dart';
-import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
+import 'package:oncare/app/router/routes.dart';
+import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/shared/widgets/coaching_sheet.dart';
 
-/// The Home tab body — five stacked cards matching the React original
-/// `Dashboard.tsx`:
-///   1. greeting line
-///   2. gradient quick-input card (체중 · 혈압 · 혈당)
-///   3. 오늘의 건강 요약 (sodium warning + 4 progress bars + quick stats)
-///   4. 오늘의 일정 (schedule list + "전체보기")
-///   5. 이번 주 건강 점수 (green gradient)
+/// The Home tab, rebuilt to match the On-Care Figma redesign.
+///
+/// Sections (top → bottom): header, greeting, AI coaching banner, 식단/운동
+/// summary cards, 영양 현황 (weekly trend + AI analysis), 이번 주 AI 추천 식단
+/// carousel, 오늘의 일정. Per the product decision the 건강 지표 (심박수·수면)
+/// cards and the sleep AI-coaching banner are intentionally omitted.
 class DashboardContent extends StatelessWidget {
   const DashboardContent({
-    required this.summary,
-    this.onQuickInputWeight,
-    this.onQuickInputBloodPressure,
-    this.onQuickInputBloodSugar,
-    this.onOpenSchedule,
     super.key,
+    this.onNotificationTap,
+    this.onCalendarTap,
   });
 
-  final DashboardSummary summary;
-  final VoidCallback? onQuickInputWeight;
-  final VoidCallback? onQuickInputBloodPressure;
-  final VoidCallback? onQuickInputBloodSugar;
-  final VoidCallback? onOpenSchedule;
+  final VoidCallback? onNotificationTap;
+  final VoidCallback? onCalendarTap;
 
   @override
   Widget build(BuildContext context) {
-    final cards = <Widget>[
-      const _Greeting(),
-      _QuickInputCard(
-        onWeight: onQuickInputWeight,
-        onBloodPressure: onQuickInputBloodPressure,
-        onBloodSugar: onQuickInputBloodSugar,
-      ),
-      CoachChatCard(
-        dietLine: summary.sodiumWarning,
-        exerciseLine: summary.exerciseFeedback,
-      ),
-      _HealthSummaryCard(summary: summary),
-      _ScheduleCard(items: summary.todaySchedule, onOpenAll: onOpenSchedule),
-      _WeekScoreCard(score: summary.weekScore, delta: summary.weekScoreDelta),
-    ];
-
     return Center(
       child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 672),
+        constraints: const BoxConstraints(maxWidth: 720),
         child: ListView(
-          padding: const EdgeInsets.fromLTRB(
-            AppSpacing.lg,
-            AppSpacing.xl,
-            AppSpacing.lg,
-            AppSpacing.xxxl,
-          ),
+          padding: const EdgeInsets.only(bottom: 108),
           children: <Widget>[
-            for (int i = 0; i < cards.length; i++) ...<Widget>[
-              cards[i]
-                  .animate()
-                  .fadeIn(
-                    duration: const Duration(milliseconds: 280),
-                    delay: Duration(milliseconds: 50 * i),
-                  )
-                  .slideY(begin: 0.06, end: 0, curve: Curves.easeOutCubic),
-              if (i < cards.length - 1) const SizedBox(height: AppSpacing.xl),
-            ],
+            _HomeHeader(
+              onNotificationTap: onNotificationTap,
+              onCalendarTap: onCalendarTap,
+              onProfileTap: () => context.go(AppRoutes.myHealth),
+            ),
+            const Padding(
+              padding: EdgeInsets.fromLTRB(24, 0, 24, 16),
+              child: Text(
+                '민수님, 오늘도 가볍게 시작해요 👋',
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                  color: FigmaColors.textMuted,
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 0, 24, 20),
+              child: _CoachingBanner(onTap: () => showCoachingSheet(context)),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 0, 24, 20),
+              child: IntrinsicHeight(
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    Expanded(
+                      child: _DietSummaryCard(
+                        onOpen: () => context.go(AppRoutes.diet),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: _ExerciseSummaryCard(
+                        onOpen: () => context.go(AppRoutes.exercise),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const Padding(
+              padding: EdgeInsets.fromLTRB(24, 0, 24, 20),
+              child: _NutritionSection(),
+            ),
+            const Padding(
+              padding: EdgeInsets.only(bottom: 20),
+              child: _RecommendedMeals(),
+            ),
+            const Padding(
+              padding: EdgeInsets.fromLTRB(24, 0, 24, 8),
+              child: _ScheduleCard(),
+            ),
           ],
         ),
       ),
@@ -77,108 +92,267 @@ class DashboardContent extends StatelessWidget {
   }
 }
 
-class _Greeting extends StatelessWidget {
-  const _Greeting();
-  @override
-  Widget build(BuildContext context) {
-    return Text(
-      '오늘도 건강한 하루 되세요 ☀️',
-      style: Theme.of(
-        context,
-      ).textTheme.bodyMedium?.copyWith(color: AppColors.mutedForeground),
-    );
-  }
-}
+// ───────────────────────────────────────────────────────────── header ──
 
-class _QuickInputCard extends StatelessWidget {
-  const _QuickInputCard({
-    this.onWeight,
-    this.onBloodPressure,
-    this.onBloodSugar,
+class _HomeHeader extends StatelessWidget {
+  const _HomeHeader({
+    this.onNotificationTap,
+    this.onCalendarTap,
+    this.onProfileTap,
   });
 
-  final VoidCallback? onWeight;
-  final VoidCallback? onBloodPressure;
-  final VoidCallback? onBloodSugar;
+  final VoidCallback? onNotificationTap;
+  final VoidCallback? onCalendarTap;
+  final VoidCallback? onProfileTap;
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Container(
-      padding: const EdgeInsets.all(AppSpacing.lg),
-      decoration: const BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-          colors: <Color>[AppColors.primary, AppColors.secondary],
-        ),
-        borderRadius: BorderRadius.all(AppRadius.card),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 12, 24, 16),
+      child: Row(
         children: <Widget>[
-          Text(
-            '오늘의 건강 기록',
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: Colors.white.withValues(alpha: 0.9),
+          const HeartLogo(),
+          const SizedBox(width: 8),
+          const Text(
+            'On-Care',
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w800,
+              color: FigmaColors.ink,
+              letterSpacing: -0.5,
             ),
           ),
-          const SizedBox(height: AppSpacing.md),
-          Row(
-            children: <Widget>[
-              Expanded(
-                child: _QuickButton(emoji: '⚖️', label: '체중', onTap: onWeight),
-              ),
-              const SizedBox(width: AppSpacing.sm),
-              Expanded(
-                child: _QuickButton(
-                  emoji: '❤️',
-                  label: '혈압',
-                  onTap: onBloodPressure,
-                ),
-              ),
-              const SizedBox(width: AppSpacing.sm),
-              Expanded(
-                child: _QuickButton(
-                  emoji: '💉',
-                  label: '혈당',
-                  onTap: onBloodSugar,
-                ),
-              ),
-            ],
+          const Spacer(),
+          _RoundIconButton(
+            onTap: onNotificationTap,
+            showDot: true,
+            child: const Icon(
+              Icons.notifications_none_rounded,
+              size: 18,
+              color: FigmaColors.primary,
+            ),
           ),
+          const SizedBox(width: 10),
+          _RoundIconButton(
+            onTap: onCalendarTap,
+            child: const Icon(
+              Icons.calendar_today_outlined,
+              size: 16,
+              color: FigmaColors.primary,
+            ),
+          ),
+          const SizedBox(width: 10),
+          _ProfileAvatar(onTap: onProfileTap),
         ],
       ),
     );
   }
 }
 
-class _QuickButton extends StatelessWidget {
-  const _QuickButton({required this.emoji, required this.label, this.onTap});
+class _RoundIconButton extends StatelessWidget {
+  const _RoundIconButton({
+    required this.child,
+    this.onTap,
+    this.showDot = false,
+  });
 
-  final String emoji;
-  final String label;
+  final Widget child;
+  final VoidCallback? onTap;
+  final bool showDot;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 36,
+      height: 36,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: <Widget>[
+          Material(
+            color: FigmaColors.softBlue,
+            shape: const CircleBorder(),
+            clipBehavior: Clip.antiAlias,
+            child: InkWell(
+              onTap: onTap,
+              child: Center(child: child),
+            ),
+          ),
+          if (showDot)
+            Positioned(
+              top: 6,
+              right: 6,
+              child: Container(
+                width: 8,
+                height: 8,
+                decoration: BoxDecoration(
+                  color: FigmaColors.redDot,
+                  shape: BoxShape.circle,
+                  border: Border.all(color: Colors.white),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProfileAvatar extends StatelessWidget {
+  const _ProfileAvatar({this.onTap});
   final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: SizedBox(
+        width: 40,
+        height: 40,
+        child: Stack(
+          clipBehavior: Clip.none,
+          children: <Widget>[
+            Container(
+              width: 40,
+              height: 40,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                gradient: const LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: <Color>[Color(0xFFE8F6FC), Color(0xFFB8E4F5)],
+                ),
+                border: Border.all(color: FigmaColors.primary, width: 2.2),
+              ),
+              child: const Icon(
+                Icons.person,
+                size: 22,
+                color: FigmaColors.primary,
+              ),
+            ),
+            Positioned(
+              right: 0,
+              bottom: 0,
+              child: Container(
+                width: 12,
+                height: 12,
+                decoration: BoxDecoration(
+                  color: FigmaColors.onlineGreen,
+                  shape: BoxShape.circle,
+                  border: Border.all(color: Colors.white, width: 2),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────── coaching banner ──
+
+class _CoachingBanner extends StatelessWidget {
+  const _CoachingBanner({required this.onTap});
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
     return Material(
-      color: Colors.white.withValues(alpha: 0.2),
-      borderRadius: const BorderRadius.all(AppRadius.lg),
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(16),
       child: InkWell(
         onTap: onTap,
-        borderRadius: const BorderRadius.all(AppRadius.lg),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: AppSpacing.md),
+        borderRadius: BorderRadius.circular(16),
+        child: Container(
+          decoration: BoxDecoration(
+            gradient: const LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: <Color>[FigmaColors.bannerStart, FigmaColors.bannerEnd],
+            ),
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: FigmaColors.primaryA(0.18)),
+            boxShadow: <BoxShadow>[
+              BoxShadow(
+                color: FigmaColors.primaryA(0.12),
+                blurRadius: 16,
+                offset: const Offset(0, 4),
+              ),
+            ],
+          ),
+          clipBehavior: Clip.antiAlias,
           child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: <Widget>[
-              Text(emoji, style: const TextStyle(fontSize: 22)),
-              const SizedBox(height: 4),
-              Text(
-                label,
-                style: TextStyle(
-                  color: Colors.white.withValues(alpha: 0.9),
-                  fontSize: 12,
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+                child: Row(
+                  children: <Widget>[
+                    const OniAvatar(size: 46),
+                    const SizedBox(width: 12),
+                    const Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          AiPill('✦ AI 코칭'),
+                          SizedBox(height: 3),
+                          Text(
+                            '오늘의 맞춤 조언',
+                            style: TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w800,
+                              color: FigmaColors.ink,
+                            ),
+                          ),
+                          SizedBox(height: 2),
+                          Text(
+                            '저녁은 나트륨을 줄이고\n20분 정도 걸어보세요',
+                            style: TextStyle(
+                              fontSize: 12,
+                              height: 1.45,
+                              fontWeight: FontWeight.w500,
+                              color: FigmaColors.textBody,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Container(
+                      width: 32,
+                      height: 32,
+                      decoration: BoxDecoration(
+                        color: FigmaColors.primaryA(0.15),
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Icon(
+                        Icons.chevron_right_rounded,
+                        size: 20,
+                        color: FigmaColors.primary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Container(
+                color: FigmaColors.primaryA(0.10),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 8,
+                ),
+                child: const Row(
+                  children: <Widget>[
+                    OniAvatar(size: 14, shadow: false),
+                    SizedBox(width: 8),
+                    Text(
+                      'AI가 오늘 3개의 맞춤 조언을 준비했어요',
+                      style: TextStyle(
+                        fontSize: 10,
+                        fontWeight: FontWeight.w600,
+                        color: FigmaColors.primary,
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ],
@@ -189,96 +363,73 @@ class _QuickButton extends StatelessWidget {
   }
 }
 
-class _HealthSummaryCard extends StatelessWidget {
-  const _HealthSummaryCard({required this.summary});
-  final DashboardSummary summary;
+// ────────────────────────────────────────────────────── summary cards ──
+
+/// Shared white card chrome for the two Home summary cards, including the
+/// gradient top stripe.
+class _StripeCard extends StatelessWidget {
+  const _StripeCard({required this.child});
+  final Widget child;
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return AppCard(
-      outlined: true,
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: FigmaColors.primaryA(0.08)),
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            color: FigmaColors.primaryA(0.10),
+            blurRadius: 16,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      clipBehavior: Clip.antiAlias,
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
-          Text(
-            '오늘의 건강 요약',
-            style: theme.textTheme.titleMedium?.copyWith(
-              fontWeight: FontWeight.w600,
+          Container(
+            height: 2,
+            decoration: const BoxDecoration(
+              gradient: LinearGradient(
+                colors: <Color>[FigmaColors.primary, FigmaColors.primaryStripe],
+              ),
             ),
           ),
-          const SizedBox(height: AppSpacing.md),
-          // Sodium-warning banner removed from this card per the new
-          // design ref; the same message now lives in the combined
-          // daily-feedback card above (see _DailyFeedbackCard).
-          for (final i in summary.indicators) ...<Widget>[
-            _IndicatorRow(indicator: i),
-            const SizedBox(height: AppSpacing.md),
-          ],
-          const Divider(color: AppColors.border, height: 1),
-          const SizedBox(height: AppSpacing.md),
-          Row(
-            children: <Widget>[
-              Expanded(
-                child: _QuickStat(
-                  icon: Icons.restaurant_outlined,
-                  label: '식단 기록',
-                  value: summary.dietEntries.toString(),
-                  unit: '회',
-                ),
-              ),
-              const SizedBox(width: AppSpacing.sm),
-              Expanded(
-                child: _QuickStat(
-                  icon: Icons.fitness_center_outlined,
-                  label: '운동 시간',
-                  value: summary.exerciseMinutes.toString(),
-                  unit: '분',
-                ),
-              ),
-            ],
-          ),
+          Padding(padding: const EdgeInsets.all(16), child: child),
         ],
       ),
     );
   }
 }
 
-class _IndicatorRow extends StatelessWidget {
-  const _IndicatorRow({required this.indicator});
-  final HealthIndicator indicator;
+class _CardTitle extends StatelessWidget {
+  const _CardTitle({required this.icon, required this.label});
+  final IconData icon;
+  final String label;
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final color = indicator.overBudget ? AppColors.warning : AppColors.primary;
-    final valueColor = indicator.overBudget
-        ? AppColors.warning
-        : AppColors.foreground;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
+    return Row(
       children: <Widget>[
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: <Widget>[
-            Text(indicator.label, style: theme.textTheme.bodyMedium),
-            Text(
-              '${indicator.current} / ${indicator.max} ${indicator.unit}',
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: valueColor,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ],
+        Container(
+          width: 24,
+          height: 24,
+          decoration: BoxDecoration(
+            color: FigmaColors.iconTint,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Icon(icon, size: 14, color: FigmaColors.primary),
         ),
-        const SizedBox(height: 6),
-        ClipRRect(
-          borderRadius: const BorderRadius.all(Radius.circular(999)),
-          child: LinearProgressIndicator(
-            value: indicator.progress,
-            minHeight: 8,
-            backgroundColor: AppColors.muted,
-            valueColor: AlwaysStoppedAnimation<Color>(color),
+        const SizedBox(width: 6),
+        Text(
+          label,
+          style: const TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w700,
+            color: FigmaColors.ink,
           ),
         ),
       ],
@@ -286,58 +437,1322 @@ class _IndicatorRow extends StatelessWidget {
   }
 }
 
-class _QuickStat extends StatelessWidget {
-  const _QuickStat({
-    required this.icon,
-    required this.label,
-    required this.value,
-    required this.unit,
-  });
-
-  final IconData icon;
-  final String label;
-  final String value;
-  final String unit;
+/// A soft "· item" recommendation box used at the bottom of both summary cards.
+class _RecBox extends StatelessWidget {
+  const _RecBox({required this.badge, required this.items});
+  final String badge;
+  final List<String> items;
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     return Container(
-      padding: const EdgeInsets.all(AppSpacing.md),
-      decoration: const BoxDecoration(
-        color: AppColors.accent,
-        borderRadius: BorderRadius.all(AppRadius.lg),
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: FigmaColors.softBlue,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          AiPill(badge, background: FigmaColors.primaryA(0.10)),
+          const SizedBox(height: 5),
+          for (final String it in items)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 3),
+              child: Text(
+                '· $it',
+                style: const TextStyle(
+                  fontSize: 9.5,
+                  fontWeight: FontWeight.w500,
+                  color: FigmaColors.ink,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CardButton extends StatelessWidget {
+  const _CardButton({required this.label, required this.onTap});
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: FigmaColors.iconTint,
+      borderRadius: BorderRadius.circular(12),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Container(
+          width: double.infinity,
+          alignment: Alignment.center,
+          padding: const EdgeInsets.symmetric(vertical: 9),
+          child: Text(
+            label,
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              color: FigmaColors.primary,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DietSummaryCard extends StatelessWidget {
+  const _DietSummaryCard({required this.onOpen});
+  final VoidCallback onOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    return _StripeCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          const _CardTitle(icon: Icons.restaurant_rounded, label: '식단'),
+          const SizedBox(height: 8),
+          _MiniAlert(
+            bg: FigmaColors.orangeA(0.09),
+            icon: '⚠️',
+            text: '나트륨 초과 감지됨',
+            color: FigmaColors.orangeText,
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: <Widget>[
+              SizedBox(
+                width: 44,
+                height: 44,
+                child: Stack(
+                  alignment: Alignment.center,
+                  children: <Widget>[
+                    CustomPaint(
+                      size: const Size(44, 44),
+                      painter: _RingPainter(
+                        pct: 0.79,
+                        track: const Color(0xFFE8F5FB),
+                        arc: FigmaColors.primary,
+                        stroke: 4,
+                      ),
+                    ),
+                    const Text(
+                      '79%',
+                      style: TextStyle(
+                        fontSize: 10,
+                        fontWeight: FontWeight.w800,
+                        color: FigmaColors.ink,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 10),
+              const Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  Text(
+                    '1,420',
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w800,
+                      color: FigmaColors.ink,
+                      letterSpacing: -0.5,
+                      height: 1,
+                    ),
+                  ),
+                  SizedBox(height: 2),
+                  Text(
+                    '/ 1,800 kcal',
+                    style: TextStyle(
+                      fontSize: 10,
+                      fontWeight: FontWeight.w500,
+                      color: FigmaColors.textMuted,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          const _MacroBar(label: '탄수화물', pct: 0.68, color: FigmaColors.primary),
+          const SizedBox(height: 6),
+          const _MacroBar(label: '단백질', pct: 0.52, color: FigmaColors.green),
+          const SizedBox(height: 6),
+          const _MacroBar(label: '지방', pct: 0.45, color: FigmaColors.orange),
+          const SizedBox(height: 12),
+          const _RecBox(
+            badge: '✦ AI 추천 저녁 식단',
+            items: <String>['닭가슴살 샐러드', '현미밥 반 공기'],
+          ),
+          const SizedBox(height: 10),
+          _CardButton(label: '식단 기록 →', onTap: onOpen),
+        ],
+      ),
+    );
+  }
+}
+
+class _ExerciseSummaryCard extends StatelessWidget {
+  const _ExerciseSummaryCard({required this.onOpen});
+  final VoidCallback onOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    return _StripeCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          const _CardTitle(icon: Icons.fitness_center_rounded, label: '운동'),
+          const SizedBox(height: 8),
+          _MiniAlert(
+            bg: FigmaColors.greenA(0.09),
+            icon: '✅',
+            text: 'AI 추천 루틴 1/3 완료',
+            color: FigmaColors.greenText,
+          ),
+          const SizedBox(height: 12),
+          const Text(
+            '320',
+            style: TextStyle(
+              fontSize: 22,
+              fontWeight: FontWeight.w800,
+              color: FigmaColors.ink,
+              letterSpacing: -0.5,
+              height: 1,
+            ),
+          ),
+          const SizedBox(height: 2),
+          const Text(
+            'kcal 소모 · 목표 500',
+            style: TextStyle(
+              fontSize: 10,
+              fontWeight: FontWeight.w500,
+              color: FigmaColors.textMuted,
+            ),
+          ),
+          const SizedBox(height: 12),
+          const _Fill(
+            pct: 0.64,
+            height: 6,
+            gradient: LinearGradient(
+              colors: <Color>[FigmaColors.primary, FigmaColors.primaryStripe],
+            ),
+          ),
+          const SizedBox(height: 12),
+          const _ChecklistRow(name: '빠르게 걷기', minutes: 30, done: true),
+          const SizedBox(height: 4),
+          const _ChecklistRow(name: '하체 스트레칭', minutes: 10, done: false),
+          const SizedBox(height: 12),
+          const _RecBox(
+            badge: '✦ AI 추천 남은 루틴',
+            items: <String>['하체 스트레칭 10분', '저강도 근력 15분'],
+          ),
+          const SizedBox(height: 10),
+          _CardButton(label: '운동 기록 →', onTap: onOpen),
+        ],
+      ),
+    );
+  }
+}
+
+class _MiniAlert extends StatelessWidget {
+  const _MiniAlert({
+    required this.bg,
+    required this.icon,
+    required this.text,
+    required this.color,
+  });
+  final Color bg;
+  final String icon;
+  final String text;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(8),
       ),
       child: Row(
         children: <Widget>[
-          Icon(icon, size: 20, color: AppColors.primary),
-          const SizedBox(width: AppSpacing.sm),
-          Expanded(
+          Text(icon, style: const TextStyle(fontSize: 9)),
+          const SizedBox(width: 4),
+          Flexible(
+            child: Text(
+              text,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 9.5,
+                fontWeight: FontWeight.w600,
+                color: color,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MacroBar extends StatelessWidget {
+  const _MacroBar({
+    required this.label,
+    required this.pct,
+    required this.color,
+  });
+  final String label;
+  final double pct;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: <Widget>[
+        SizedBox(
+          width: 44,
+          child: Text(
+            label,
+            maxLines: 1,
+            softWrap: false,
+            overflow: TextOverflow.clip,
+            style: const TextStyle(
+              fontSize: 9,
+              fontWeight: FontWeight.w600,
+              color: FigmaColors.textMuted,
+            ),
+          ),
+        ),
+        const SizedBox(width: 6),
+        Expanded(
+          child: _Fill(pct: pct, color: color),
+        ),
+      ],
+    );
+  }
+}
+
+/// An intrinsic-safe horizontal progress fill. Uses a flex split rather than
+/// [FractionallySizedBox] so it survives [IntrinsicHeight]'s intrinsic-sizing
+/// pass (FractionallySizedBox throws during that pass).
+class _Fill extends StatelessWidget {
+  const _Fill({required this.pct, this.color, this.gradient, this.height = 4});
+
+  final double pct;
+  final Color? color;
+  final Gradient? gradient;
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    final int filled = (pct.clamp(0.0, 1.0) * 1000).round();
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(999),
+      child: SizedBox(
+        height: height,
+        child: Row(
+          children: <Widget>[
+            Expanded(
+              flex: filled,
+              child: DecoratedBox(
+                decoration: BoxDecoration(color: color, gradient: gradient),
+              ),
+            ),
+            Expanded(
+              flex: 1000 - filled,
+              child: const ColoredBox(color: FigmaColors.track),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ChecklistRow extends StatelessWidget {
+  const _ChecklistRow({
+    required this.name,
+    required this.minutes,
+    required this.done,
+  });
+  final String name;
+  final int minutes;
+  final bool done;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: <Widget>[
+        Container(
+          width: 14,
+          height: 14,
+          decoration: BoxDecoration(
+            color: done ? FigmaColors.primary : FigmaColors.track,
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: done
+              ? const Icon(Icons.check, size: 9, color: Colors.white)
+              : null,
+        ),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(
+            name,
+            style: TextStyle(
+              fontSize: 10,
+              fontWeight: FontWeight.w500,
+              color: done ? FigmaColors.textMuted : FigmaColors.ink,
+              decoration: done ? TextDecoration.lineThrough : null,
+            ),
+          ),
+        ),
+        Text(
+          '$minutes분',
+          style: const TextStyle(
+            fontSize: 9,
+            fontWeight: FontWeight.w500,
+            color: FigmaColors.textFaint,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _RingPainter extends CustomPainter {
+  _RingPainter({
+    required this.pct,
+    required this.track,
+    required this.arc,
+    required this.stroke,
+  });
+  final double pct;
+  final Color track;
+  final Color arc;
+  final double stroke;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Offset center = size.center(Offset.zero);
+    final double radius = (math.min(size.width, size.height) - stroke) / 2;
+    final Paint trackPaint = Paint()
+      ..color = track
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = stroke;
+    canvas.drawCircle(center, radius, trackPaint);
+    final Paint arcPaint = Paint()
+      ..color = arc
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = stroke
+      ..strokeCap = StrokeCap.round;
+    canvas.drawArc(
+      Rect.fromCircle(center: center, radius: radius),
+      -math.pi / 2,
+      2 * math.pi * pct.clamp(0.0, 1.0),
+      false,
+      arcPaint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant _RingPainter old) =>
+      old.pct != pct || old.arc != arc || old.track != track;
+}
+
+/// The overall "오늘 종합" summary donut shown to the left of the nutrition
+/// delta tiles — today's total intake as a share of the daily target.
+class _SummaryDonut extends StatelessWidget {
+  const _SummaryDonut();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 10),
+      decoration: BoxDecoration(
+        color: FigmaColors.primaryA(0.06),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: FigmaColors.primaryA(0.15)),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          SizedBox(
+            width: 40,
+            height: 40,
+            child: Stack(
+              alignment: Alignment.center,
+              children: <Widget>[
+                CustomPaint(
+                  size: const Size(40, 40),
+                  painter: _RingPainter(
+                    pct: 0.79,
+                    track: const Color(0xFFE8F5FB),
+                    arc: FigmaColors.primary,
+                    stroke: 4,
+                  ),
+                ),
+                const Text(
+                  '79%',
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w800,
+                    color: FigmaColors.ink,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 6),
+          const Text(
+            '오늘 종합',
+            style: TextStyle(
+              fontSize: 9.5,
+              fontWeight: FontWeight.w600,
+              color: FigmaColors.ink,
+            ),
+          ),
+          const SizedBox(height: 2),
+          const Text(
+            '목표 대비',
+            style: TextStyle(
+              fontSize: 8,
+              fontWeight: FontWeight.w500,
+              color: FigmaColors.textMuted,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ───────────────────────────────────────────────────── nutrition section ──
+
+class _NutData {
+  const _NutData({
+    required this.cur,
+    required this.prev,
+    required this.unit,
+    required this.goal,
+    required this.color,
+    required this.warn,
+  });
+  final List<double> cur;
+  final List<double> prev;
+  final String unit;
+  final double goal;
+  final Color color;
+  final bool warn;
+}
+
+const Map<String, _NutData> _nutrition = <String, _NutData>{
+  '칼로리': _NutData(
+    cur: <double>[1650, 2100, 1480, 1720, 1390, 1860, 1420],
+    prev: <double>[1820, 1950, 1700, 1800, 1650, 2050, 1610],
+    unit: 'kcal',
+    goal: 1800,
+    color: FigmaColors.primary,
+    warn: false,
+  ),
+  '나트륨': _NutData(
+    cur: <double>[2050, 2280, 2120, 2400, 2200, 2550, 2100],
+    prev: <double>[1900, 2000, 1950, 2100, 2050, 2200, 2180],
+    unit: 'mg',
+    goal: 2000,
+    color: FigmaColors.orange,
+    warn: true,
+  ),
+  '당류': _NutData(
+    cur: <double>[28, 42, 22, 31, 18, 38, 45],
+    prev: <double>[35, 38, 30, 40, 28, 44, 32],
+    unit: 'g',
+    goal: 50,
+    color: FigmaColors.sugarPurple,
+    warn: false,
+  ),
+};
+
+const List<String> _weekDays = <String>['월', '화', '수', '목', '금', '토', '일'];
+
+class _NutritionSection extends StatefulWidget {
+  const _NutritionSection();
+
+  @override
+  State<_NutritionSection> createState() => _NutritionSectionState();
+}
+
+class _NutritionSectionState extends State<_NutritionSection> {
+  String _tab = '칼로리';
+
+  @override
+  Widget build(BuildContext context) {
+    final _NutData cfg = _nutrition[_tab]!;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Row(
+                    children: <Widget>[
+                      const Text(
+                        '영양 현황',
+                        style: TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w700,
+                          color: FigmaColors.ink,
+                        ),
+                      ),
+                      const SizedBox(width: 6),
+                      AiPill('✦ AI 분석', background: FigmaColors.primaryA(0.10)),
+                    ],
+                  ),
+                  const SizedBox(height: 2),
+                  const Text(
+                    '주간 누적 추이 · 지난주 대비',
+                    style: TextStyle(
+                      fontSize: 10,
+                      fontWeight: FontWeight.w500,
+                      color: FigmaColors.textMuted,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const Row(
+              children: <Widget>[
+                Text(
+                  '자세히',
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: FigmaColors.primary,
+                  ),
+                ),
+                Icon(Icons.chevron_right, size: 14, color: FigmaColors.primary),
+              ],
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        const IntrinsicHeight(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              Expanded(child: _SummaryDonut()),
+              SizedBox(width: 6),
+              Expanded(
+                child: _DeltaTile(
+                  label: '칼로리',
+                  delta: '-8%',
+                  up: false,
+                  good: true,
+                ),
+              ),
+              SizedBox(width: 6),
+              Expanded(
+                child: _DeltaTile(
+                  label: '나트륨',
+                  delta: '+9%',
+                  up: true,
+                  good: false,
+                ),
+              ),
+              SizedBox(width: 6),
+              Expanded(
+                child: _DeltaTile(
+                  label: '당류',
+                  delta: '-5%',
+                  up: false,
+                  good: true,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
+        Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(
+              color: cfg.warn
+                  ? FigmaColors.orangeA(0.20)
+                  : FigmaColors.primaryA(0.08),
+            ),
+            boxShadow: <BoxShadow>[
+              BoxShadow(
+                color: FigmaColors.primaryA(0.06),
+                blurRadius: 14,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Row(
+                children: <Widget>[
+                  for (final String t in _nutrition.keys) ...<Widget>[
+                    _NutTab(
+                      label: t,
+                      active: _tab == t,
+                      warn: _nutrition[t]!.warn,
+                      activeColor: _nutrition[t]!.color,
+                      onTap: () => setState(() => _tab = t),
+                    ),
+                    const SizedBox(width: 6),
+                  ],
+                ],
+              ),
+              const SizedBox(height: 16),
+              if (cfg.warn) ...<Widget>[
+                _SodiumInsight(),
+                const SizedBox(height: 16),
+              ],
+              _ChartLegend(color: cfg.color),
+              const SizedBox(height: 8),
+              SizedBox(
+                height: 62,
+                child: CustomPaint(
+                  size: Size.infinite,
+                  painter: _NutritionChartPainter(cfg),
+                ),
+              ),
+              const SizedBox(height: 4),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: <Widget>[
+                  for (int i = 0; i < _weekDays.length; i++)
+                    Text(
+                      _weekDays[i],
+                      style: TextStyle(
+                        fontSize: 8,
+                        fontWeight: FontWeight.w600,
+                        color: i == 6 ? cfg.color : FigmaColors.textFaint,
+                      ),
+                    ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: <Widget>[
+                  Expanded(
+                    child: _StatTile(
+                      label: '이번주 평균',
+                      value: _avg(cfg.cur),
+                      unit: cfg.unit,
+                      highlight: cfg.warn,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: _StatTile(
+                      label: '지난주 평균',
+                      value: _avg(cfg.prev),
+                      unit: cfg.unit,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: _StatTile(
+                      label: '목표',
+                      value: cfg.goal,
+                      unit: cfg.unit,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  double _avg(List<double> xs) =>
+      (xs.reduce((double a, double b) => a + b) / xs.length).roundToDouble();
+}
+
+class _NutTab extends StatelessWidget {
+  const _NutTab({
+    required this.label,
+    required this.active,
+    required this.warn,
+    required this.activeColor,
+    required this.onTap,
+  });
+  final String label;
+  final bool active;
+  final bool warn;
+  final Color activeColor;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
+        decoration: BoxDecoration(
+          color: active ? activeColor : FigmaColors.track,
+          borderRadius: BorderRadius.circular(999),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+                color: active ? Colors.white : FigmaColors.textMuted,
+              ),
+            ),
+            if (warn && !active) ...<Widget>[
+              const SizedBox(width: 4),
+              Container(
+                width: 6,
+                height: 6,
+                decoration: const BoxDecoration(
+                  color: FigmaColors.orange,
+                  shape: BoxShape.circle,
+                ),
+              ),
+            ],
+            if (warn && active) ...<Widget>[
+              const SizedBox(width: 4),
+              const Text('⚠️', style: TextStyle(fontSize: 9)),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SodiumInsight extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: <Color>[FigmaColors.bannerStart, FigmaColors.bannerEnd],
+        ),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: FigmaColors.primaryA(0.18)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          AiPill('✦ AI', background: FigmaColors.primaryA(0.15)),
+          const SizedBox(width: 8),
+          const Expanded(
+            child: Text.rich(
+              TextSpan(
+                style: TextStyle(
+                  fontSize: 10.5,
+                  fontWeight: FontWeight.w500,
+                  color: FigmaColors.ink,
+                  height: 1.5,
+                ),
+                children: <InlineSpan>[
+                  TextSpan(text: '나트륨 섭취가 '),
+                  TextSpan(
+                    text: '2주 연속 증가',
+                    style: TextStyle(
+                      fontWeight: FontWeight.w700,
+                      color: FigmaColors.orange,
+                    ),
+                  ),
+                  TextSpan(text: ' 추세예요. 소금 사용량을 줄이고, '),
+                  TextSpan(
+                    text: '고염분 식단 알림',
+                    style: TextStyle(
+                      fontWeight: FontWeight.w700,
+                      color: FigmaColors.primary,
+                    ),
+                  ),
+                  TextSpan(text: '을 켜볼까요?'),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ChartLegend extends StatelessWidget {
+  const _ChartLegend({required this.color});
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: <Widget>[
+        Container(width: 16, height: 2, color: color),
+        const SizedBox(width: 4),
+        const Text(
+          '이번 주',
+          style: TextStyle(
+            fontSize: 9,
+            fontWeight: FontWeight.w600,
+            color: FigmaColors.textMuted,
+          ),
+        ),
+        const SizedBox(width: 12),
+        const SizedBox(
+          width: 16,
+          child: Divider(color: Color(0xFFD0D8E4), thickness: 1, height: 2),
+        ),
+        const SizedBox(width: 4),
+        const Text(
+          '지난 주',
+          style: TextStyle(
+            fontSize: 9,
+            fontWeight: FontWeight.w600,
+            color: FigmaColors.textMuted,
+          ),
+        ),
+        const Spacer(),
+        Container(
+          width: 8,
+          height: 8,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        ),
+        const SizedBox(width: 4),
+        const Text(
+          '오늘',
+          style: TextStyle(
+            fontSize: 9,
+            fontWeight: FontWeight.w600,
+            color: FigmaColors.textMuted,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _NutritionChartPainter extends CustomPainter {
+  _NutritionChartPainter(this.cfg);
+  final _NutData cfg;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final double maxVal =
+        <double>[...cfg.cur, ...cfg.prev].reduce(math.max) * 1.12;
+    final double w = size.width;
+    final double h = size.height;
+    Offset at(int i, double v) =>
+        Offset((i / (cfg.cur.length - 1)) * w, h - (v / maxVal) * h);
+
+    // Goal line.
+    final double gy = h - (cfg.goal / maxVal) * h;
+    _dashLine(
+      canvas,
+      Offset(0, gy),
+      Offset(w, gy),
+      cfg.warn ? FigmaColors.orangeA(0.35) : const Color(0xFFE0E8EF),
+      1,
+    );
+
+    // Previous week (dashed grey).
+    _dashPolyline(
+      canvas,
+      <Offset>[for (int i = 0; i < cfg.prev.length; i++) at(i, cfg.prev[i])],
+      const Color(0xFFD0D8E4),
+      1.5,
+    );
+
+    // Current week area + line.
+    final List<Offset> curPts = <Offset>[
+      for (int i = 0; i < cfg.cur.length; i++) at(i, cfg.cur[i]),
+    ];
+    final Path area = Path()..moveTo(0, h);
+    for (final Offset p in curPts) {
+      area.lineTo(p.dx, p.dy);
+    }
+    area
+      ..lineTo(w, h)
+      ..close();
+    canvas.drawPath(area, Paint()..color = cfg.color.withValues(alpha: 0.08));
+
+    final Path line = Path()..moveTo(curPts.first.dx, curPts.first.dy);
+    for (final Offset p in curPts.skip(1)) {
+      line.lineTo(p.dx, p.dy);
+    }
+    canvas.drawPath(
+      line,
+      Paint()
+        ..color = cfg.color
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 2
+        ..strokeJoin = StrokeJoin.round
+        ..strokeCap = StrokeCap.round,
+    );
+
+    // Today marker.
+    final Offset last = curPts.last;
+    canvas.drawCircle(last, 4, Paint()..color = Colors.white);
+    canvas.drawCircle(
+      last,
+      4,
+      Paint()
+        ..color = cfg.color
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 2,
+    );
+    canvas.drawCircle(last, 1.5, Paint()..color = cfg.color);
+  }
+
+  void _dashLine(Canvas c, Offset a, Offset b, Color color, double width) {
+    final Paint p = Paint()
+      ..color = color
+      ..strokeWidth = width;
+    const double dash = 3, gap = 3;
+    final double total = (b - a).distance;
+    final Offset dir = (b - a) / total;
+    double d = 0;
+    while (d < total) {
+      final Offset s = a + dir * d;
+      final Offset e = a + dir * math.min(d + dash, total);
+      c.drawLine(s, e, p);
+      d += dash + gap;
+    }
+  }
+
+  void _dashPolyline(Canvas c, List<Offset> pts, Color color, double width) {
+    for (int i = 0; i < pts.length - 1; i++) {
+      _dashLine(c, pts[i], pts[i + 1], color, width);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _NutritionChartPainter old) => old.cfg != cfg;
+}
+
+class _DeltaTile extends StatelessWidget {
+  const _DeltaTile({
+    required this.label,
+    required this.delta,
+    required this.up,
+    required this.good,
+  });
+  final String label;
+  final String delta;
+  final bool up;
+  final bool good;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color tone = good ? FigmaColors.greenText : FigmaColors.orangeText;
+    final Color chip = good ? FigmaColors.green : FigmaColors.orange;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+      decoration: BoxDecoration(
+        color: chip.withValues(alpha: good ? 0.08 : 0.07),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: chip.withValues(alpha: 0.18)),
+      ),
+      child: Column(
+        children: <Widget>[
+          Container(
+            width: 24,
+            height: 24,
+            decoration: BoxDecoration(
+              color: chip.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Icon(
+              up ? Icons.arrow_upward_rounded : Icons.arrow_downward_rounded,
+              size: 13,
+              color: tone,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            label,
+            style: const TextStyle(
+              fontSize: 9.5,
+              fontWeight: FontWeight.w600,
+              color: FigmaColors.ink,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            delta,
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w800,
+              color: tone,
+              height: 1,
+            ),
+          ),
+          const SizedBox(height: 2),
+          const Text(
+            '지난주 대비',
+            style: TextStyle(
+              fontSize: 8,
+              fontWeight: FontWeight.w500,
+              color: FigmaColors.textMuted,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatTile extends StatelessWidget {
+  const _StatTile({
+    required this.label,
+    required this.value,
+    required this.unit,
+    this.highlight = false,
+  });
+  final String label;
+  final double value;
+  final String unit;
+  final bool highlight;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+      decoration: BoxDecoration(
+        color: highlight ? FigmaColors.orangeA(0.07) : FigmaColors.statBg,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        children: <Widget>[
+          Text(
+            label,
+            style: const TextStyle(
+              fontSize: 8.5,
+              fontWeight: FontWeight.w500,
+              color: FigmaColors.textMuted,
+            ),
+          ),
+          const SizedBox(height: 1),
+          Text(
+            NumberFormat('#,###').format(value),
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              color: highlight ? FigmaColors.orangeText : FigmaColors.ink,
+            ),
+          ),
+          Text(
+            unit,
+            style: const TextStyle(
+              fontSize: 8,
+              fontWeight: FontWeight.w500,
+              color: FigmaColors.textFaint,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ───────────────────────────────────────────────────── recommended meals ──
+
+class _RecMeal {
+  const _RecMeal(
+    this.emoji,
+    this.name,
+    this.reason,
+    this.bg,
+    this.tag,
+    this.tagColor,
+  );
+  final String emoji;
+  final String name;
+  final String reason;
+  final Color bg;
+  final String tag;
+  final Color tagColor;
+}
+
+const List<_RecMeal> _recMeals = <_RecMeal>[
+  _RecMeal(
+    '🥗',
+    '닭가슴살 샐러드',
+    '나트륨 조절에 좋아요',
+    Color(0xFFE8F5E9),
+    '저나트륨',
+    FigmaColors.greenText,
+  ),
+  _RecMeal(
+    '🍱',
+    '현미 도시락',
+    '혈당 안정에 도움돼요',
+    Color(0xFFFFF8E1),
+    '저GI',
+    FigmaColors.orangeText,
+  ),
+  _RecMeal(
+    '🐟',
+    '연어 구이 + 나물',
+    '오메가3 + 식이섬유',
+    Color(0xFFE3F2FD),
+    '고단백',
+    FigmaColors.primary,
+  ),
+  _RecMeal(
+    '🥦',
+    '두부 채소 볶음',
+    '칼로리 낮고 포만감↑',
+    Color(0xFFF3E5F5),
+    '저칼로리',
+    FigmaColors.sugarPurple,
+  ),
+];
+
+class _RecommendedMeals extends StatelessWidget {
+  const _RecommendedMeals();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.fromLTRB(24, 0, 24, 12),
+          child: Row(
+            children: <Widget>[
+              const Text(
+                '이번 주 AI 추천 식단',
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                  color: FigmaColors.ink,
+                ),
+              ),
+              const SizedBox(width: 6),
+              AiPill('✦ AI 분석', background: FigmaColors.primaryA(0.10)),
+              const Spacer(),
+              const Text(
+                '전체 보기',
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: FigmaColors.primary,
+                ),
+              ),
+            ],
+          ),
+        ),
+        SizedBox(
+          height: 158,
+          child: ListView.separated(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            itemCount: _recMeals.length,
+            separatorBuilder: (_, _) => const SizedBox(width: 12),
+            itemBuilder: (_, int i) => _RecMealCard(meal: _recMeals[i]),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _RecMealCard extends StatelessWidget {
+  const _RecMealCard({required this.meal});
+  final _RecMeal meal;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 130,
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: const Color(0x0D000000)),
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.07),
+            blurRadius: 12,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Container(
+            height: 72,
+            width: double.infinity,
+            color: meal.bg,
+            alignment: Alignment.center,
+            child: Text(meal.emoji, style: const TextStyle(fontSize: 32)),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(10, 8, 10, 10),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
                 Text(
-                  label,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: AppColors.mutedForeground,
+                  meal.name,
+                  style: const TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    color: FigmaColors.ink,
+                    height: 1.3,
                   ),
                 ),
-                Text.rich(
-                  TextSpan(
-                    children: <InlineSpan>[
-                      TextSpan(
-                        text: value,
-                        style: theme.textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                      TextSpan(
-                        text: ' $unit',
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: AppColors.mutedForeground,
-                        ),
-                      ),
-                    ],
+                const SizedBox(height: 3),
+                Text(
+                  meal.reason,
+                  style: const TextStyle(
+                    fontSize: 9.5,
+                    fontWeight: FontWeight.w500,
+                    color: FigmaColors.textMuted,
+                    height: 1.4,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 2,
+                  ),
+                  decoration: BoxDecoration(
+                    color: meal.tagColor.withValues(alpha: 0.12),
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                  child: Text(
+                    meal.tag,
+                    style: TextStyle(
+                      fontSize: 9,
+                      fontWeight: FontWeight.w700,
+                      color: meal.tagColor,
+                    ),
                   ),
                 ),
               ],
@@ -349,175 +1764,113 @@ class _QuickStat extends StatelessWidget {
   }
 }
 
+// ───────────────────────────────────────────────────────── schedule ──
+
 class _ScheduleCard extends StatelessWidget {
-  const _ScheduleCard({required this.items, this.onOpenAll});
-
-  final List<ScheduleItem> items;
-  final VoidCallback? onOpenAll;
+  const _ScheduleCard();
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return AppCard(
-      outlined: true,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Row(
-            children: <Widget>[
-              const Icon(
-                Icons.calendar_today_outlined,
-                size: 20,
-                color: AppColors.primary,
-              ),
-              const SizedBox(width: AppSpacing.sm),
-              Text(
-                '오늘의 일정',
-                style: theme.textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              const Spacer(),
-              TextButton(
-                onPressed: onOpenAll,
-                style: TextButton.styleFrom(
-                  foregroundColor: AppColors.primary,
-                  padding: EdgeInsets.zero,
-                  minimumSize: const Size(0, 0),
-                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                ),
-                child: const Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: <Widget>[
-                    Text('전체보기', style: TextStyle(fontSize: 13)),
-                    Icon(Icons.chevron_right, size: 16),
-                  ],
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: AppSpacing.md),
-          for (final item in items) ...<Widget>[
-            Material(
-              color: AppColors.accent,
-              borderRadius: const BorderRadius.all(AppRadius.lg),
-              child: InkWell(
-                onTap: onOpenAll,
-                borderRadius: const BorderRadius.all(AppRadius.lg),
-                child: Padding(
-                  padding: const EdgeInsets.all(AppSpacing.md),
-                  child: Row(
-                    children: <Widget>[
-                      Container(
-                        width: 44,
-                        height: 44,
-                        decoration: const BoxDecoration(
-                          color: AppColors.background,
-                          borderRadius: BorderRadius.all(AppRadius.lg),
-                        ),
-                        alignment: Alignment.center,
-                        child: Text(
-                          item.emoji,
-                          style: const TextStyle(fontSize: 20),
-                        ),
-                      ),
-                      const SizedBox(width: AppSpacing.md),
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: <Widget>[
-                            Text(
-                              item.title,
-                              style: theme.textTheme.bodyMedium?.copyWith(
-                                fontWeight: FontWeight.w600,
-                              ),
-                            ),
-                            const SizedBox(height: 2),
-                            Text(
-                              item.time,
-                              style: theme.textTheme.bodySmall?.copyWith(
-                                color: AppColors.mutedForeground,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      const Icon(
-                        Icons.chevron_right,
-                        size: 20,
-                        color: AppColors.mutedForeground,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-            if (item != items.last) const SizedBox(height: AppSpacing.sm),
-          ],
-        ],
-      ),
-    );
-  }
-}
-
-class _WeekScoreCard extends StatelessWidget {
-  const _WeekScoreCard({required this.score, required this.delta});
-
-  final int score;
-  final int delta;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Container(
-      padding: const EdgeInsets.all(AppSpacing.lg),
-      decoration: const BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-          colors: <Color>[
-            AppColors.scoreGradientStart,
-            AppColors.scoreGradientEnd,
-          ],
-        ),
-        borderRadius: BorderRadius.all(AppRadius.card),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Row(
-            children: <Widget>[
-              const Icon(Icons.trending_up, color: Colors.white, size: 24),
-              const SizedBox(width: AppSpacing.md),
-              Column(
+    final DateTime now = DateTime.now();
+    final String todayLabel =
+        '${now.month}월 ${now.day}일 ${_weekDays[now.weekday - 1]}요일';
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Expanded(
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
-                  Text(
-                    '이번 주 건강 점수',
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: Colors.white.withValues(alpha: 0.9),
+                  const Text(
+                    '오늘의 일정',
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w700,
+                      color: FigmaColors.ink,
                     ),
                   ),
+                  const SizedBox(height: 2),
                   Text(
-                    '$score점',
-                    style: theme.textTheme.headlineSmall?.copyWith(
-                      color: Colors.white,
-                      fontWeight: FontWeight.w600,
+                    todayLabel,
+                    style: const TextStyle(
+                      fontSize: 12,
+                      color: FigmaColors.textSub,
                     ),
                   ),
                 ],
               ),
+            ),
+            const Text(
+              '전체 보기',
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: FigmaColors.primary,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: FigmaColors.softBlue,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: FigmaColors.primaryA(0.12)),
+          ),
+          child: Row(
+            children: <Widget>[
+              const Text(
+                '19:30',
+                style: TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w800,
+                  color: FigmaColors.primary,
+                  letterSpacing: -0.3,
+                ),
+              ),
+              const SizedBox(width: 16),
+              Container(
+                width: 1,
+                height: 34,
+                color: FigmaColors.primaryA(0.35),
+              ),
+              const SizedBox(width: 16),
+              const Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      '저녁 산책',
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w700,
+                        color: FigmaColors.ink,
+                      ),
+                    ),
+                    SizedBox(height: 2),
+                    Text(
+                      '집 주변 · 20분',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: FigmaColors.textSub,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const Icon(
+                Icons.chevron_right,
+                size: 18,
+                color: FigmaColors.primary,
+              ),
             ],
           ),
-          const SizedBox(height: AppSpacing.sm),
-          Text(
-            '지난 주보다 $delta점 상승했어요! 🎉',
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: Colors.white.withValues(alpha: 0.9),
-            ),
-          ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -1,213 +1,765 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:image_picker/image_picker.dart';
 
-import 'package:oncare/core/errors/app_error.dart';
-import 'package:oncare/design_system/tokens/colors.dart';
-import 'package:oncare/design_system/tokens/spacing.dart';
-import 'package:oncare/features/diet/domain/entities/diet_day.dart';
-import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
-import 'package:oncare/features/diet/presentation/pages/diet_analyze_page.dart';
-import 'package:oncare/features/diet/presentation/pages/diet_entry_detail_page.dart';
-import 'package:oncare/features/diet/presentation/widgets/diet_summary_card.dart';
-import 'package:oncare/features/diet/presentation/widgets/diet_week_strip.dart';
-import 'package:oncare/features/diet/presentation/widgets/meal_card.dart';
+import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/features/diet/presentation/widgets/diet_flows.dart';
 import 'package:oncare/features/notification/presentation/widgets/notification_panel.dart';
-import 'package:oncare/gen/l10n/app_localizations.dart';
-import 'package:oncare/shared/widgets/ai_coach_card.dart';
-import 'package:oncare/shared/widgets/error_view.dart';
 import 'package:oncare/shared/widgets/modals/right_slide_panel.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
-import 'package:oncare/shared/widgets/oncare_header.dart';
-import 'package:oncare/shared/widgets/swipe_to_delete.dart';
 
-class DietRecordPage extends ConsumerStatefulWidget {
+/// 식단 tab, rebuilt to match the On-Care Figma redesign. The weekly date
+/// strip is centred on today (per the product request), the nutrition summary /
+/// AI feedback / meal log follow the mockup, and the "식단 추가" and meal-edit
+/// flows open as bottom sheets.
+class DietRecordPage extends StatefulWidget {
   const DietRecordPage({super.key});
 
   @override
-  ConsumerState<DietRecordPage> createState() => _DietRecordPageState();
+  State<DietRecordPage> createState() => _DietRecordPageState();
 }
 
-class _DietRecordPageState extends ConsumerState<DietRecordPage> {
-  late DateTime _selectedDay = DateTime.now();
+const List<String> _weekdayLabels = <String>['월', '화', '수', '목', '금', '토', '일'];
 
-  static String _currentMealType() {
-    final h = DateTime.now().hour;
-    if (h < 11) return 'breakfast';
-    if (h < 15) return 'lunch';
-    if (h < 21) return 'dinner';
-    return 'snack';
+class _DietRecordPageState extends State<DietRecordPage> {
+  int _weekShift = 0; // whole-week steps away from today
+  late DateTime _selected;
+
+  DateTime get _today {
+    final DateTime n = DateTime.now();
+    return DateTime(n.year, n.month, n.day);
   }
 
-  Future<void> _deleteDietEntry(String id) async {
-    final messenger = ScaffoldMessenger.of(context);
-    try {
-      await ref.read(dietRepositoryProvider).deleteEntry(id);
-      ref.invalidate(dietTodayProvider); // 삭제가 오늘 목록·요약에 반영
-    } catch (_) {
-      messenger.showSnackBar(
-        const SnackBar(content: Text('삭제에 실패했어요. 잠시 후 다시 시도해 주세요')),
-      );
-    }
+  @override
+  void initState() {
+    super.initState();
+    _selected = _today;
   }
 
-  Future<void> _openEntryDetail(DietEntry entry) async {
-    final result = await Navigator.of(context).push<DietEntryDetailResult>(
-      MaterialPageRoute<DietEntryDetailResult>(
-        builder: (_) => DietEntryDetailPage(entry: entry),
-      ),
-    );
-    if (!mounted || result == null) return;
-    ref.invalidate(dietTodayProvider);
-    final message = switch (result) {
-      DietEntryDetailResult.updated => '식단 기록이 수정되었어요.',
-      DietEntryDetailResult.deleted => '식단 기록이 삭제되었어요.',
-    };
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(message)));
-  }
-
-  Future<ImageSource?> _pickSource() {
-    return showModalBottomSheet<ImageSource>(
-      context: context,
-      builder: (BuildContext ctx) => SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            ListTile(
-              leading: const Icon(Icons.photo_camera_outlined),
-              title: const Text('사진 촬영'),
-              onTap: () => Navigator.of(ctx).pop(ImageSource.camera),
-            ),
-            ListTile(
-              leading: const Icon(Icons.photo_library_outlined),
-              title: const Text('갤러리에서 선택'),
-              onTap: () => Navigator.of(ctx).pop(ImageSource.gallery),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Future<void> _openDietAddFlow() async {
-    final source = await _pickSource();
-    if (source == null) return;
-    final XFile? file = await ImagePicker().pickImage(
-      source: source,
-      imageQuality: 80,
-      maxWidth: 1600,
-    );
-    if (file == null) return;
-    final bytes = await file.readAsBytes();
-    if (!mounted) return;
-
-    final added = await Navigator.of(context).push<bool>(
-      MaterialPageRoute<bool>(
-        builder: (_) =>
-            DietAnalyzePage(imageBytes: bytes, mealType: _currentMealType()),
-        fullscreenDialog: true,
-      ),
-    );
-    if (!mounted) return;
-    if (added == true) {
-      ref.invalidate(dietTodayProvider); // 새 식단이 오늘 목록·요약에 반영
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('식단이 추가되었어요')));
-    }
+  int _weekOfMonth(DateTime d) {
+    final DateTime first = DateTime(d.year, d.month);
+    final int offset = first.weekday - 1; // days from Monday
+    return ((d.day + offset - 1) / 7).floor() + 1;
   }
 
   @override
   Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context);
-    final async = ref.watch(dietTodayProvider);
+    final DateTime today = _today;
+    // Window is always centred on today (+ whole-week shifts): 3 days before,
+    // today in the middle, 3 days after.
+    final DateTime center = today.add(Duration(days: _weekShift * 7));
+    final List<DateTime> days = List<DateTime>.generate(
+      7,
+      (int i) => center.add(Duration(days: i - 3)),
+    );
+    final bool atToday = _weekShift == 0 && _selected == today;
 
     return Scaffold(
-      backgroundColor: AppColors.background,
-      body: Column(
-        children: <Widget>[
-          OncareHeader(
-            title: l.pageDietTitle,
-            onNotificationTap: () => showRightSlidePanel<void>(
-              context,
-              content: const NotificationPanelBody(),
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        bottom: false,
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 720),
+            child: ListView(
+              padding: const EdgeInsets.only(bottom: 108),
+              children: <Widget>[
+                FigmaTabHeader(
+                  title: '식단',
+                  onBell: () => showRightSlidePanel<void>(
+                    context,
+                    content: const NotificationPanelBody(),
+                  ),
+                  onCalendar: () => showScheduleCalendarSheet(context),
+                ),
+                _DateStrip(
+                  days: days,
+                  today: today,
+                  selected: _selected,
+                  weekLabel: '${center.month}월 ${_weekOfMonth(center)}주차',
+                  showTodayButton: !atToday,
+                  onSelect: (DateTime d) => setState(() => _selected = d),
+                  onPrev: () => setState(() => _weekShift -= 1),
+                  onNext: _weekShift >= 0
+                      ? null
+                      : () => setState(() => _weekShift += 1),
+                  onToday: () => setState(() {
+                    _weekShift = 0;
+                    _selected = today;
+                  }),
+                ),
+                const SizedBox(height: 8),
+                const _NutritionSummary(),
+                const SizedBox(height: 20),
+                const _AiFeedback(),
+                const SizedBox(height: 20),
+                _MealLog(
+                  onAdd: () => showDietAddSheet(context),
+                  onEditMeal: (DietMeal m) => showMealEditSheet(context, m),
+                ),
+              ],
             ),
-            onCalendarTap: () => showScheduleCalendarSheet(context),
           ),
-          Expanded(
-            child: async.when(
-              data: (day) => Center(
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 672),
-                  child: ListView(
-                    padding: const EdgeInsets.fromLTRB(
-                      AppSpacing.lg,
-                      AppSpacing.lg,
-                      AppSpacing.lg,
-                      AppSpacing.xxxl,
-                    ),
-                    children: <Widget>[
-                      DietWeekStrip(
-                        selectedDay: _selectedDay,
-                        onSelect: (d) => setState(() => _selectedDay = d),
-                        onShiftWeek: (delta) => setState(() {
-                          _selectedDay = _selectedDay.add(
-                            Duration(days: 7 * delta),
-                          );
-                        }),
-                      ),
-                      const SizedBox(height: AppSpacing.lg),
-                      DietSummaryCard(day: day),
-                      const SizedBox(height: AppSpacing.lg),
-                      AiCoachCard(message: day.aiCoachMessage),
-                      const SizedBox(height: AppSpacing.lg),
-                      Padding(
-                        padding: const EdgeInsets.only(bottom: AppSpacing.sm),
-                        child: Text(
-                          '오늘의 식단',
-                          style: Theme.of(context).textTheme.titleMedium
-                              ?.copyWith(fontWeight: FontWeight.w600),
-                        ),
-                      ),
-                      for (final entry in day.entries) ...<Widget>[
-                        if (entry.id == null)
-                          MealCard(
-                            entry: entry,
-                            onTap: () => _openEntryDetail(entry),
-                          )
-                        else
-                          SwipeToDelete(
-                            dismissKey: ValueKey<String>('diet-${entry.id}'),
-                            message: '이 식단 기록을 삭제할까요?',
-                            onDelete: () => _deleteDietEntry(entry.id!),
-                            child: MealCard(
-                              entry: entry,
-                              onTap: () => _openEntryDetail(entry),
-                            ),
-                          ),
-                        const SizedBox(height: AppSpacing.sm),
-                      ],
-                    ],
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────── date strip ──
+
+class _DateStrip extends StatelessWidget {
+  const _DateStrip({
+    required this.days,
+    required this.today,
+    required this.selected,
+    required this.weekLabel,
+    required this.showTodayButton,
+    required this.onSelect,
+    required this.onPrev,
+    required this.onNext,
+    required this.onToday,
+  });
+
+  final List<DateTime> days;
+  final DateTime today;
+  final DateTime selected;
+  final String weekLabel;
+  final bool showTodayButton;
+  final ValueChanged<DateTime> onSelect;
+  final VoidCallback onPrev;
+  final VoidCallback? onNext;
+  final VoidCallback onToday;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Text(
+                  weekLabel,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: FigmaColors.textSub,
                   ),
                 ),
+                if (showTodayButton)
+                  GestureDetector(
+                    onTap: onToday,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 3,
+                      ),
+                      decoration: BoxDecoration(
+                        color: FigmaColors.primaryA(0.10),
+                        borderRadius: BorderRadius.circular(999),
+                        border: Border.all(color: FigmaColors.primaryA(0.25)),
+                      ),
+                      child: const Text(
+                        '오늘로',
+                        style: TextStyle(
+                          fontSize: 10,
+                          fontWeight: FontWeight.w700,
+                          color: FigmaColors.primary,
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: <Widget>[
+              _Arrow(icon: Icons.chevron_left, onTap: onPrev),
+              Expanded(
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    for (final DateTime d in days)
+                      _DayCell(
+                        day: d,
+                        isToday: d == today,
+                        isSelected: d == selected,
+                        onTap: () => onSelect(d),
+                      ),
+                  ],
+                ),
               ),
-              loading: () => const Center(child: CircularProgressIndicator()),
-              error: (Object e, _) => ErrorView(
-                error: e is AppError ? e : UnknownError(message: e.toString()),
-                onRetry: () => ref.invalidate(dietTodayProvider),
+              _Arrow(icon: Icons.chevron_right, onTap: onNext),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Arrow extends StatelessWidget {
+  const _Arrow({required this.icon, required this.onTap});
+  final IconData icon;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Opacity(
+      opacity: onTap == null ? 0.35 : 1,
+      child: Material(
+        color: FigmaColors.softBlue,
+        shape: const CircleBorder(),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onTap,
+          child: SizedBox(
+            width: 28,
+            height: 28,
+            child: Icon(icon, size: 16, color: FigmaColors.primary),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DayCell extends StatelessWidget {
+  const _DayCell({
+    required this.day,
+    required this.isToday,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final DateTime day;
+  final bool isToday;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color labelColor = isSelected || isToday
+        ? FigmaColors.primary
+        : FigmaColors.textFaint;
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Text(
+            _weekdayLabels[day.weekday - 1],
+            style: TextStyle(
+              fontSize: 9.5,
+              fontWeight: FontWeight.w600,
+              color: labelColor,
+            ),
+          ),
+          const SizedBox(height: 3),
+          Container(
+            width: 30,
+            height: 30,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: isSelected ? FigmaColors.primary : Colors.transparent,
+              borderRadius: BorderRadius.circular(12),
+              boxShadow: isSelected
+                  ? <BoxShadow>[
+                      BoxShadow(
+                        color: FigmaColors.primaryA(0.40),
+                        blurRadius: 10,
+                        offset: const Offset(0, 3),
+                      ),
+                    ]
+                  : null,
+            ),
+            child: Text(
+              '${day.day}',
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+                color: isSelected
+                    ? Colors.white
+                    : isToday
+                    ? FigmaColors.primary
+                    : FigmaColors.textSub,
               ),
             ),
           ),
         ],
       ),
-      floatingActionButton: FloatingActionButton(
-        backgroundColor: AppColors.primary,
-        foregroundColor: AppColors.primaryForeground,
-        tooltip: '식단 추가',
-        onPressed: _openDietAddFlow,
-        child: const Icon(Icons.add),
+    );
+  }
+}
+
+// ──────────────────────────────────────────────────── nutrition summary ──
+
+class _NutritionSummary extends StatelessWidget {
+  const _NutritionSummary();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.symmetric(horizontal: 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            '오늘의 영양 요약',
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+              color: FigmaColors.ink,
+            ),
+          ),
+          SizedBox(height: 12),
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: _SummaryTile(
+                  label: '칼로리',
+                  value: '1420',
+                  unit: 'kcal',
+                  color: FigmaColors.primary,
+                ),
+              ),
+              SizedBox(width: 8),
+              Expanded(
+                child: _SummaryTile(
+                  label: '나트륨',
+                  value: '2100',
+                  unit: 'mg',
+                  color: FigmaColors.orange,
+                ),
+              ),
+              SizedBox(width: 8),
+              Expanded(
+                child: _SummaryTile(
+                  label: '당류',
+                  value: '45',
+                  unit: 'g',
+                  color: FigmaColors.primary,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SummaryTile extends StatelessWidget {
+  const _SummaryTile({
+    required this.label,
+    required this.value,
+    required this.unit,
+    required this.color,
+  });
+
+  final String label;
+  final String value;
+  final String unit;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: color.withValues(alpha: 0.13)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            label,
+            style: const TextStyle(
+              fontSize: 10,
+              fontWeight: FontWeight.w600,
+              color: FigmaColors.textSub,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            value,
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.w800,
+              color: color,
+              height: 1,
+              letterSpacing: -0.5,
+            ),
+          ),
+          const SizedBox(height: 1),
+          Text(
+            unit,
+            style: TextStyle(
+              fontSize: 9.5,
+              fontWeight: FontWeight.w500,
+              color: color.withValues(alpha: 0.8),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────── AI feedback ──
+
+class _AiFeedback extends StatelessWidget {
+  const _AiFeedback();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Column(
+        children: <Widget>[
+          Container(
+            padding: const EdgeInsets.all(14),
+            decoration: BoxDecoration(
+              color: FigmaColors.softBlue,
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(color: FigmaColors.primaryA(0.15)),
+            ),
+            child: const Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                OniAvatar(size: 40),
+                SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        'AI 피드백',
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w700,
+                          color: FigmaColors.primary,
+                        ),
+                      ),
+                      SizedBox(height: 2),
+                      Text(
+                        '오늘 나트륨이 2100mg으로 목표(2000mg)를 초과했어요.\n내일은 국물류를 줄이면 균형을 맞출 수 있어요.',
+                        style: TextStyle(
+                          fontSize: 12,
+                          height: 1.5,
+                          fontWeight: FontWeight.w500,
+                          color: FigmaColors.ink,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 8),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            decoration: BoxDecoration(
+              color: const Color(0xFFF4F5F7),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: const Row(
+              children: <Widget>[
+                Text('📤', style: TextStyle(fontSize: 10)),
+                SizedBox(width: 6),
+                Expanded(
+                  child: Text.rich(
+                    TextSpan(
+                      style: TextStyle(
+                        fontSize: 10,
+                        fontWeight: FontWeight.w500,
+                        color: FigmaColors.textMuted,
+                      ),
+                      children: <InlineSpan>[
+                        TextSpan(text: '오늘의 식단 분석이 '),
+                        TextSpan(
+                          text: '김트레이너님',
+                          style: TextStyle(
+                            fontWeight: FontWeight.w600,
+                            color: Color(0xFF8A929E),
+                          ),
+                        ),
+                        TextSpan(text: '에게 자동 전송됐어요'),
+                      ],
+                    ),
+                  ),
+                ),
+                Icon(Icons.check, size: 13, color: FigmaColors.statusGreen),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────── meal log ──
+
+class _MealLog extends StatelessWidget {
+  const _MealLog({required this.onAdd, required this.onEditMeal});
+
+  final VoidCallback onAdd;
+  final ValueChanged<DietMeal> onEditMeal;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              const Text(
+                '오늘의 식단',
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                  color: FigmaColors.ink,
+                ),
+              ),
+              const Spacer(),
+              _AddButton(onTap: onAdd),
+            ],
+          ),
+          const SizedBox(height: 12),
+          for (final DietMeal m in kDietMeals) ...<Widget>[
+            _MealCard(meal: m, onTap: () => onEditMeal(m)),
+            const SizedBox(height: 12),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _AddButton extends StatelessWidget {
+  const _AddButton({required this.onTap});
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: FigmaColors.primary,
+      borderRadius: BorderRadius.circular(999),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(999),
+        child: const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(Icons.add, size: 13, color: Colors.white),
+              SizedBox(width: 4),
+              Text(
+                '식단 추가',
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  color: Colors.white,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MealCard extends StatelessWidget {
+  const _MealCard({required this.meal, required this.onTap});
+  final DietMeal meal;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.08),
+            blurRadius: 20,
+            offset: const Offset(0, 6),
+          ),
+        ],
+      ),
+      child: Material(
+        color: Colors.transparent,
+        borderRadius: BorderRadius.circular(20),
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(20),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 10,
+                        vertical: 2,
+                      ),
+                      decoration: BoxDecoration(
+                        color: FigmaColors.primaryA(0.12),
+                        borderRadius: BorderRadius.circular(999),
+                      ),
+                      child: Text(
+                        meal.badge,
+                        style: const TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w700,
+                          color: FigmaColors.primary,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      meal.time,
+                      style: const TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w500,
+                        color: FigmaColors.textFaint,
+                      ),
+                    ),
+                    const Spacer(),
+                    Text(
+                      '${meal.total} kcal',
+                      style: const TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w800,
+                        color: FigmaColors.primary,
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    const Icon(
+                      Icons.chevron_right,
+                      size: 16,
+                      color: FigmaColors.textFaint,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                const Divider(height: 1, color: FigmaColors.hairline),
+                const SizedBox(height: 12),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Container(
+                      width: 52,
+                      height: 52,
+                      alignment: Alignment.center,
+                      decoration: BoxDecoration(
+                        color: meal.thumbBg,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: <Widget>[
+                          Text(
+                            meal.emoji,
+                            style: const TextStyle(fontSize: 22),
+                          ),
+                          const Text(
+                            '사진 분석',
+                            style: TextStyle(
+                              fontSize: 7.5,
+                              fontWeight: FontWeight.w600,
+                              color: FigmaColors.textMuted,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: <Widget>[
+                          for (final DietFood f in meal.items)
+                            Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 3),
+                              child: Row(
+                                children: <Widget>[
+                                  Expanded(
+                                    child: Text(
+                                      f.name,
+                                      style: const TextStyle(
+                                        fontSize: 12.5,
+                                        fontWeight: FontWeight.w500,
+                                        color: Color(0xFF3A3A4A),
+                                      ),
+                                    ),
+                                  ),
+                                  Text(
+                                    '${f.kcal} kcal',
+                                    style: const TextStyle(
+                                      fontSize: 12,
+                                      fontWeight: FontWeight.w600,
+                                      color: FigmaColors.textSub,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                Wrap(
+                  spacing: 6,
+                  runSpacing: 6,
+                  children: <Widget>[
+                    for (final DietTag t in meal.tags)
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 10,
+                          vertical: 3,
+                        ),
+                        decoration: BoxDecoration(
+                          color: t.over
+                              ? const Color(0x1AFF5841)
+                              : FigmaColors.primaryA(0.10),
+                          borderRadius: BorderRadius.circular(999),
+                        ),
+                        child: Text(
+                          t.label,
+                          style: TextStyle(
+                            fontSize: 10.5,
+                            fontWeight: FontWeight.w600,
+                            color: t.over
+                                ? const Color(0xFFFF5841)
+                                : FigmaColors.primary,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -1,25 +1,63 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
 import 'package:oncare/features/diet/presentation/widgets/diet_flows.dart';
 import 'package:oncare/features/notification/presentation/widgets/notification_panel.dart';
 import 'package:oncare/shared/widgets/modals/right_slide_panel.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
 
 /// 식단 tab, rebuilt to match the On-Care Figma redesign. The weekly date
-/// strip is centred on today (per the product request), the nutrition summary /
-/// AI feedback / meal log follow the mockup, and the "식단 추가" and meal-edit
-/// flows open as bottom sheets.
-class DietRecordPage extends StatefulWidget {
+/// strip is centred on today (per the product request); the nutrition summary /
+/// AI feedback / meal log are driven by [dietTodayProvider], and the "식단 추가"
+/// and meal-edit flows open as bottom sheets wired to the diet repository.
+///
+/// The backend currently exposes only "today", so a non-today selection shows
+/// an empty state until the per-date query lands (tracked as a follow-up).
+class DietRecordPage extends ConsumerStatefulWidget {
   const DietRecordPage({super.key});
 
   @override
-  State<DietRecordPage> createState() => _DietRecordPageState();
+  ConsumerState<DietRecordPage> createState() => _DietRecordPageState();
 }
 
 const List<String> _weekdayLabels = <String>['월', '화', '수', '목', '금', '토', '일'];
 
-class _DietRecordPageState extends State<DietRecordPage> {
+/// Meal-type presentation metadata (badge label, thumbnail emoji + tint).
+const Map<MealType, ({String badge, String emoji, Color bg})> _mealMeta =
+    <MealType, ({String badge, String emoji, Color bg})>{
+      MealType.breakfast: (badge: '아침', emoji: '🥣', bg: Color(0xFFFFF3E0)),
+      MealType.lunch: (badge: '점심', emoji: '🥗', bg: Color(0xFFE8F5E9)),
+      MealType.dinner: (badge: '저녁', emoji: '🐟', bg: Color(0xFFE3F2FD)),
+      MealType.snack: (badge: '간식', emoji: '🍎', bg: Color(0xFFFCE4EC)),
+    };
+
+/// Maps a backend [DietEntry] onto the Figma meal-card view model.
+DietMeal _mealFromEntry(DietEntry e) {
+  final ({String badge, String emoji, Color bg}) meta =
+      _mealMeta[e.mealType] ?? _mealMeta[MealType.snack]!;
+  return DietMeal(
+    id: e.id,
+    badge: meta.badge,
+    time: e.timeLabel,
+    total: e.totalCalories,
+    emoji: meta.emoji,
+    thumbBg: meta.bg,
+    items: <DietFood>[
+      for (final FoodItem f in e.foods) DietFood(f.name, f.calories),
+    ],
+    tags: <DietTag>[
+      DietTag('나트륨 ${e.sodiumMg}mg', over: e.sodiumMg > 700),
+      DietTag('당류 ${e.sugarG}g'),
+    ],
+    sodium: e.sodiumMg,
+    sugar: e.sugarG,
+  );
+}
+
+class _DietRecordPageState extends ConsumerState<DietRecordPage> {
   int _weekShift = 0; // whole-week steps away from today
   late DateTime _selected;
 
@@ -51,6 +89,7 @@ class _DietRecordPageState extends State<DietRecordPage> {
       (int i) => center.add(Duration(days: i - 3)),
     );
     final bool atToday = _weekShift == 0 && _selected == today;
+    final AsyncValue<DietDay> diet = ref.watch(dietTodayProvider);
 
     return Scaffold(
       backgroundColor: Colors.white,
@@ -87,14 +126,29 @@ class _DietRecordPageState extends State<DietRecordPage> {
                   }),
                 ),
                 const SizedBox(height: 8),
-                const _NutritionSummary(),
-                const SizedBox(height: 20),
-                const _AiFeedback(),
-                const SizedBox(height: 20),
-                _MealLog(
-                  onAdd: () => showDietAddSheet(context),
-                  onEditMeal: (DietMeal m) => showMealEditSheet(context, m),
-                ),
+                if (!atToday)
+                  const _EmptyDay()
+                else
+                  diet.when(
+                    loading: () => const _DietLoading(),
+                    error: (Object e, StackTrace _) => _DietError(
+                      onRetry: () => ref.invalidate(dietTodayProvider),
+                    ),
+                    data: (DietDay day) => Column(
+                      children: <Widget>[
+                        _NutritionSummary(day: day),
+                        const SizedBox(height: 20),
+                        _AiFeedback(message: day.aiCoachMessage),
+                        const SizedBox(height: 20),
+                        _MealLog(
+                          entries: day.entries,
+                          onAdd: () => showDietAddSheet(context),
+                          onEditMeal: (DietMeal m) =>
+                              showMealEditSheet(context, m),
+                        ),
+                      ],
+                    ),
+                  ),
               ],
             ),
           ),
@@ -300,16 +354,18 @@ class _DayCell extends StatelessWidget {
 // ──────────────────────────────────────────────────── nutrition summary ──
 
 class _NutritionSummary extends StatelessWidget {
-  const _NutritionSummary();
+  const _NutritionSummary({required this.day});
+
+  final DietDay day;
 
   @override
   Widget build(BuildContext context) {
-    return const Padding(
-      padding: EdgeInsets.symmetric(horizontal: 24),
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          Text(
+          const Text(
             '오늘의 영양 요약',
             style: TextStyle(
               fontSize: 14,
@@ -317,31 +373,31 @@ class _NutritionSummary extends StatelessWidget {
               color: FigmaColors.ink,
             ),
           ),
-          SizedBox(height: 12),
+          const SizedBox(height: 12),
           Row(
             children: <Widget>[
               Expanded(
                 child: _SummaryTile(
                   label: '칼로리',
-                  value: '1420',
+                  value: '${day.totalCalories}',
                   unit: 'kcal',
                   color: FigmaColors.primary,
                 ),
               ),
-              SizedBox(width: 8),
+              const SizedBox(width: 8),
               Expanded(
                 child: _SummaryTile(
                   label: '나트륨',
-                  value: '2100',
+                  value: '${day.totalSodiumMg}',
                   unit: 'mg',
                   color: FigmaColors.orange,
                 ),
               ),
-              SizedBox(width: 8),
+              const SizedBox(width: 8),
               Expanded(
                 child: _SummaryTile(
                   label: '당류',
-                  value: '45',
+                  value: '${day.totalSugarG}',
                   unit: 'g',
                   color: FigmaColors.primary,
                 ),
@@ -416,92 +472,54 @@ class _SummaryTile extends StatelessWidget {
 // ─────────────────────────────────────────────────────── AI feedback ──
 
 class _AiFeedback extends StatelessWidget {
-  const _AiFeedback();
+  const _AiFeedback({required this.message});
+
+  final String message;
 
   @override
   Widget build(BuildContext context) {
+    if (message.trim().isEmpty) return const SizedBox.shrink();
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 24),
-      child: Column(
-        children: <Widget>[
-          Container(
-            padding: const EdgeInsets.all(14),
-            decoration: BoxDecoration(
-              color: FigmaColors.softBlue,
-              borderRadius: BorderRadius.circular(16),
-              border: Border.all(color: FigmaColors.primaryA(0.15)),
-            ),
-            child: const Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                OniAvatar(size: 40),
-                SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: <Widget>[
-                      Text(
-                        'AI 피드백',
-                        style: TextStyle(
-                          fontSize: 12,
-                          fontWeight: FontWeight.w700,
-                          color: FigmaColors.primary,
-                        ),
-                      ),
-                      SizedBox(height: 2),
-                      Text(
-                        '오늘 나트륨이 2100mg으로 목표(2000mg)를 초과했어요.\n내일은 국물류를 줄이면 균형을 맞출 수 있어요.',
-                        style: TextStyle(
-                          fontSize: 12,
-                          height: 1.5,
-                          fontWeight: FontWeight.w500,
-                          color: FigmaColors.ink,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(height: 8),
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-            decoration: BoxDecoration(
-              color: const Color(0xFFF4F5F7),
-              borderRadius: BorderRadius.circular(12),
-            ),
-            child: const Row(
-              children: <Widget>[
-                Text('📤', style: TextStyle(fontSize: 10)),
-                SizedBox(width: 6),
-                Expanded(
-                  child: Text.rich(
-                    TextSpan(
-                      style: TextStyle(
-                        fontSize: 10,
-                        fontWeight: FontWeight.w500,
-                        color: FigmaColors.textMuted,
-                      ),
-                      children: <InlineSpan>[
-                        TextSpan(text: '오늘의 식단 분석이 '),
-                        TextSpan(
-                          text: '김트레이너님',
-                          style: TextStyle(
-                            fontWeight: FontWeight.w600,
-                            color: Color(0xFF8A929E),
-                          ),
-                        ),
-                        TextSpan(text: '에게 자동 전송됐어요'),
-                      ],
+      child: Container(
+        padding: const EdgeInsets.all(14),
+        decoration: BoxDecoration(
+          color: FigmaColors.softBlue,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: FigmaColors.primaryA(0.15)),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            const OniAvatar(size: 40),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  const Text(
+                    'AI 피드백',
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      color: FigmaColors.primary,
                     ),
                   ),
-                ),
-                Icon(Icons.check, size: 13, color: FigmaColors.statusGreen),
-              ],
+                  const SizedBox(height: 2),
+                  Text(
+                    message,
+                    style: const TextStyle(
+                      fontSize: 12,
+                      height: 1.5,
+                      fontWeight: FontWeight.w500,
+                      color: FigmaColors.ink,
+                    ),
+                  ),
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -510,8 +528,13 @@ class _AiFeedback extends StatelessWidget {
 // ─────────────────────────────────────────────────────────── meal log ──
 
 class _MealLog extends StatelessWidget {
-  const _MealLog({required this.onAdd, required this.onEditMeal});
+  const _MealLog({
+    required this.entries,
+    required this.onAdd,
+    required this.onEditMeal,
+  });
 
+  final List<DietEntry> entries;
   final VoidCallback onAdd;
   final ValueChanged<DietMeal> onEditMeal;
 
@@ -537,10 +560,32 @@ class _MealLog extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 12),
-          for (final DietMeal m in kDietMeals) ...<Widget>[
-            _MealCard(meal: m, onTap: () => onEditMeal(m)),
-            const SizedBox(height: 12),
-          ],
+          if (entries.isEmpty)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 28),
+              child: Center(
+                child: Text(
+                  '아직 기록된 식단이 없어요.\n사진으로 첫 끼니를 추가해 보세요!',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 12.5,
+                    height: 1.5,
+                    fontWeight: FontWeight.w500,
+                    color: FigmaColors.textMuted,
+                  ),
+                ),
+              ),
+            )
+          else
+            for (final DietEntry e in entries) ...<Widget>[
+              Builder(
+                builder: (BuildContext context) {
+                  final DietMeal m = _mealFromEntry(e);
+                  return _MealCard(meal: m, onTap: () => onEditMeal(m));
+                },
+              ),
+              const SizedBox(height: 12),
+            ],
         ],
       ),
     );
@@ -758,6 +803,79 @@ class _MealCard extends StatelessWidget {
                 ),
               ],
             ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────── loading / error / empty ──
+
+class _DietLoading extends StatelessWidget {
+  const _DietLoading();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.symmetric(vertical: 48),
+      child: Center(
+        child: SizedBox(
+          width: 28,
+          height: 28,
+          child: CircularProgressIndicator(strokeWidth: 3),
+        ),
+      ),
+    );
+  }
+}
+
+class _DietError extends StatelessWidget {
+  const _DietError({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 40),
+      child: Column(
+        children: <Widget>[
+          const Text(
+            '식단 정보를 불러오지 못했어요.',
+            style: TextStyle(fontSize: 13, color: FigmaColors.textMuted),
+          ),
+          const SizedBox(height: 14),
+          OutlinedButton(
+            onPressed: onRetry,
+            style: OutlinedButton.styleFrom(
+              foregroundColor: FigmaColors.primary,
+              side: BorderSide(color: FigmaColors.primaryA(0.4)),
+            ),
+            child: const Text('다시 시도'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyDay extends StatelessWidget {
+  const _EmptyDay();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.symmetric(horizontal: 24, vertical: 48),
+      child: Center(
+        child: Text(
+          '선택한 날짜의 기록은 아직 볼 수 없어요.\n오늘 날짜에서 식단을 확인해 주세요.',
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 12.5,
+            height: 1.5,
+            fontWeight: FontWeight.w500,
+            color: FigmaColors.textMuted,
           ),
         ),
       ),

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
@@ -1,6 +1,13 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
 
 import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/features/diet/domain/entities/diet_analysis.dart';
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
 
 /// A single logged food item.
 class DietFood {
@@ -16,7 +23,8 @@ class DietTag {
   final bool over;
 }
 
-/// One meal in the daily log.
+/// One meal in the daily log. [id] is the backend entry id (null for a
+/// not-yet-persisted draft) and is required to edit or delete the entry.
 class DietMeal {
   const DietMeal({
     required this.badge,
@@ -28,6 +36,7 @@ class DietMeal {
     required this.tags,
     required this.sodium,
     required this.sugar,
+    this.id,
   });
 
   final String badge;
@@ -39,53 +48,25 @@ class DietMeal {
   final List<DietTag> tags;
   final int sodium;
   final int sugar;
+  final String? id;
 }
 
-const List<DietMeal> kDietMeals = <DietMeal>[
-  DietMeal(
-    badge: '아침',
-    time: '08:20',
-    total: 315,
-    emoji: '🥣',
-    thumbBg: Color(0xFFFFF3E0),
-    items: <DietFood>[
-      DietFood('오트밀', 220),
-      DietFood('바나나 1개', 90),
-      DietFood('아메리카노', 5),
-    ],
-    tags: <DietTag>[DietTag('나트륨 380mg'), DietTag('당류 18g')],
-    sodium: 380,
-    sugar: 18,
-  ),
-  DietMeal(
-    badge: '점심',
-    time: '12:40',
-    total: 530,
-    emoji: '🥗',
-    thumbBg: Color(0xFFE8F5E9),
-    items: <DietFood>[
-      DietFood('닭가슴살 샐러드', 380),
-      DietFood('현미밥 반공기', 150),
-    ],
-    tags: <DietTag>[DietTag('나트륨 1120mg', over: true), DietTag('당류 14g')],
-    sodium: 1120,
-    sugar: 14,
-  ),
-  DietMeal(
-    badge: '저녁',
-    time: '19:00',
-    total: 575,
-    emoji: '🐟',
-    thumbBg: Color(0xFFE3F2FD),
-    items: <DietFood>[
-      DietFood('연어 스테이크', 420),
-      DietFood('구운 야채', 155),
-    ],
-    tags: <DietTag>[DietTag('나트륨 600mg'), DietTag('당류 13g')],
-    sodium: 600,
-    sugar: 13,
-  ),
-];
+/// Korean meal badge → backend `meal_type` string used by the diet API.
+const Map<String, String> _mealTypeByBadge = <String, String>{
+  '아침': 'breakfast',
+  '점심': 'lunch',
+  '저녁': 'dinner',
+  '간식': 'snack',
+};
+
+/// Best-guess meal type for a new entry, based on the current time of day.
+String _currentMealType() {
+  final int h = DateTime.now().hour;
+  if (h < 11) return 'breakfast';
+  if (h < 15) return 'lunch';
+  if (h < 21) return 'dinner';
+  return 'snack';
+}
 
 Widget _sheetShell(BuildContext context, Widget child) {
   return SafeArea(
@@ -117,6 +98,24 @@ Widget _sheetHandle() => Container(
 );
 
 // ─────────────────────────────────────────────────── 식단 추가하기 ──
+
+/// Pick a food photo from [source], then hand it to the AI analysis sheet.
+/// Silently returns if the user cancels the picker.
+Future<void> _pickAndAnalyze(
+  BuildContext sheetContext,
+  BuildContext pageContext,
+  ImageSource source,
+) async {
+  final XFile? file = await ImagePicker().pickImage(
+    source: source,
+    imageQuality: 85,
+  );
+  if (file == null) return;
+  final Uint8List bytes = await file.readAsBytes();
+  if (sheetContext.mounted) Navigator.of(sheetContext).pop();
+  if (!pageContext.mounted) return;
+  await showDietResultSheet(pageContext, bytes, _currentMealType());
+}
 
 /// "식단 추가하기" — pick a photo source, then show the AI analysis result.
 Future<void> showDietAddSheet(BuildContext context) {
@@ -169,10 +168,8 @@ Future<void> showDietAddSheet(BuildContext context) {
                   iconColor: FigmaColors.primary,
                   title: '사진 선택하기',
                   subtitle: '갤러리에서 음식 사진 선택',
-                  onTap: () {
-                    Navigator.of(ctx).pop();
-                    showDietResultSheet(context);
-                  },
+                  onTap: () =>
+                      _pickAndAnalyze(ctx, context, ImageSource.gallery),
                 ),
                 const SizedBox(height: 12),
                 _SourceOption(
@@ -181,10 +178,7 @@ Future<void> showDietAddSheet(BuildContext context) {
                   iconColor: FigmaColors.greenText,
                   title: '사진 찍기',
                   subtitle: '카메라로 음식 촬영',
-                  onTap: () {
-                    Navigator.of(ctx).pop();
-                    showDietResultSheet(context);
-                  },
+                  onTap: () => _pickAndAnalyze(ctx, context, ImageSource.camera),
                 ),
               ],
             ),
@@ -277,14 +271,77 @@ class _SourceOption extends StatelessWidget {
 // ─────────────────────────────────────────────────── 분석 완료 ──
 
 /// AI analysis result sheet shown after picking a photo.
-Future<void> showDietResultSheet(BuildContext context) {
+/// Runs the real `POST /diet/analyze` on the picked [imageBytes] and shows the
+/// recognised foods + nutrition. The backend persists the entry as part of
+/// analysis, so a successful result refreshes [dietTodayProvider].
+Future<void> showDietResultSheet(
+  BuildContext context,
+  Uint8List imageBytes,
+  String mealType,
+) {
   return showModalBottomSheet<void>(
     context: context,
     isScrollControlled: true,
     backgroundColor: Colors.transparent,
     barrierColor: FigmaColors.sheetScrim,
-    builder: (BuildContext ctx) => _sheetShell(
-      ctx,
+    builder: (BuildContext ctx) =>
+        _ResultSheet(imageBytes: imageBytes, mealType: mealType),
+  );
+}
+
+class _ResultSheet extends ConsumerStatefulWidget {
+  const _ResultSheet({required this.imageBytes, required this.mealType});
+  final Uint8List imageBytes;
+  final String mealType;
+
+  @override
+  ConsumerState<_ResultSheet> createState() => _ResultSheetState();
+}
+
+class _ResultSheetState extends ConsumerState<_ResultSheet> {
+  DietAnalysisResult? _result;
+  bool _loading = true;
+  bool _failed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _run();
+  }
+
+  Future<void> _run() async {
+    setState(() {
+      _loading = true;
+      _failed = false;
+    });
+    try {
+      final DietAnalysisResult result = await ref
+          .read(dietRepositoryProvider)
+          .analyze(
+            imageBytes: widget.imageBytes,
+            filename: 'meal.jpg',
+            mealType: widget.mealType,
+          );
+      if (!mounted) return;
+      // analyze() already persisted the entry → refresh the day's summary/list.
+      ref.invalidate(dietTodayProvider);
+      setState(() {
+        _result = result;
+        _loading = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _failed = true;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _sheetShell(
+      context,
       Column(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
@@ -295,19 +352,23 @@ Future<void> showDietResultSheet(BuildContext context) {
               children: <Widget>[
                 const OniAvatar(),
                 const SizedBox(width: 10),
-                const Expanded(
+                Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
                       Text(
-                        '분석 완료!',
-                        style: TextStyle(
+                        _loading
+                            ? '분석 중…'
+                            : _failed
+                            ? '분석 실패'
+                            : '분석 완료!',
+                        style: const TextStyle(
                           fontSize: 15,
                           fontWeight: FontWeight.w800,
                           color: FigmaColors.ink,
                         ),
                       ),
-                      Text(
+                      const Text(
                         'AI 영양 분석 결과',
                         style: TextStyle(
                           fontSize: 12,
@@ -318,121 +379,170 @@ Future<void> showDietResultSheet(BuildContext context) {
                     ],
                   ),
                 ),
-                _CircleClose(onTap: () => Navigator.of(ctx).pop()),
+                _CircleClose(onTap: () => Navigator.of(context).pop()),
               ],
             ),
           ),
           Padding(
             padding: const EdgeInsets.fromLTRB(20, 4, 20, 24),
-            child: Column(
-              children: <Widget>[
-                Container(
-                  width: double.infinity,
-                  padding: const EdgeInsets.all(14),
-                  decoration: BoxDecoration(
-                    color: FigmaColors.softBlue,
-                    borderRadius: BorderRadius.circular(14),
-                  ),
-                  child: const Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: <Widget>[
-                      Text(
-                        '인식된 음식',
-                        style: TextStyle(
-                          fontSize: 11,
-                          fontWeight: FontWeight.w600,
-                          color: FigmaColors.primary,
-                        ),
-                      ),
-                      SizedBox(height: 4),
-                      Text(
-                        '닭가슴살 샐러드 · 현미밥 반공기',
-                        style: TextStyle(
-                          fontSize: 15,
-                          fontWeight: FontWeight.w700,
-                          color: FigmaColors.ink,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: 12),
-                const Align(
-                  alignment: Alignment.centerLeft,
-                  child: Text(
-                    '영양 분석 결과 (수정 가능)',
-                    style: TextStyle(
-                      fontSize: 12,
-                      fontWeight: FontWeight.w600,
-                      color: FigmaColors.textMuted,
-                    ),
-                  ),
-                ),
-                const SizedBox(height: 8),
-                const _ResultRow(label: '칼로리', value: '486', unit: 'kcal'),
-                const SizedBox(height: 8),
-                const _ResultRow(label: '나트륨', value: '820', unit: 'mg'),
-                const SizedBox(height: 8),
-                const _ResultRow(label: '당류', value: '12', unit: 'g'),
-                const SizedBox(height: 16),
-                Row(
-                  children: <Widget>[
-                    Expanded(
-                      child: OutlinedButton.icon(
-                        onPressed: () => Navigator.of(ctx).pop(),
-                        style: OutlinedButton.styleFrom(
-                          foregroundColor: FigmaColors.primary,
-                          side: BorderSide(color: FigmaColors.primaryA(0.4)),
-                          padding: const EdgeInsets.symmetric(vertical: 13),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(14),
-                          ),
-                        ),
-                        icon: const Icon(Icons.edit_outlined, size: 16),
-                        label: const Text(
-                          '수정하기',
-                          style: TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w700,
-                          ),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: FilledButton.icon(
-                        onPressed: () {
-                          Navigator.of(ctx).pop();
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(content: Text('식단이 저장되었어요')),
-                          );
-                        },
-                        style: FilledButton.styleFrom(
-                          backgroundColor: FigmaColors.primary,
-                          padding: const EdgeInsets.symmetric(vertical: 13),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(14),
-                          ),
-                        ),
-                        icon: const Icon(Icons.save_outlined, size: 16),
-                        label: const Text(
-                          '저장하기',
-                          style: TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w700,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
+            child: _body(),
           ),
         ],
       ),
-    ),
-  );
+    );
+  }
+
+  Widget _body() {
+    if (_loading) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 32),
+        child: Column(
+          children: <Widget>[
+            SizedBox(
+              width: 28,
+              height: 28,
+              child: CircularProgressIndicator(strokeWidth: 3),
+            ),
+            SizedBox(height: 14),
+            Text(
+              '사진 속 음식을 분석하고 있어요',
+              style: TextStyle(fontSize: 13, color: FigmaColors.textMuted),
+            ),
+          ],
+        ),
+      );
+    }
+    if (_failed || _result == null) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 20),
+        child: Column(
+          children: <Widget>[
+            const Text(
+              '분석에 실패했어요. 잠시 후 다시 시도해 주세요.',
+              style: TextStyle(fontSize: 13, color: FigmaColors.textMuted),
+            ),
+            const SizedBox(height: 16),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: _run,
+                style: FilledButton.styleFrom(
+                  backgroundColor: FigmaColors.primary,
+                  padding: const EdgeInsets.symmetric(vertical: 13),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                ),
+                child: const Text(
+                  '다시 시도',
+                  style: TextStyle(fontSize: 14, fontWeight: FontWeight.w700),
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final DietAnalysisResult r = _result!;
+    final String recognized = r.foods.map((RecognizedFood f) => f.name).join(' · ');
+    return Column(
+      children: <Widget>[
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(14),
+          decoration: BoxDecoration(
+            color: FigmaColors.softBlue,
+            borderRadius: BorderRadius.circular(14),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              const Text(
+                '인식된 음식',
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  color: FigmaColors.primary,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                recognized.isEmpty ? '인식된 음식이 없어요' : recognized,
+                style: const TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w700,
+                  color: FigmaColors.ink,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
+        const Align(
+          alignment: Alignment.centerLeft,
+          child: Text(
+            '영양 분석 결과',
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: FigmaColors.textMuted,
+            ),
+          ),
+        ),
+        const SizedBox(height: 8),
+        _ResultRow(label: '칼로리', value: '${r.totalCalories}', unit: 'kcal'),
+        const SizedBox(height: 8),
+        _ResultRow(label: '나트륨', value: '${r.totalSodiumMg}', unit: 'mg'),
+        const SizedBox(height: 8),
+        _ResultRow(label: '당류', value: '${r.totalSugarG}', unit: 'g'),
+        if (r.coachComment.isNotEmpty) ...<Widget>[
+          const SizedBox(height: 12),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: FigmaColors.statBg,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Text(
+              r.coachComment,
+              style: const TextStyle(
+                fontSize: 12,
+                height: 1.5,
+                fontWeight: FontWeight.w500,
+                color: FigmaColors.textBody,
+              ),
+            ),
+          ),
+        ],
+        const SizedBox(height: 16),
+        SizedBox(
+          width: double.infinity,
+          child: FilledButton.icon(
+            onPressed: () {
+              Navigator.of(context).pop();
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('식단이 저장되었어요')),
+              );
+            },
+            style: FilledButton.styleFrom(
+              backgroundColor: FigmaColors.primary,
+              padding: const EdgeInsets.symmetric(vertical: 13),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(14),
+              ),
+            ),
+            icon: const Icon(Icons.check, size: 16),
+            label: const Text(
+              '완료',
+              style: TextStyle(fontSize: 14, fontWeight: FontWeight.w700),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
 }
 
 class _ResultRow extends StatelessWidget {
@@ -492,20 +602,103 @@ Future<void> showMealEditSheet(BuildContext context, DietMeal meal) {
   );
 }
 
-class _MealEditSheet extends StatefulWidget {
+class _MealEditSheet extends ConsumerStatefulWidget {
   const _MealEditSheet({required this.meal});
   final DietMeal meal;
 
   @override
-  State<_MealEditSheet> createState() => _MealEditSheetState();
+  ConsumerState<_MealEditSheet> createState() => _MealEditSheetState();
 }
 
-class _MealEditSheetState extends State<_MealEditSheet> {
+class _MealEditSheetState extends ConsumerState<_MealEditSheet> {
   static const List<String> _types = <String>['아침', '점심', '저녁', '간식'];
   late String _type = widget.meal.badge;
   late List<DietFood> _foods = List<DietFood>.of(widget.meal.items);
+  bool _busy = false;
 
   int get _total => _foods.fold(0, (int a, DietFood f) => a + f.kcal);
+
+  Future<void> _save() async {
+    final String? id = widget.meal.id;
+    final NavigatorState navigator = Navigator.of(context);
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    if (id == null) {
+      navigator.pop();
+      return;
+    }
+    setState(() => _busy = true);
+    try {
+      await ref
+          .read(dietRepositoryProvider)
+          .updateEntry(
+            id: id,
+            mealType: _mealTypeByBadge[_type],
+            foods: <FoodItem>[
+              for (final DietFood f in _foods)
+                FoodItem(name: f.name, calories: f.kcal),
+            ],
+            totalCalories: _total,
+          );
+      ref.invalidate(dietTodayProvider);
+      navigator.pop();
+      messenger.showSnackBar(
+        const SnackBar(content: Text('식단이 저장되었어요')),
+      );
+    } catch (_) {
+      if (mounted) setState(() => _busy = false);
+      messenger.showSnackBar(
+        const SnackBar(content: Text('저장에 실패했어요. 잠시 후 다시 시도해 주세요')),
+      );
+    }
+  }
+
+  Future<void> _confirmDelete() async {
+    final String? id = widget.meal.id;
+    if (id == null) {
+      Navigator.of(context).pop();
+      return;
+    }
+    final bool ok =
+        await showDialog<bool>(
+          context: context,
+          builder: (BuildContext ctx) => AlertDialog(
+            title: const Text('식단 기록 삭제'),
+            content: const Text('이 식단 기록을 삭제할까요?'),
+            actions: <Widget>[
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(false),
+                child: const Text('취소'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(true),
+                style: TextButton.styleFrom(
+                  foregroundColor: const Color(0xFFFF3B30),
+                ),
+                child: const Text('삭제'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+    if (!ok || !mounted) return;
+
+    final NavigatorState navigator = Navigator.of(context);
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    setState(() => _busy = true);
+    try {
+      await ref.read(dietRepositoryProvider).deleteEntry(id);
+      ref.invalidate(dietTodayProvider);
+      navigator.pop();
+      messenger.showSnackBar(
+        const SnackBar(content: Text('식단이 삭제되었어요')),
+      );
+    } catch (_) {
+      if (mounted) setState(() => _busy = false);
+      messenger.showSnackBar(
+        const SnackBar(content: Text('삭제에 실패했어요. 잠시 후 다시 시도해 주세요')),
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -535,12 +728,7 @@ class _MealEditSheetState extends State<_MealEditSheet> {
                   ),
                 ),
                 TextButton(
-                  onPressed: () {
-                    Navigator.of(context).pop();
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('식단이 저장되었어요')),
-                    );
-                  },
+                  onPressed: _busy ? null : _save,
                   child: const Text(
                     '저장',
                     style: TextStyle(
@@ -727,12 +915,7 @@ class _MealEditSheetState extends State<_MealEditSheet> {
             child: SizedBox(
               width: double.infinity,
               child: OutlinedButton.icon(
-                onPressed: () {
-                  Navigator.of(context).pop();
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('식단이 삭제되었어요')),
-                  );
-                },
+                onPressed: _busy ? null : _confirmDelete,
                 style: OutlinedButton.styleFrom(
                   foregroundColor: const Color(0xFFFF3B30),
                   side: const BorderSide(color: Color(0x33FF3B30)),

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
@@ -1,0 +1,945 @@
+import 'package:flutter/material.dart';
+
+import 'package:oncare/design_system/figma/figma_kit.dart';
+
+/// A single logged food item.
+class DietFood {
+  const DietFood(this.name, this.kcal);
+  final String name;
+  final int kcal;
+}
+
+/// A nutrient chip on a meal card (`over` = above the daily target → red).
+class DietTag {
+  const DietTag(this.label, {this.over = false});
+  final String label;
+  final bool over;
+}
+
+/// One meal in the daily log.
+class DietMeal {
+  const DietMeal({
+    required this.badge,
+    required this.time,
+    required this.total,
+    required this.emoji,
+    required this.thumbBg,
+    required this.items,
+    required this.tags,
+    required this.sodium,
+    required this.sugar,
+  });
+
+  final String badge;
+  final String time;
+  final int total;
+  final String emoji;
+  final Color thumbBg;
+  final List<DietFood> items;
+  final List<DietTag> tags;
+  final int sodium;
+  final int sugar;
+}
+
+const List<DietMeal> kDietMeals = <DietMeal>[
+  DietMeal(
+    badge: '아침',
+    time: '08:20',
+    total: 315,
+    emoji: '🥣',
+    thumbBg: Color(0xFFFFF3E0),
+    items: <DietFood>[
+      DietFood('오트밀', 220),
+      DietFood('바나나 1개', 90),
+      DietFood('아메리카노', 5),
+    ],
+    tags: <DietTag>[DietTag('나트륨 380mg'), DietTag('당류 18g')],
+    sodium: 380,
+    sugar: 18,
+  ),
+  DietMeal(
+    badge: '점심',
+    time: '12:40',
+    total: 530,
+    emoji: '🥗',
+    thumbBg: Color(0xFFE8F5E9),
+    items: <DietFood>[
+      DietFood('닭가슴살 샐러드', 380),
+      DietFood('현미밥 반공기', 150),
+    ],
+    tags: <DietTag>[DietTag('나트륨 1120mg', over: true), DietTag('당류 14g')],
+    sodium: 1120,
+    sugar: 14,
+  ),
+  DietMeal(
+    badge: '저녁',
+    time: '19:00',
+    total: 575,
+    emoji: '🐟',
+    thumbBg: Color(0xFFE3F2FD),
+    items: <DietFood>[
+      DietFood('연어 스테이크', 420),
+      DietFood('구운 야채', 155),
+    ],
+    tags: <DietTag>[DietTag('나트륨 600mg'), DietTag('당류 13g')],
+    sodium: 600,
+    sugar: 13,
+  ),
+];
+
+Widget _sheetShell(BuildContext context, Widget child) {
+  return SafeArea(
+    top: false,
+    child: ConstrainedBox(
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.9,
+        maxWidth: 480,
+      ),
+      child: Container(
+        decoration: const BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+        ),
+        child: child,
+      ),
+    ),
+  );
+}
+
+Widget _sheetHandle() => Container(
+  margin: const EdgeInsets.only(top: 12, bottom: 4),
+  width: 36,
+  height: 4,
+  decoration: BoxDecoration(
+    color: const Color(0xFFDDE3EA),
+    borderRadius: BorderRadius.circular(999),
+  ),
+);
+
+// ─────────────────────────────────────────────────── 식단 추가하기 ──
+
+/// "식단 추가하기" — pick a photo source, then show the AI analysis result.
+Future<void> showDietAddSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    barrierColor: FigmaColors.sheetScrim,
+    builder: (BuildContext ctx) => _sheetShell(
+      ctx,
+      Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Center(child: _sheetHandle()),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 8, 20, 4),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    const Expanded(
+                      child: Text(
+                        '식단 추가하기',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.w800,
+                          color: FigmaColors.ink,
+                        ),
+                      ),
+                    ),
+                    _CircleClose(onTap: () => Navigator.of(ctx).pop()),
+                  ],
+                ),
+                const SizedBox(height: 2),
+                const Text(
+                  '사진으로 음식을 분석해요',
+                  style: TextStyle(fontSize: 12, color: FigmaColors.textMuted),
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 12, 20, 24),
+            child: Column(
+              children: <Widget>[
+                _SourceOption(
+                  icon: Icons.image_outlined,
+                  iconBg: FigmaColors.primaryA(0.12),
+                  iconColor: FigmaColors.primary,
+                  title: '사진 선택하기',
+                  subtitle: '갤러리에서 음식 사진 선택',
+                  onTap: () {
+                    Navigator.of(ctx).pop();
+                    showDietResultSheet(context);
+                  },
+                ),
+                const SizedBox(height: 12),
+                _SourceOption(
+                  icon: Icons.photo_camera_outlined,
+                  iconBg: FigmaColors.greenA(0.12),
+                  iconColor: FigmaColors.greenText,
+                  title: '사진 찍기',
+                  subtitle: '카메라로 음식 촬영',
+                  onTap: () {
+                    Navigator.of(ctx).pop();
+                    showDietResultSheet(context);
+                  },
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+class _SourceOption extends StatelessWidget {
+  const _SourceOption({
+    required this.icon,
+    required this.iconBg,
+    required this.iconColor,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final Color iconBg;
+  final Color iconColor;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.white,
+      borderRadius: BorderRadius.circular(16),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(16),
+        child: Container(
+          padding: const EdgeInsets.all(14),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: FigmaColors.primaryA(0.15)),
+          ),
+          child: Row(
+            children: <Widget>[
+              Container(
+                width: 44,
+                height: 44,
+                decoration: BoxDecoration(
+                  color: iconBg,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Icon(icon, color: iconColor, size: 22),
+              ),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      title,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w700,
+                        color: FigmaColors.ink,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      subtitle,
+                      style: const TextStyle(
+                        fontSize: 12,
+                        color: FigmaColors.textMuted,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const Icon(
+                Icons.chevron_right,
+                size: 18,
+                color: FigmaColors.textFaint,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────── 분석 완료 ──
+
+/// AI analysis result sheet shown after picking a photo.
+Future<void> showDietResultSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    barrierColor: FigmaColors.sheetScrim,
+    builder: (BuildContext ctx) => _sheetShell(
+      ctx,
+      Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Center(child: _sheetHandle()),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 8, 20, 8),
+            child: Row(
+              children: <Widget>[
+                const OniAvatar(),
+                const SizedBox(width: 10),
+                const Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        '분석 완료!',
+                        style: TextStyle(
+                          fontSize: 15,
+                          fontWeight: FontWeight.w800,
+                          color: FigmaColors.ink,
+                        ),
+                      ),
+                      Text(
+                        'AI 영양 분석 결과',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: FigmaColors.primary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                _CircleClose(onTap: () => Navigator.of(ctx).pop()),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 4, 20, 24),
+            child: Column(
+              children: <Widget>[
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(14),
+                  decoration: BoxDecoration(
+                    color: FigmaColors.softBlue,
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  child: const Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        '인식된 음식',
+                        style: TextStyle(
+                          fontSize: 11,
+                          fontWeight: FontWeight.w600,
+                          color: FigmaColors.primary,
+                        ),
+                      ),
+                      SizedBox(height: 4),
+                      Text(
+                        '닭가슴살 샐러드 · 현미밥 반공기',
+                        style: TextStyle(
+                          fontSize: 15,
+                          fontWeight: FontWeight.w700,
+                          color: FigmaColors.ink,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 12),
+                const Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '영양 분석 결과 (수정 가능)',
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      color: FigmaColors.textMuted,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                const _ResultRow(label: '칼로리', value: '486', unit: 'kcal'),
+                const SizedBox(height: 8),
+                const _ResultRow(label: '나트륨', value: '820', unit: 'mg'),
+                const SizedBox(height: 8),
+                const _ResultRow(label: '당류', value: '12', unit: 'g'),
+                const SizedBox(height: 16),
+                Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: OutlinedButton.icon(
+                        onPressed: () => Navigator.of(ctx).pop(),
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: FigmaColors.primary,
+                          side: BorderSide(color: FigmaColors.primaryA(0.4)),
+                          padding: const EdgeInsets.symmetric(vertical: 13),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(14),
+                          ),
+                        ),
+                        icon: const Icon(Icons.edit_outlined, size: 16),
+                        label: const Text(
+                          '수정하기',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: FilledButton.icon(
+                        onPressed: () {
+                          Navigator.of(ctx).pop();
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('식단이 저장되었어요')),
+                          );
+                        },
+                        style: FilledButton.styleFrom(
+                          backgroundColor: FigmaColors.primary,
+                          padding: const EdgeInsets.symmetric(vertical: 13),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(14),
+                          ),
+                        ),
+                        icon: const Icon(Icons.save_outlined, size: 16),
+                        label: const Text(
+                          '저장하기',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+class _ResultRow extends StatelessWidget {
+  const _ResultRow({required this.label, required this.value, required this.unit});
+  final String label;
+  final String value;
+  final String unit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      decoration: BoxDecoration(
+        color: FigmaColors.statBg,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Row(
+        children: <Widget>[
+          Text(
+            label,
+            style: const TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+              color: FigmaColors.ink,
+            ),
+          ),
+          const Spacer(),
+          Text(
+            value,
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w800,
+              color: FigmaColors.primary,
+            ),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            unit,
+            style: const TextStyle(fontSize: 12, color: FigmaColors.textMuted),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────── 식사 수정 ──
+
+/// Meal-edit sheet: meal type, time, editable food list + nutrient values.
+Future<void> showMealEditSheet(BuildContext context, DietMeal meal) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    barrierColor: FigmaColors.sheetScrim,
+    builder: (BuildContext ctx) => _MealEditSheet(meal: meal),
+  );
+}
+
+class _MealEditSheet extends StatefulWidget {
+  const _MealEditSheet({required this.meal});
+  final DietMeal meal;
+
+  @override
+  State<_MealEditSheet> createState() => _MealEditSheetState();
+}
+
+class _MealEditSheetState extends State<_MealEditSheet> {
+  static const List<String> _types = <String>['아침', '점심', '저녁', '간식'];
+  late String _type = widget.meal.badge;
+  late List<DietFood> _foods = List<DietFood>.of(widget.meal.items);
+
+  int get _total => _foods.fold(0, (int a, DietFood f) => a + f.kcal);
+
+  @override
+  Widget build(BuildContext context) {
+    return _sheetShell(
+      context,
+      Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Center(child: _sheetHandle()),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 8, 20, 8),
+            child: Row(
+              children: <Widget>[
+                _CircleClose(
+                  icon: Icons.arrow_back,
+                  onTap: () => Navigator.of(context).pop(),
+                ),
+                Expanded(
+                  child: Text(
+                    '${widget.meal.badge} 식단',
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w800,
+                      color: FigmaColors.ink,
+                    ),
+                  ),
+                ),
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('식단이 저장되었어요')),
+                    );
+                  },
+                  child: const Text(
+                    '저장',
+                    style: TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w700,
+                      color: FigmaColors.primary,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Flexible(
+            child: ListView(
+              shrinkWrap: true,
+              padding: const EdgeInsets.fromLTRB(20, 4, 20, 28),
+              children: <Widget>[
+                _card(<Widget>[
+                  const _FieldLabel('식사 정보'),
+                  const SizedBox(height: 10),
+                  Row(
+                    children: <Widget>[
+                      for (final String t in _types) ...<Widget>[
+                        Expanded(
+                          child: GestureDetector(
+                            onTap: () => setState(() => _type = t),
+                            child: Container(
+                              alignment: Alignment.center,
+                              padding: const EdgeInsets.symmetric(vertical: 10),
+                              decoration: BoxDecoration(
+                                color: _type == t
+                                    ? FigmaColors.primaryA(0.10)
+                                    : Colors.white,
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(
+                                  color: _type == t
+                                      ? FigmaColors.primary
+                                      : FigmaColors.hairline,
+                                ),
+                              ),
+                              child: Text(
+                                t,
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w700,
+                                  color: _type == t
+                                      ? FigmaColors.primary
+                                      : FigmaColors.textSub,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                        if (t != _types.last) const SizedBox(width: 8),
+                      ],
+                    ],
+                  ),
+                  const SizedBox(height: 14),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: <Widget>[
+                      const _FieldLabel('먹은 시간'),
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 14,
+                          vertical: 8,
+                        ),
+                        decoration: BoxDecoration(
+                          color: FigmaColors.statBg,
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: <Widget>[
+                            const Icon(
+                              Icons.schedule,
+                              size: 14,
+                              color: FigmaColors.textMuted,
+                            ),
+                            const SizedBox(width: 6),
+                            Text(
+                              widget.meal.time,
+                              style: const TextStyle(
+                                fontSize: 13,
+                                fontWeight: FontWeight.w700,
+                                color: FigmaColors.ink,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ]),
+                const SizedBox(height: 12),
+                _card(<Widget>[
+                  Row(
+                    children: <Widget>[
+                      const Expanded(child: _FieldLabel('먹은 음식')),
+                      GestureDetector(
+                        onTap: () => setState(
+                          () => _foods = <DietFood>[
+                            ..._foods,
+                            const DietFood('새 음식', 0),
+                          ],
+                        ),
+                        child: const Text(
+                          '+ 음식 추가',
+                          style: TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w700,
+                            color: FigmaColors.primary,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  const Text(
+                    '음식명과 칼로리를 수정할 수 있어요',
+                    style: TextStyle(fontSize: 11, color: FigmaColors.textMuted),
+                  ),
+                  const SizedBox(height: 10),
+                  for (int i = 0; i < _foods.length; i++) ...<Widget>[
+                    _FoodRow(
+                      index: i + 1,
+                      food: _foods[i],
+                      onDelete: () =>
+                          setState(() => _foods = <DietFood>[..._foods]..removeAt(i)),
+                    ),
+                    const SizedBox(height: 8),
+                  ],
+                  const Divider(height: 16, color: FigmaColors.hairline),
+                  Row(
+                    children: <Widget>[
+                      const Text(
+                        '총 칼로리',
+                        style: TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: FigmaColors.textSub,
+                        ),
+                      ),
+                      const Spacer(),
+                      Text(
+                        '$_total kcal',
+                        style: const TextStyle(
+                          fontSize: 15,
+                          fontWeight: FontWeight.w800,
+                          color: FigmaColors.primary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ]),
+                const SizedBox(height: 12),
+                _card(<Widget>[
+                  const _FieldLabel('영양 정보'),
+                  const SizedBox(height: 4),
+                  const Text(
+                    '분석된 값을 직접 수정할 수 있어요',
+                    style: TextStyle(fontSize: 11, color: FigmaColors.textMuted),
+                  ),
+                  const SizedBox(height: 10),
+                  _NutrientRow(
+                    label: '나트륨',
+                    hint: '하루 권장 2,000mg 이하',
+                    value: '${widget.meal.sodium}',
+                    unit: 'mg',
+                  ),
+                  const SizedBox(height: 10),
+                  _NutrientRow(
+                    label: '당류',
+                    hint: '하루 권장 50g 이하',
+                    value: '${widget.meal.sugar}',
+                    unit: 'g',
+                  ),
+                ]),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 4, 20, 24),
+            child: SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                onPressed: () {
+                  Navigator.of(context).pop();
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('식단이 삭제되었어요')),
+                  );
+                },
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: const Color(0xFFFF3B30),
+                  side: const BorderSide(color: Color(0x33FF3B30)),
+                  padding: const EdgeInsets.symmetric(vertical: 13),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                ),
+                icon: const Icon(Icons.delete_outline, size: 18),
+                label: const Text(
+                  '식단 삭제',
+                  style: TextStyle(fontSize: 14, fontWeight: FontWeight.w700),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _card(List<Widget> children) => Container(
+    padding: const EdgeInsets.all(16),
+    decoration: BoxDecoration(
+      color: FigmaColors.statBg,
+      borderRadius: BorderRadius.circular(16),
+    ),
+    child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: children),
+  );
+}
+
+class _FieldLabel extends StatelessWidget {
+  const _FieldLabel(this.text);
+  final String text;
+  @override
+  Widget build(BuildContext context) => Text(
+    text,
+    style: const TextStyle(
+      fontSize: 14,
+      fontWeight: FontWeight.w700,
+      color: FigmaColors.ink,
+    ),
+  );
+}
+
+class _FoodRow extends StatelessWidget {
+  const _FoodRow({
+    required this.index,
+    required this.food,
+    required this.onDelete,
+  });
+  final int index;
+  final DietFood food;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: FigmaColors.hairline),
+      ),
+      child: Row(
+        children: <Widget>[
+          Container(
+            width: 20,
+            height: 20,
+            alignment: Alignment.center,
+            decoration: const BoxDecoration(
+              color: FigmaColors.primary,
+              shape: BoxShape.circle,
+            ),
+            child: Text(
+              '$index',
+              style: const TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                color: Colors.white,
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              food.name,
+              style: const TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w700,
+                color: FigmaColors.ink,
+              ),
+            ),
+          ),
+          Text(
+            '${food.kcal}',
+            style: const TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+              color: FigmaColors.ink,
+            ),
+          ),
+          const SizedBox(width: 4),
+          const Text(
+            'kcal',
+            style: TextStyle(fontSize: 11, color: FigmaColors.textMuted),
+          ),
+          const SizedBox(width: 8),
+          GestureDetector(
+            onTap: onDelete,
+            child: const Icon(
+              Icons.cancel,
+              size: 18,
+              color: Color(0xFFFFB4A8),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NutrientRow extends StatelessWidget {
+  const _NutrientRow({
+    required this.label,
+    required this.hint,
+    required this.value,
+    required this.unit,
+  });
+  final String label;
+  final String hint;
+  final String value;
+  final String unit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: FigmaColors.hairline),
+      ),
+      child: Row(
+        children: <Widget>[
+          Container(width: 3, height: 34, color: FigmaColors.primary),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  label,
+                  style: const TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: FigmaColors.ink,
+                  ),
+                ),
+                Text(
+                  hint,
+                  style: const TextStyle(
+                    fontSize: 10,
+                    color: FigmaColors.textMuted,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Text(
+            value,
+            style: const TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w800,
+              color: FigmaColors.ink,
+            ),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            unit,
+            style: const TextStyle(fontSize: 12, color: FigmaColors.textMuted),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CircleClose extends StatelessWidget {
+  const _CircleClose({required this.onTap, this.icon = Icons.close});
+  final VoidCallback onTap;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: const Color(0xFFF4F6F8),
+      shape: const CircleBorder(),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: SizedBox(
+          width: 32,
+          height: 32,
+          child: Icon(icon, size: 16, color: FigmaColors.textSub),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
@@ -106,12 +106,23 @@ Future<void> _pickAndAnalyze(
   BuildContext pageContext,
   ImageSource source,
 ) async {
-  final XFile? file = await ImagePicker().pickImage(
-    source: source,
-    imageQuality: 85,
-  );
-  if (file == null) return;
-  final Uint8List bytes = await file.readAsBytes();
+  final Uint8List bytes;
+  try {
+    final XFile? file = await ImagePicker().pickImage(
+      source: source,
+      imageQuality: 85,
+    );
+    if (file == null) return; // user cancelled
+    bytes = await file.readAsBytes();
+  } catch (_) {
+    // Permission denied / platform error / unreadable file — don't crash.
+    if (sheetContext.mounted) {
+      ScaffoldMessenger.of(sheetContext).showSnackBar(
+        const SnackBar(content: Text('사진을 불러오지 못했어요. 잠시 후 다시 시도해 주세요')),
+      );
+    }
+    return;
+  }
   if (sheetContext.mounted) Navigator.of(sheetContext).pop();
   if (!pageContext.mounted) return;
   await showDietResultSheet(pageContext, bytes, _currentMealType());
@@ -639,6 +650,8 @@ class _MealEditSheetState extends ConsumerState<_MealEditSheet> {
             ],
             totalCalories: _total,
           );
+      // Sheet dismissed mid-save → don't pop the page below.
+      if (!mounted) return;
       ref.invalidate(dietTodayProvider);
       navigator.pop();
       messenger.showSnackBar(
@@ -687,6 +700,8 @@ class _MealEditSheetState extends ConsumerState<_MealEditSheet> {
     setState(() => _busy = true);
     try {
       await ref.read(dietRepositoryProvider).deleteEntry(id);
+      // Sheet dismissed mid-delete → don't pop the page below.
+      if (!mounted) return;
       ref.invalidate(dietTodayProvider);
       navigator.pop();
       messenger.showSnackBar(
@@ -702,7 +717,8 @@ class _MealEditSheetState extends ConsumerState<_MealEditSheet> {
 
   @override
   Widget build(BuildContext context) {
-    return _sheetShell(
+    // Block back/drag dismiss while a save/delete request is in flight.
+    final Widget sheet = _sheetShell(
       context,
       Column(
         mainAxisSize: MainAxisSize.min,
@@ -714,7 +730,7 @@ class _MealEditSheetState extends ConsumerState<_MealEditSheet> {
               children: <Widget>[
                 _CircleClose(
                   icon: Icons.arrow_back,
-                  onTap: () => Navigator.of(context).pop(),
+                  onTap: _busy ? null : () => Navigator.of(context).pop(),
                 ),
                 Expanded(
                   child: Text(
@@ -935,6 +951,7 @@ class _MealEditSheetState extends ConsumerState<_MealEditSheet> {
         ],
       ),
     );
+    return PopScope(canPop: !_busy, child: sheet);
   }
 
   Widget _card(List<Widget> children) => Container(
@@ -1106,7 +1123,7 @@ class _NutrientRow extends StatelessWidget {
 
 class _CircleClose extends StatelessWidget {
   const _CircleClose({required this.onTap, this.icon = Icons.close});
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
   final IconData icon;
 
   @override

--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -1,10 +1,23 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/features/exercise/presentation/widgets/exercise_flows.dart';
 import 'package:oncare/features/notification/presentation/widgets/notification_panel.dart';
 import 'package:oncare/shared/widgets/modals/right_slide_panel.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
+
+/// Korean label for a workout type badge.
+String _typeLabel(ExerciseType t) => switch (t) {
+  ExerciseType.cardio => '유산소',
+  ExerciseType.strength => '근력',
+  ExerciseType.yoga => '요가',
+  ExerciseType.walking => '걷기',
+  ExerciseType.stretching => '스트레칭',
+  ExerciseType.other => '운동',
+};
 
 /// 운동 tab, rebuilt to the On-Care Figma redesign — a 운동 기록 / 헬스장
 /// sub-tab switcher over a weekly summary, stacked activity chart, AI routine,
@@ -131,103 +144,144 @@ class _SubTabs extends StatelessWidget {
 
 // ───────────────────────────────────────────────────────── 운동 기록 ──
 
-class _RecordTab extends StatelessWidget {
+class _RecordTab extends ConsumerWidget {
   const _RecordTab({required this.onAdd});
   final VoidCallback onAdd;
 
   @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        const Padding(
-          padding: EdgeInsets.fromLTRB(24, 0, 24, 12),
-          child: Text(
-            '이번 주 운동 요약',
-            style: TextStyle(
-              fontSize: 14,
-              fontWeight: FontWeight.w700,
-              color: FigmaColors.ink,
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AsyncValue<ExerciseWeek> weekAsync = ref.watch(exerciseWeekProvider);
+    return weekAsync.when(
+      loading: () => const Padding(
+        padding: EdgeInsets.symmetric(vertical: 64),
+        child: Center(
+          child: SizedBox(
+            width: 28,
+            height: 28,
+            child: CircularProgressIndicator(strokeWidth: 3),
+          ),
+        ),
+      ),
+      error: (Object e, StackTrace _) => Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 48),
+        child: Column(
+          children: <Widget>[
+            const Text(
+              '운동 정보를 불러오지 못했어요.',
+              style: TextStyle(fontSize: 13, color: FigmaColors.textMuted),
+            ),
+            const SizedBox(height: 14),
+            OutlinedButton(
+              onPressed: () => ref.invalidate(exerciseWeekProvider),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: FigmaColors.primary,
+                side: BorderSide(color: FigmaColors.primaryA(0.4)),
+              ),
+              child: const Text('다시 시도'),
+            ),
+          ],
+        ),
+      ),
+      data: (ExerciseWeek week) => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          const Padding(
+            padding: EdgeInsets.fromLTRB(24, 0, 24, 12),
+            child: Text(
+              '이번 주 운동 요약',
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w700,
+                color: FigmaColors.ink,
+              ),
             ),
           ),
-        ),
-        const Padding(
-          padding: EdgeInsets.symmetric(horizontal: 24),
-          child: Row(
-            children: <Widget>[
-              Expanded(
-                child: _StatCard(label: '이번 주', value: '6', unit: '회'),
-              ),
-              SizedBox(width: 8),
-              Expanded(
-                child: _StatCard(label: '시간', value: '350', unit: '분'),
-              ),
-              SizedBox(width: 8),
-              Expanded(
-                child: _StatCard(
-                  label: '칼로리',
-                  value: '2239',
-                  unit: 'kcal',
-                  accent: true,
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: Row(
+              children: <Widget>[
+                Expanded(
+                  child: _StatCard(
+                    label: '이번 주',
+                    value: '${week.sessions.length}',
+                    unit: '회',
+                  ),
                 ),
-              ),
-              SizedBox(width: 8),
-              Expanded(
-                child: _StatCard(
-                  label: '연속',
-                  value: '6',
-                  unit: '일 연속',
-                  streak: true,
+                const SizedBox(width: 8),
+                Expanded(
+                  child: _StatCard(
+                    label: '시간',
+                    value: '${week.totalMinutes}',
+                    unit: '분',
+                  ),
                 ),
-              ),
-            ],
+                const SizedBox(width: 8),
+                Expanded(
+                  child: _StatCard(
+                    label: '칼로리',
+                    value: '${week.totalCalories}',
+                    unit: 'kcal',
+                    accent: true,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: _StatCard(
+                    label: '연속',
+                    value: '${week.streakDays}',
+                    unit: '일 연속',
+                    streak: true,
+                  ),
+                ),
+              ],
+            ),
           ),
-        ),
-        const SizedBox(height: 20),
-        const Padding(
-          padding: EdgeInsets.fromLTRB(24, 0, 24, 12),
-          child: Row(
-            children: <Widget>[
-              Text(
-                '운동 현황',
-                style: TextStyle(
-                  fontSize: 14,
-                  fontWeight: FontWeight.w700,
-                  color: FigmaColors.ink,
+          const SizedBox(height: 20),
+          const Padding(
+            padding: EdgeInsets.fromLTRB(24, 0, 24, 12),
+            child: Row(
+              children: <Widget>[
+                Text(
+                  '운동 현황',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    color: FigmaColors.ink,
+                  ),
                 ),
-              ),
-              SizedBox(width: 8),
-              Text(
-                '이번 주',
-                style: TextStyle(
-                  fontSize: 12,
-                  fontWeight: FontWeight.w600,
-                  color: FigmaColors.textMuted,
+                SizedBox(width: 8),
+                Text(
+                  '이번 주',
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: FigmaColors.textMuted,
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
-        ),
-        const Padding(
-          padding: EdgeInsets.symmetric(horizontal: 24),
-          child: _ActivityChart(),
-        ),
-        const SizedBox(height: 20),
-        const Padding(
-          padding: EdgeInsets.symmetric(horizontal: 24),
-          child: _ExerciseFeedback(),
-        ),
-        const SizedBox(height: 20),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: _AiRoutine(onAdd: onAdd),
-        ),
-        const SizedBox(height: 20),
-        const Padding(
-          padding: EdgeInsets.symmetric(horizontal: 24),
-          child: _TodayLogs(),
-        ),
-      ],
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: _ActivityChart(week: week),
+          ),
+          const SizedBox(height: 20),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: _ExerciseFeedback(message: week.aiCoachMessage),
+          ),
+          const SizedBox(height: 20),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: _AiRoutine(onAdd: onAdd),
+          ),
+          const SizedBox(height: 20),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: _TodayLogs(sessions: week.sessions),
+          ),
+        ],
+      ),
     );
   }
 }
@@ -333,10 +387,33 @@ class _StatCard extends StatelessWidget {
 }
 
 class _ActivityChart extends StatelessWidget {
-  const _ActivityChart();
+  const _ActivityChart({required this.week});
+
+  final ExerciseWeek week;
 
   @override
   Widget build(BuildContext context) {
+    final int n = week.dailyMinutes.length;
+    final bool hasBreakdown =
+        n > 0 &&
+        week.cardioMinutes.length == n &&
+        week.strengthMinutes.length == n &&
+        week.stretchingMinutes.length == n;
+    final List<_Bar> bars = <_Bar>[
+      for (int i = 0; i < n; i++)
+        if (hasBreakdown)
+          _Bar(
+            week.cardioMinutes[i],
+            week.strengthMinutes[i],
+            week.stretchingMinutes[i],
+          )
+        else
+          _Bar(week.dailyMinutes[i], 0, 0),
+    ];
+    final List<String> dayLabels = week.dayLabels.length == n
+        ? week.dayLabels
+        : _barDays;
+
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
@@ -356,7 +433,13 @@ class _ActivityChart extends StatelessWidget {
           SizedBox(
             height: 150,
             width: double.infinity,
-            child: CustomPaint(painter: _StackedBarPainter()),
+            child: CustomPaint(
+              painter: _StackedBarPainter(
+                bars: bars,
+                dayLabels: dayLabels,
+                todayIndex: n - 1,
+              ),
+            ),
           ),
           const SizedBox(height: 6),
           const Row(
@@ -413,68 +496,87 @@ class _Bar {
   final double stretch;
 }
 
-const List<_Bar> _bars = <_Bar>[
-  _Bar(30, 16, 8),
-  _Bar(40, 24, 9),
-  _Bar(32, 18, 9),
-  _Bar(36, 24, 9),
-  _Bar(40, 25, 9),
-  _Bar(28, 12, 5),
-  _Bar(6, 0, 0),
-];
 const List<String> _barDays = <String>['월', '화', '수', '목', '금', '토', '일'];
 
 class _StackedBarPainter extends CustomPainter {
-  static const double _max = 90;
-  static const List<double> _grids = <double>[80, 60, 40, 20, 0];
+  const _StackedBarPainter({
+    required this.bars,
+    required this.dayLabels,
+    required this.todayIndex,
+  });
+
+  final List<_Bar> bars;
+  final List<String> dayLabels;
+  final int todayIndex;
+
+  /// Round the busiest day up to the next 20-minute step so bars never clip;
+  /// falls back to 90 when there's no data yet.
+  double get _max {
+    double m = 0;
+    for (final _Bar b in bars) {
+      final double total = b.cardio + b.strength + b.stretch;
+      if (total > m) m = total;
+    }
+    if (m <= 0) return 90;
+    return (m / 20).ceil() * 20;
+  }
 
   @override
   void paint(Canvas canvas, Size size) {
+    if (bars.isEmpty) return;
     const double left = 24;
     const double bottomPad = 24;
     final double chartH = size.height - bottomPad;
     final double chartW = size.width - left;
+    final double max = _max;
+    final List<double> grids = <double>[
+      max,
+      max * 0.75,
+      max * 0.5,
+      max * 0.25,
+      0,
+    ];
 
     const TextStyle gridStyle = TextStyle(
       fontSize: 8,
       color: FigmaColors.textFaint,
     );
-    for (final double g in _grids) {
-      final double y = chartH - (g / _max) * chartH;
+    for (final double g in grids) {
+      final double y = chartH - (g / max) * chartH;
       final Paint line = Paint()
         ..color = const Color(0x0F000000)
         ..strokeWidth = 1;
       canvas.drawLine(Offset(left, y), Offset(size.width, y), line);
       final TextPainter tp = TextPainter(
-        text: TextSpan(text: '${g.toInt()}', style: gridStyle),
+        text: TextSpan(text: '${g.round()}', style: gridStyle),
         textDirection: TextDirection.ltr,
       )..layout();
       tp.paint(canvas, Offset(left - tp.width - 4, y - tp.height / 2));
     }
 
-    final double slot = chartW / _bars.length;
+    final double slot = chartW / bars.length;
     const double barW = 26;
-    for (int i = 0; i < _bars.length; i++) {
-      final _Bar b = _bars[i];
+    for (int i = 0; i < bars.length; i++) {
+      final _Bar b = bars[i];
       final double cx = left + slot * i + slot / 2;
       final double x = cx - barW / 2;
-      final bool isToday = i == 6;
+      final bool isToday = i == todayIndex;
       double yBottom = chartH;
       double h;
       // stretch (light, bottom)
-      h = (b.stretch / _max) * chartH;
+      h = (b.stretch / max) * chartH;
       if (h > 0) {
         _rrect(canvas, x, yBottom - h, barW, h, const Color(0xFFD4EEF8), 3);
         yBottom -= h;
       }
       // strength (dark mid)
-      h = (b.strength / _max) * chartH;
+      h = (b.strength / max) * chartH;
       if (h > 0) {
         _rrect(canvas, x, yBottom - h, barW, h, const Color(0xFF1B6FA8), 0);
         yBottom -= h;
       }
       // cardio (blue top)
-      h = (b.cardio / _max) * chartH;
+      h = (b.cardio / max) * chartH;
       if (h > 0) {
         _rrect(
           canvas,
@@ -493,7 +595,7 @@ class _StackedBarPainter extends CustomPainter {
       // day label
       final TextPainter tp = TextPainter(
         text: TextSpan(
-          text: _barDays[i],
+          text: i < dayLabels.length ? dayLabels[i] : '',
           style: TextStyle(
             fontSize: 9,
             fontWeight: isToday ? FontWeight.w700 : FontWeight.w500,
@@ -538,94 +640,59 @@ class _StackedBarPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+  bool shouldRepaint(covariant _StackedBarPainter oldDelegate) =>
+      oldDelegate.bars != bars ||
+      oldDelegate.dayLabels != dayLabels ||
+      oldDelegate.todayIndex != todayIndex;
 }
 
 class _ExerciseFeedback extends StatelessWidget {
-  const _ExerciseFeedback();
+  const _ExerciseFeedback({required this.message});
+
+  final String message;
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: <Widget>[
-        Container(
-          padding: const EdgeInsets.all(14),
-          decoration: BoxDecoration(
-            color: FigmaColors.softBlue,
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(color: FigmaColors.primaryA(0.15)),
-          ),
-          child: const Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              OniAvatar(size: 40),
-              SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Text(
-                      'AI 피드백',
-                      style: TextStyle(
-                        fontSize: 12,
-                        fontWeight: FontWeight.w700,
-                        color: FigmaColors.primary,
-                      ),
-                    ),
-                    SizedBox(height: 2),
-                    Text(
-                      '걷기 30분 완료! 💪\n하체 스트레칭과 근력 운동까지 마치면 오늘 루틴 100%예요.',
-                      style: TextStyle(
-                        fontSize: 12,
-                        height: 1.5,
-                        fontWeight: FontWeight.w500,
-                        color: FigmaColors.ink,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
-        const SizedBox(height: 8),
-        Container(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-          decoration: BoxDecoration(
-            color: const Color(0xFFF4F5F7),
-            borderRadius: BorderRadius.circular(12),
-          ),
-          child: const Row(
-            children: <Widget>[
-              Text('✦', style: TextStyle(fontSize: 10)),
-              SizedBox(width: 6),
-              Expanded(
-                child: Text.rich(
-                  TextSpan(
-                    style: TextStyle(
-                      fontSize: 10,
-                      fontWeight: FontWeight.w500,
-                      color: FigmaColors.textMuted,
-                    ),
-                    children: <InlineSpan>[
-                      TextSpan(text: '오늘 루틴은 '),
-                      TextSpan(
-                        text: 'AI 맞춤 조언',
-                        style: TextStyle(
-                          fontWeight: FontWeight.w600,
-                          color: Color(0xFF8A929E),
-                        ),
-                      ),
-                      TextSpan(text: '을 바탕으로 구성됐어요'),
-                    ],
+    if (message.trim().isEmpty) return const SizedBox.shrink();
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: FigmaColors.softBlue,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: FigmaColors.primaryA(0.15)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          const OniAvatar(size: 40),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                const Text(
+                  'AI 피드백',
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                    color: FigmaColors.primary,
                   ),
                 ),
-              ),
-              Icon(Icons.check, size: 13, color: FigmaColors.primary),
-            ],
+                const SizedBox(height: 2),
+                Text(
+                  message,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    height: 1.5,
+                    fontWeight: FontWeight.w500,
+                    color: FigmaColors.ink,
+                  ),
+                ),
+              ],
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }
@@ -854,7 +921,9 @@ class _RoutineCard extends StatelessWidget {
 }
 
 class _TodayLogs extends StatelessWidget {
-  const _TodayLogs();
+  const _TodayLogs({required this.sessions});
+
+  final List<ExerciseSession> sessions;
 
   @override
   Widget build(BuildContext context) {
@@ -862,64 +931,43 @@ class _TodayLogs extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
         const Text(
-          '오늘의 운동',
+          '운동 기록',
           style: TextStyle(
             fontSize: 14,
             fontWeight: FontWeight.w700,
             color: FigmaColors.ink,
           ),
         ),
-        const SizedBox(height: 8),
-        Container(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-          decoration: BoxDecoration(
-            color: const Color(0xFFF4F5F7),
-            borderRadius: BorderRadius.circular(12),
-          ),
-          child: const Row(
-            children: <Widget>[
-              Text('📥', style: TextStyle(fontSize: 10)),
-              SizedBox(width: 6),
-              Expanded(
-                child: Text.rich(
-                  TextSpan(
-                    style: TextStyle(
-                      fontSize: 10,
-                      fontWeight: FontWeight.w500,
-                      color: FigmaColors.textMuted,
-                    ),
-                    children: <InlineSpan>[
-                      TextSpan(text: '오늘 헬스장 운동 데이터를 '),
-                      TextSpan(
-                        text: '김트레이너님',
-                        style: TextStyle(
-                          fontWeight: FontWeight.w600,
-                          color: Color(0xFF8A929E),
-                        ),
-                      ),
-                      TextSpan(text: '이 전송했어요'),
-                    ],
-                  ),
+        const SizedBox(height: 12),
+        if (sessions.isEmpty)
+          const Padding(
+            padding: EdgeInsets.symmetric(vertical: 24),
+            child: Center(
+              child: Text(
+                '이번 주 운동 기록이 없어요.\n운동을 추가해 기록을 남겨 보세요!',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 12.5,
+                  height: 1.5,
+                  fontWeight: FontWeight.w500,
+                  color: FigmaColors.textMuted,
                 ),
               ),
-              Icon(Icons.check, size: 13, color: FigmaColors.statusGreen),
-            ],
-          ),
-        ),
-        const SizedBox(height: 12),
-        const _LogCard(
-          tag: '유산소',
-          time: '07:30',
-          kcal: 225,
-          items: <String>['러닝머신 30분', '30분 운동'],
-        ),
-        const SizedBox(height: 12),
-        const _LogCard(
-          tag: '근력',
-          time: '18:00',
-          kcal: 150,
-          items: <String>['스쿼트 3세트', '데드리프트 3세트'],
-        ),
+            ),
+          )
+        else
+          for (final ExerciseSession s in sessions) ...<Widget>[
+            _LogCard(
+              tag: _typeLabel(s.type),
+              time: s.timeLabel ?? s.dateLabel ?? s.dayLabel,
+              kcal: s.calories,
+              items: s.items.isNotEmpty
+                  ? s.items
+                  : <String>['${s.minutes}분 운동'],
+              session: s,
+            ),
+            const SizedBox(height: 12),
+          ],
       ],
     );
   }
@@ -931,12 +979,14 @@ class _LogCard extends StatelessWidget {
     required this.time,
     required this.kcal,
     required this.items,
+    this.session,
   });
 
   final String tag;
   final String time;
   final int kcal;
   final List<String> items;
+  final ExerciseSession? session;
 
   @override
   Widget build(BuildContext context) {
@@ -998,7 +1048,7 @@ class _LogCard extends StatelessWidget {
               const SizedBox(width: 4),
               GestureDetector(
                 behavior: HitTestBehavior.opaque,
-                onTap: () => showExerciseAddSheet(context, edit: true),
+                onTap: () => showExerciseAddSheet(context, session: session),
                 child: const Padding(
                   padding: EdgeInsets.all(4),
                   child: Icon(
@@ -1242,21 +1292,20 @@ class _GymTab extends StatelessWidget {
                         ],
                       ),
                       const SizedBox(height: 10),
-                      Row(
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
                         children: <Widget>[
                           for (final List<String> s in const <List<String>>[
                             <String>['오늘 19:00', '잔여 1자리'],
                             <String>['내일 07:30', '여유 있음'],
                             <String>['내일 20:00', '잔여 2자리'],
                           ])
-                            Padding(
-                              padding: const EdgeInsets.only(right: 8),
-                              child: _SlotChip(
-                                label: s[0],
-                                sub: s[1],
-                                selected: selectedSlot == s[0],
-                                onTap: () => onSlot(s[0]),
-                              ),
+                            _SlotChip(
+                              label: s[0],
+                              sub: s[1],
+                              selected: selectedSlot == s[0],
+                              onTap: () => onSlot(s[0]),
                             ),
                         ],
                       ),

--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -1,86 +1,1412 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:oncare/design_system/tokens/colors.dart';
-import 'package:oncare/design_system/tokens/spacing.dart';
-import 'package:oncare/features/exercise/presentation/widgets/add_session_sheet.dart';
-import 'package:oncare/features/exercise/presentation/widgets/exercise_tab_switcher.dart';
-import 'package:oncare/features/exercise/presentation/widgets/gym_tab.dart';
-import 'package:oncare/features/exercise/presentation/widgets/workout_record_tab.dart';
+import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/features/exercise/presentation/widgets/exercise_flows.dart';
 import 'package:oncare/features/notification/presentation/widgets/notification_panel.dart';
-import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/widgets/modals/right_slide_panel.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
-import 'package:oncare/shared/widgets/oncare_header.dart';
 
-class ExercisePage extends ConsumerStatefulWidget {
+/// 운동 tab, rebuilt to the On-Care Figma redesign — a 운동 기록 / 헬스장
+/// sub-tab switcher over a weekly summary, stacked activity chart, AI routine,
+/// today's logs, and the gym card.
+class ExercisePage extends StatefulWidget {
   const ExercisePage({super.key});
 
   @override
-  ConsumerState<ExercisePage> createState() => _ExercisePageState();
+  State<ExercisePage> createState() => _ExercisePageState();
 }
 
-class _ExercisePageState extends ConsumerState<ExercisePage> {
-  int _activeIndex = 0;
+class _ExercisePageState extends State<ExercisePage> {
+  int _subTab = 0; // 0 = 운동 기록, 1 = 헬스장
+  String? _slot;
 
   @override
   Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context);
     return Scaffold(
-      backgroundColor: AppColors.background,
-      body: Column(
-        children: <Widget>[
-          OncareHeader(
-            title: l.pageExerciseTitle,
-            onNotificationTap: () => showRightSlidePanel<void>(
-              context,
-              content: const NotificationPanelBody(),
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        bottom: false,
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 720),
+            child: ListView(
+              padding: const EdgeInsets.only(bottom: 108),
+              children: <Widget>[
+                FigmaTabHeader(
+                  title: '운동',
+                  onBell: () => showRightSlidePanel<void>(
+                    context,
+                    content: const NotificationPanelBody(),
+                  ),
+                  onCalendar: () => showScheduleCalendarSheet(context),
+                ),
+                _SubTabs(
+                  active: _subTab,
+                  onChanged: (int i) => setState(() => _subTab = i),
+                ),
+                const SizedBox(height: 16),
+                if (_subTab == 0)
+                  _RecordTab(onAdd: () => showExerciseAddSheet(context))
+                else
+                  _GymTab(
+                    selectedSlot: _slot,
+                    onSlot: (String s) =>
+                        setState(() => _slot = _slot == s ? null : s),
+                    onFind: () => showGymLocatorSheet(context),
+                  ),
+              ],
             ),
-            onCalendarTap: () => showScheduleCalendarSheet(context),
           ),
-          Expanded(
-            child: Center(
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 672),
+        ),
+      ),
+    );
+  }
+}
+
+class _SubTabs extends StatelessWidget {
+  const _SubTabs({required this.active, required this.onChanged});
+  final int active;
+  final ValueChanged<int> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Container(
+        decoration: const BoxDecoration(
+          border: Border(
+            bottom: BorderSide(color: Color(0x12000000), width: 1.5),
+          ),
+        ),
+        child: Row(
+          children: <Widget>[
+            _tab(0, Icons.event_note_outlined, '운동 기록'),
+            _tab(1, Icons.place_outlined, '헬스장'),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _tab(int i, IconData icon, String label) {
+    final bool on = active == i;
+    return Expanded(
+      child: GestureDetector(
+        onTap: () => onChanged(i),
+        behavior: HitTestBehavior.opaque,
+        child: Container(
+          padding: const EdgeInsets.only(bottom: 10),
+          decoration: BoxDecoration(
+            border: Border(
+              bottom: BorderSide(
+                color: on ? FigmaColors.primary : Colors.transparent,
+                width: 2,
+              ),
+            ),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Icon(
+                icon,
+                size: 14,
+                color: on ? FigmaColors.primary : FigmaColors.textMuted,
+              ),
+              const SizedBox(width: 6),
+              Text(
+                label,
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                  color: on ? FigmaColors.ink : FigmaColors.textMuted,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ───────────────────────────────────────────────────────── 운동 기록 ──
+
+class _RecordTab extends StatelessWidget {
+  const _RecordTab({required this.onAdd});
+  final VoidCallback onAdd;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        const Padding(
+          padding: EdgeInsets.fromLTRB(24, 0, 24, 12),
+          child: Text(
+            '이번 주 운동 요약',
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+              color: FigmaColors.ink,
+            ),
+          ),
+        ),
+        const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 24),
+          child: Row(
+            children: <Widget>[
+              Expanded(
+                child: _StatCard(label: '이번 주', value: '6', unit: '회'),
+              ),
+              SizedBox(width: 8),
+              Expanded(
+                child: _StatCard(label: '시간', value: '350', unit: '분'),
+              ),
+              SizedBox(width: 8),
+              Expanded(
+                child: _StatCard(
+                  label: '칼로리',
+                  value: '2239',
+                  unit: 'kcal',
+                  accent: true,
+                ),
+              ),
+              SizedBox(width: 8),
+              Expanded(
+                child: _StatCard(
+                  label: '연속',
+                  value: '6',
+                  unit: '일 연속',
+                  streak: true,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 20),
+        const Padding(
+          padding: EdgeInsets.fromLTRB(24, 0, 24, 12),
+          child: Row(
+            children: <Widget>[
+              Text(
+                '운동 현황',
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                  color: FigmaColors.ink,
+                ),
+              ),
+              SizedBox(width: 8),
+              Text(
+                '이번 주',
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: FigmaColors.textMuted,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 24),
+          child: _ActivityChart(),
+        ),
+        const SizedBox(height: 20),
+        const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 24),
+          child: _ExerciseFeedback(),
+        ),
+        const SizedBox(height: 20),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: _AiRoutine(onAdd: onAdd),
+        ),
+        const SizedBox(height: 20),
+        const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 24),
+          child: _TodayLogs(),
+        ),
+      ],
+    );
+  }
+}
+
+class _StatCard extends StatelessWidget {
+  const _StatCard({
+    required this.label,
+    required this.value,
+    required this.unit,
+    this.accent = false,
+    this.streak = false,
+  });
+
+  final String label;
+  final String value;
+  final String unit;
+  final bool accent;
+  final bool streak;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color bg = streak
+        ? FigmaColors.heartOrange
+        : accent
+        ? FigmaColors.primaryA(0.07)
+        : FigmaColors.statBg;
+    final Color valueColor = streak
+        ? Colors.white
+        : accent
+        ? FigmaColors.primary
+        : FigmaColors.ink;
+    final Color labelColor = streak
+        ? Colors.white.withValues(alpha: 0.8)
+        : FigmaColors.textMuted;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(16),
+        border: streak
+            ? null
+            : Border.all(
+                color: accent
+                    ? FigmaColors.primaryA(0.15)
+                    : FigmaColors.hairline,
+              ),
+        boxShadow: streak
+            ? <BoxShadow>[
+                BoxShadow(
+                  color: FigmaColors.heartOrange.withValues(alpha: 0.4),
+                  blurRadius: 14,
+                  offset: const Offset(0, 4),
+                ),
+              ]
+            : null,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: 9.5,
+                    fontWeight: FontWeight.w600,
+                    color: labelColor,
+                  ),
+                ),
+              ),
+              if (streak) const Text('🔥', style: TextStyle(fontSize: 12)),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            value,
+            style: TextStyle(
+              fontSize: accent ? 13 : 15,
+              fontWeight: FontWeight.w800,
+              color: valueColor,
+              height: 1,
+              letterSpacing: -0.4,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            unit,
+            style: TextStyle(
+              fontSize: 9,
+              fontWeight: FontWeight.w500,
+              color: streak
+                  ? Colors.white.withValues(alpha: 0.85)
+                  : accent
+                  ? FigmaColors.primary.withValues(alpha: 0.7)
+                  : FigmaColors.textMuted,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ActivityChart extends StatelessWidget {
+  const _ActivityChart();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: FigmaColors.primaryA(0.10)),
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            color: FigmaColors.primaryA(0.08),
+            blurRadius: 16,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        children: <Widget>[
+          SizedBox(
+            height: 150,
+            width: double.infinity,
+            child: CustomPaint(painter: _StackedBarPainter()),
+          ),
+          const SizedBox(height: 6),
+          const Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              _Legend(color: FigmaColors.primary, label: '유산소'),
+              SizedBox(width: 16),
+              _Legend(color: Color(0xFF1B6FA8), label: '근력'),
+              SizedBox(width: 16),
+              _Legend(color: Color(0xFFD4EEF8), label: '스트레칭'),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Legend extends StatelessWidget {
+  const _Legend({required this.color, required this.label});
+  final Color color;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: <Widget>[
+        Container(
+          width: 10,
+          height: 10,
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: BorderRadius.circular(3),
+          ),
+        ),
+        const SizedBox(width: 6),
+        Text(
+          label,
+          style: const TextStyle(
+            fontSize: 10,
+            fontWeight: FontWeight.w500,
+            color: FigmaColors.textSub,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Bar {
+  const _Bar(this.cardio, this.strength, this.stretch);
+  final double cardio;
+  final double strength;
+  final double stretch;
+}
+
+const List<_Bar> _bars = <_Bar>[
+  _Bar(30, 16, 8),
+  _Bar(40, 24, 9),
+  _Bar(32, 18, 9),
+  _Bar(36, 24, 9),
+  _Bar(40, 25, 9),
+  _Bar(28, 12, 5),
+  _Bar(6, 0, 0),
+];
+const List<String> _barDays = <String>['월', '화', '수', '목', '금', '토', '일'];
+
+class _StackedBarPainter extends CustomPainter {
+  static const double _max = 90;
+  static const List<double> _grids = <double>[80, 60, 40, 20, 0];
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const double left = 24;
+    const double bottomPad = 24;
+    final double chartH = size.height - bottomPad;
+    final double chartW = size.width - left;
+
+    const TextStyle gridStyle = TextStyle(
+      fontSize: 8,
+      color: FigmaColors.textFaint,
+    );
+    for (final double g in _grids) {
+      final double y = chartH - (g / _max) * chartH;
+      final Paint line = Paint()
+        ..color = const Color(0x0F000000)
+        ..strokeWidth = 1;
+      canvas.drawLine(Offset(left, y), Offset(size.width, y), line);
+      final TextPainter tp = TextPainter(
+        text: TextSpan(text: '${g.toInt()}', style: gridStyle),
+        textDirection: TextDirection.ltr,
+      )..layout();
+      tp.paint(canvas, Offset(left - tp.width - 4, y - tp.height / 2));
+    }
+
+    final double slot = chartW / _bars.length;
+    const double barW = 26;
+    for (int i = 0; i < _bars.length; i++) {
+      final _Bar b = _bars[i];
+      final double cx = left + slot * i + slot / 2;
+      final double x = cx - barW / 2;
+      final bool isToday = i == 6;
+      double yBottom = chartH;
+      double h;
+      // stretch (light, bottom)
+      h = (b.stretch / _max) * chartH;
+      if (h > 0) {
+        _rrect(canvas, x, yBottom - h, barW, h, const Color(0xFFD4EEF8), 3);
+        yBottom -= h;
+      }
+      // strength (dark mid)
+      h = (b.strength / _max) * chartH;
+      if (h > 0) {
+        _rrect(canvas, x, yBottom - h, barW, h, const Color(0xFF1B6FA8), 0);
+        yBottom -= h;
+      }
+      // cardio (blue top)
+      h = (b.cardio / _max) * chartH;
+      if (h > 0) {
+        _rrect(
+          canvas,
+          x,
+          yBottom - h,
+          barW,
+          h,
+          isToday ? const Color(0xFF2190C4) : FigmaColors.primary,
+          3,
+        );
+        yBottom -= h;
+      }
+      if (b.cardio + b.strength + b.stretch == 0) {
+        _rrect(canvas, x, chartH - 3, barW, 3, const Color(0xFFEEF2F6), 1.5);
+      }
+      // day label
+      final TextPainter tp = TextPainter(
+        text: TextSpan(
+          text: _barDays[i],
+          style: TextStyle(
+            fontSize: 9,
+            fontWeight: isToday ? FontWeight.w700 : FontWeight.w500,
+            color: isToday ? FigmaColors.primary : FigmaColors.textMuted,
+          ),
+        ),
+        textDirection: TextDirection.ltr,
+      )..layout();
+      tp.paint(canvas, Offset(cx - tp.width / 2, chartH + 5));
+      if (isToday) {
+        final TextPainter t2 = TextPainter(
+          text: const TextSpan(
+            text: '오늘',
+            style: TextStyle(
+              fontSize: 7.5,
+              fontWeight: FontWeight.w600,
+              color: FigmaColors.primary,
+            ),
+          ),
+          textDirection: TextDirection.ltr,
+        )..layout();
+        t2.paint(canvas, Offset(cx - t2.width / 2, chartH + 15));
+      }
+    }
+  }
+
+  void _rrect(
+    Canvas c,
+    double x,
+    double y,
+    double w,
+    double h,
+    Color color,
+    double r,
+  ) {
+    final RRect rr = RRect.fromRectAndCorners(
+      Rect.fromLTWH(x, y, w, h),
+      topLeft: Radius.circular(r),
+      topRight: Radius.circular(r),
+    );
+    c.drawRRect(rr, Paint()..color = color);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}
+
+class _ExerciseFeedback extends StatelessWidget {
+  const _ExerciseFeedback();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        Container(
+          padding: const EdgeInsets.all(14),
+          decoration: BoxDecoration(
+            color: FigmaColors.softBlue,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: FigmaColors.primaryA(0.15)),
+          ),
+          child: const Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              OniAvatar(size: 40),
+              SizedBox(width: 12),
+              Expanded(
                 child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
-                    Padding(
-                      padding: const EdgeInsets.fromLTRB(
-                        AppSpacing.lg,
-                        AppSpacing.md,
-                        AppSpacing.lg,
-                        AppSpacing.sm,
-                      ),
-                      child: ExerciseTabSwitcher(
-                        activeIndex: _activeIndex,
-                        onChange: (i) => setState(() => _activeIndex = i),
+                    Text(
+                      'AI 피드백',
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                        color: FigmaColors.primary,
                       ),
                     ),
-                    Expanded(
-                      child: IndexedStack(
-                        index: _activeIndex,
-                        children: const <Widget>[
-                          WorkoutRecordTab(),
-                          GymTab(),
-                        ],
+                    SizedBox(height: 2),
+                    Text(
+                      '걷기 30분 완료! 💪\n하체 스트레칭과 근력 운동까지 마치면 오늘 루틴 100%예요.',
+                      style: TextStyle(
+                        fontSize: 12,
+                        height: 1.5,
+                        fontWeight: FontWeight.w500,
+                        color: FigmaColors.ink,
                       ),
                     ),
                   ],
                 ),
               ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 8),
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            color: const Color(0xFFF4F5F7),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: const Row(
+            children: <Widget>[
+              Text('✦', style: TextStyle(fontSize: 10)),
+              SizedBox(width: 6),
+              Expanded(
+                child: Text.rich(
+                  TextSpan(
+                    style: TextStyle(
+                      fontSize: 10,
+                      fontWeight: FontWeight.w500,
+                      color: FigmaColors.textMuted,
+                    ),
+                    children: <InlineSpan>[
+                      TextSpan(text: '오늘 루틴은 '),
+                      TextSpan(
+                        text: 'AI 맞춤 조언',
+                        style: TextStyle(
+                          fontWeight: FontWeight.w600,
+                          color: Color(0xFF8A929E),
+                        ),
+                      ),
+                      TextSpan(text: '을 바탕으로 구성됐어요'),
+                    ],
+                  ),
+                ),
+              ),
+              Icon(Icons.check, size: 13, color: FigmaColors.primary),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _AiRoutine extends StatelessWidget {
+  const _AiRoutine({required this.onAdd});
+  final VoidCallback onAdd;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Row(
+          children: <Widget>[
+            const Text(
+              'AI 맞춤 루틴 · 오늘',
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w700,
+                color: FigmaColors.ink,
+              ),
+            ),
+            const Spacer(),
+            const Text(
+              '1/3',
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w700,
+                color: FigmaColors.primary,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Material(
+              color: FigmaColors.primary,
+              borderRadius: BorderRadius.circular(999),
+              child: InkWell(
+                onTap: onAdd,
+                borderRadius: BorderRadius.circular(999),
+                child: const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: <Widget>[
+                      Icon(Icons.add, size: 12, color: Colors.white),
+                      SizedBox(width: 4),
+                      Text(
+                        '운동 추가',
+                        style: TextStyle(
+                          fontSize: 11,
+                          fontWeight: FontWeight.w700,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        _Fill33(),
+        const SizedBox(height: 16),
+        const _RoutineCard(
+          title: '빠르게 걷기 30분',
+          subtitle: '유산소 · 혈압 관리',
+          done: true,
+        ),
+        const SizedBox(height: 10),
+        const _RoutineCard(
+          title: '하체 스트레칭',
+          subtitle: '스트레칭 · 유연성',
+          minutes: '10분',
+        ),
+        const SizedBox(height: 10),
+        const _RoutineCard(
+          title: '저강도 근력',
+          subtitle: '근력 · 근지구력',
+          minutes: '15분',
+        ),
+      ],
+    );
+  }
+}
+
+class _Fill33 extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(999),
+      child: SizedBox(
+        height: 5,
+        child: Row(
+          children: <Widget>[
+            const Expanded(
+              flex: 33,
+              child: ColoredBox(color: FigmaColors.primary),
+            ),
+            Expanded(
+              flex: 67,
+              child: ColoredBox(color: FigmaColors.primaryA(0.12)),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RoutineCard extends StatelessWidget {
+  const _RoutineCard({
+    required this.title,
+    required this.subtitle,
+    this.done = false,
+    this.minutes,
+  });
+
+  final String title;
+  final String subtitle;
+  final bool done;
+  final String? minutes;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(
+          color: done ? FigmaColors.primaryA(0.15) : FigmaColors.hairline,
+        ),
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.06),
+            blurRadius: 12,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Row(
+        children: <Widget>[
+          if (done)
+            Container(
+              width: 28,
+              height: 28,
+              decoration: const BoxDecoration(
+                color: FigmaColors.primary,
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(Icons.check, size: 15, color: Colors.white),
+            )
+          else
+            Container(
+              width: 28,
+              height: 28,
+              decoration: BoxDecoration(
+                color: const Color(0xFFF6FBFE),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: FigmaColors.primaryA(0.3), width: 2),
+              ),
+            ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  title,
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    color: done ? FigmaColors.textFaint : FigmaColors.ink,
+                    decoration: done ? TextDecoration.lineThrough : null,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  subtitle,
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w500,
+                    color: done ? FigmaColors.textFaint : FigmaColors.textMuted,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (done)
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              decoration: BoxDecoration(
+                color: FigmaColors.statusGreen,
+                borderRadius: BorderRadius.circular(999),
+              ),
+              child: const Row(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  Icon(Icons.check, size: 9, color: Colors.white),
+                  SizedBox(width: 3),
+                  Text(
+                    '미션 완료!',
+                    style: TextStyle(
+                      fontSize: 9,
+                      fontWeight: FontWeight.w700,
+                      color: Colors.white,
+                    ),
+                  ),
+                ],
+              ),
+            )
+          else if (minutes != null)
+            Text(
+              minutes!,
+              style: const TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+                color: FigmaColors.textMuted,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TodayLogs extends StatelessWidget {
+  const _TodayLogs();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        const Text(
+          '오늘의 운동',
+          style: TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.w700,
+            color: FigmaColors.ink,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            color: const Color(0xFFF4F5F7),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: const Row(
+            children: <Widget>[
+              Text('📥', style: TextStyle(fontSize: 10)),
+              SizedBox(width: 6),
+              Expanded(
+                child: Text.rich(
+                  TextSpan(
+                    style: TextStyle(
+                      fontSize: 10,
+                      fontWeight: FontWeight.w500,
+                      color: FigmaColors.textMuted,
+                    ),
+                    children: <InlineSpan>[
+                      TextSpan(text: '오늘 헬스장 운동 데이터를 '),
+                      TextSpan(
+                        text: '김트레이너님',
+                        style: TextStyle(
+                          fontWeight: FontWeight.w600,
+                          color: Color(0xFF8A929E),
+                        ),
+                      ),
+                      TextSpan(text: '이 전송했어요'),
+                    ],
+                  ),
+                ),
+              ),
+              Icon(Icons.check, size: 13, color: FigmaColors.statusGreen),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
+        const _LogCard(
+          tag: '유산소',
+          time: '07:30',
+          kcal: 225,
+          items: <String>['러닝머신 30분', '30분 운동'],
+        ),
+        const SizedBox(height: 12),
+        const _LogCard(
+          tag: '근력',
+          time: '18:00',
+          kcal: 150,
+          items: <String>['스쿼트 3세트', '데드리프트 3세트'],
+        ),
+      ],
+    );
+  }
+}
+
+class _LogCard extends StatelessWidget {
+  const _LogCard({
+    required this.tag,
+    required this.time,
+    required this.kcal,
+    required this.items,
+  });
+
+  final String tag;
+  final String time;
+  final int kcal;
+  final List<String> items;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: FigmaColors.hairline),
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.07),
+            blurRadius: 16,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 2,
+                ),
+                decoration: BoxDecoration(
+                  color: FigmaColors.primaryA(0.12),
+                  borderRadius: BorderRadius.circular(999),
+                ),
+                child: Text(
+                  tag,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                    color: FigmaColors.primary,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                time,
+                style: const TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w500,
+                  color: FigmaColors.textFaint,
+                ),
+              ),
+              const Spacer(),
+              Text(
+                '$kcal kcal',
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w800,
+                  color: FigmaColors.primary,
+                ),
+              ),
+              const SizedBox(width: 4),
+              GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () => showExerciseAddSheet(context, edit: true),
+                child: const Padding(
+                  padding: EdgeInsets.all(4),
+                  child: Icon(
+                    Icons.chevron_right,
+                    size: 16,
+                    color: FigmaColors.textFaint,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          const Divider(height: 1, color: FigmaColors.hairline),
+          const SizedBox(height: 12),
+          for (final String it in items)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 3),
+              child: Row(
+                children: <Widget>[
+                  Container(
+                    width: 6,
+                    height: 6,
+                    decoration: const BoxDecoration(
+                      color: FigmaColors.primary,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    it,
+                    style: const TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w500,
+                      color: Color(0xFF3A3A4A),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+// ───────────────────────────────────────────────────────── 헬스장 ──
+
+class _GymTab extends StatelessWidget {
+  const _GymTab({
+    required this.selectedSlot,
+    required this.onSlot,
+    required this.onFind,
+  });
+
+  final String? selectedSlot;
+  final ValueChanged<String> onSlot;
+  final VoidCallback onFind;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton.icon(
+              onPressed: onFind,
+              style: FilledButton.styleFrom(
+                backgroundColor: FigmaColors.primary,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16),
+                ),
+              ),
+              icon: const Icon(Icons.search, size: 16),
+              label: const Text(
+                '헬스장 찾기',
+                style: TextStyle(fontSize: 14, fontWeight: FontWeight.w700),
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(20),
+              border: Border.all(color: FigmaColors.hairline),
+              boxShadow: <BoxShadow>[
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.09),
+                  blurRadius: 24,
+                  offset: const Offset(0, 4),
+                ),
+              ],
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                const Row(
+                  children: <Widget>[
+                    Icon(
+                      Icons.place_outlined,
+                      size: 15,
+                      color: FigmaColors.primary,
+                    ),
+                    SizedBox(width: 6),
+                    Text(
+                      '내 헬스장',
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                        color: FigmaColors.textMuted,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 10),
+                const Text(
+                  '강남 피트니스 센터',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w800,
+                    color: FigmaColors.ink,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                const Text(
+                  '📍 서울시 강남구 역삼동 123-45 · 0.8km',
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w500,
+                    color: FigmaColors.textMuted,
+                  ),
+                ),
+                const SizedBox(height: 14),
+                Row(
+                  children: <Widget>[
+                    Container(
+                      width: 36,
+                      height: 36,
+                      decoration: const BoxDecoration(
+                        color: Color(0xFFEEF2F6),
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Icon(
+                        Icons.person_outline,
+                        size: 18,
+                        color: FigmaColors.textFaint,
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    const Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          '김트레이너',
+                          style: TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w700,
+                            color: FigmaColors.ink,
+                          ),
+                        ),
+                        Text(
+                          '전담 트레이너',
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: FigmaColors.textMuted,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 14),
+                Row(
+                  children: <Widget>[
+                    for (final String t in <String>['다이어트', '재활운동'])
+                      Padding(
+                        padding: const EdgeInsets.only(right: 8),
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 12,
+                            vertical: 5,
+                          ),
+                          decoration: BoxDecoration(
+                            color: FigmaColors.primaryA(0.10),
+                            borderRadius: BorderRadius.circular(999),
+                          ),
+                          child: Text(
+                            t,
+                            style: const TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w700,
+                              color: FigmaColors.primary,
+                            ),
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 14),
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    gradient: const LinearGradient(
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                      colors: <Color>[
+                        FigmaColors.bannerStart,
+                        FigmaColors.bannerEnd,
+                      ],
+                    ),
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(color: FigmaColors.primaryA(0.18)),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      const Row(
+                        children: <Widget>[
+                          Text(
+                            '✦ AI 추천 예약 시간',
+                            style: TextStyle(
+                              fontSize: 10.5,
+                              fontWeight: FontWeight.w700,
+                              color: FigmaColors.primary,
+                            ),
+                          ),
+                          SizedBox(width: 6),
+                          Text(
+                            '김트레이너 빈 시간',
+                            style: TextStyle(
+                              fontSize: 9,
+                              fontWeight: FontWeight.w500,
+                              color: FigmaColors.textMuted,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 10),
+                      Row(
+                        children: <Widget>[
+                          for (final List<String> s in const <List<String>>[
+                            <String>['오늘 19:00', '잔여 1자리'],
+                            <String>['내일 07:30', '여유 있음'],
+                            <String>['내일 20:00', '잔여 2자리'],
+                          ])
+                            Padding(
+                              padding: const EdgeInsets.only(right: 8),
+                              child: _SlotChip(
+                                label: s[0],
+                                sub: s[1],
+                                selected: selectedSlot == s[0],
+                                onTap: () => onSlot(s[0]),
+                              ),
+                            ),
+                        ],
+                      ),
+                      if (selectedSlot != null) ...<Widget>[
+                        const SizedBox(height: 10),
+                        SizedBox(
+                          width: double.infinity,
+                          child: FilledButton(
+                            onPressed: () {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(
+                                  content: Text('$selectedSlot 예약이 확정됐어요'),
+                                ),
+                              );
+                            },
+                            style: FilledButton.styleFrom(
+                              backgroundColor: FigmaColors.primary,
+                              padding: const EdgeInsets.symmetric(vertical: 10),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                            ),
+                            child: Text(
+                              '$selectedSlot 예약 확정',
+                              style: const TextStyle(
+                                fontSize: 12,
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 14),
+                const Divider(height: 1, color: FigmaColors.hairline),
+                const SizedBox(height: 12),
+                Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: OutlinedButton(
+                        onPressed: () => showGymInfoSheet(context),
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: FigmaColors.primary,
+                          backgroundColor: FigmaColors.softBlue,
+                          side: BorderSide(color: FigmaColors.primaryA(0.18)),
+                          padding: const EdgeInsets.symmetric(vertical: 11),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                        ),
+                        child: const Text(
+                          '헬스장 정보',
+                          style: TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: FilledButton(
+                        onPressed: () => showGymChatSheet(context),
+                        style: FilledButton.styleFrom(
+                          backgroundColor: FigmaColors.primary,
+                          padding: const EdgeInsets.symmetric(vertical: 11),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                        ),
+                        child: const Text(
+                          '💬 1:1 상담',
+                          style: TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
             ),
           ),
         ],
       ),
-      floatingActionButton: _activeIndex == 0
-          ? FloatingActionButton(
-              backgroundColor: AppColors.primary,
-              foregroundColor: AppColors.primaryForeground,
-              tooltip: '운동 기록 추가',
-              onPressed: () => showAddSessionSheet(context),
-              child: const Icon(Icons.add),
-            )
-          : null,
+    );
+  }
+}
+
+class _SlotChip extends StatelessWidget {
+  const _SlotChip({
+    required this.label,
+    required this.sub,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String label;
+  final String sub;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        decoration: BoxDecoration(
+          color: selected ? FigmaColors.primary : Colors.white,
+          borderRadius: BorderRadius.circular(12),
+          border: selected
+              ? null
+              : Border.all(color: FigmaColors.primaryA(0.25)),
+          boxShadow: selected
+              ? <BoxShadow>[
+                  BoxShadow(
+                    color: FigmaColors.primaryA(0.35),
+                    blurRadius: 10,
+                    offset: const Offset(0, 3),
+                  ),
+                ]
+              : null,
+        ),
+        child: Column(
+          children: <Widget>[
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                color: selected ? Colors.white : FigmaColors.ink,
+              ),
+            ),
+            Text(
+              sub,
+              style: TextStyle(
+                fontSize: 9,
+                fontWeight: FontWeight.w500,
+                color: selected
+                    ? Colors.white.withValues(alpha: 0.8)
+                    : FigmaColors.textMuted,
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
@@ -1,6 +1,55 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+
+const List<String> _weekdayLabels = <String>['월', '화', '수', '목', '금', '토', '일'];
+
+/// The "운동 종류" chip order shared by the add/edit sheet.
+const List<String> _exerciseTypeLabels = <String>[
+  '걷기',
+  '달리기',
+  '스트레칭',
+  '근력운동',
+  '자전거',
+  '기타',
+];
+
+/// Chip index → backend [ExerciseType].
+ExerciseType _typeFromIndex(int i) => switch (i) {
+  0 => ExerciseType.walking,
+  1 => ExerciseType.cardio,
+  2 => ExerciseType.stretching,
+  3 => ExerciseType.strength,
+  4 => ExerciseType.cardio,
+  _ => ExerciseType.other,
+};
+
+/// [ExerciseType] → chip index (for pre-filling the edit sheet).
+int _indexFromType(ExerciseType t) => switch (t) {
+  ExerciseType.walking => 0,
+  ExerciseType.cardio => 1,
+  ExerciseType.stretching => 2,
+  ExerciseType.strength => 3,
+  ExerciseType.yoga => 2,
+  ExerciseType.other => 5,
+};
+
+/// Rough kcal/min per type, used to estimate burn when the user only logs a
+/// duration (matches the prototype's estimate ranges).
+int _estimateCalories(ExerciseType type, int minutes) {
+  final double perMin = switch (type) {
+    ExerciseType.cardio => 9,
+    ExerciseType.strength => 6,
+    ExerciseType.walking => 4,
+    ExerciseType.stretching => 3,
+    ExerciseType.yoga => 3,
+    ExerciseType.other => 5,
+  };
+  return (perMin * minutes).round();
+}
 
 Widget _shell(BuildContext context, Widget child) => SafeArea(
   top: false,
@@ -32,38 +81,92 @@ Widget _handle() => Container(
 // ─────────────────────────────────────────────────────── 운동 추가 ──
 
 /// A compact "운동 추가" sheet: pick a type + duration/intensity, then save.
-Future<void> showExerciseAddSheet(BuildContext context, {bool edit = false}) {
+/// Pass [session] to open in edit mode (pre-filled → PUT); omit it to add.
+Future<void> showExerciseAddSheet(
+  BuildContext context, {
+  ExerciseSession? session,
+}) {
   return showModalBottomSheet<void>(
     context: context,
     isScrollControlled: true,
     backgroundColor: Colors.transparent,
     barrierColor: FigmaColors.sheetScrim,
-    builder: (BuildContext ctx) => _ExerciseAddSheet(edit: edit),
+    builder: (BuildContext ctx) => _ExerciseAddSheet(session: session),
   );
 }
 
-class _ExerciseAddSheet extends StatefulWidget {
-  const _ExerciseAddSheet({required this.edit});
+class _ExerciseAddSheet extends ConsumerStatefulWidget {
+  const _ExerciseAddSheet({this.session});
 
-  final bool edit;
+  final ExerciseSession? session;
+
+  bool get isEdit => session != null;
 
   @override
-  State<_ExerciseAddSheet> createState() => _ExerciseAddSheetState();
+  ConsumerState<_ExerciseAddSheet> createState() => _ExerciseAddSheetState();
 }
 
-class _ExerciseAddSheetState extends State<_ExerciseAddSheet> {
-  static const List<String> _types = <String>[
-    '걷기',
-    '달리기',
-    '스트레칭',
-    '근력운동',
-    '자전거',
-    '기타',
-  ];
+class _ExerciseAddSheetState extends ConsumerState<_ExerciseAddSheet> {
+  static const List<String> _types = _exerciseTypeLabels;
   static const List<String> _levels = <String>['가벼움', '보통', '높음'];
-  int _type = 1;
+  late int _type = widget.session != null
+      ? _indexFromType(widget.session!.type)
+      : 1;
   int _level = 0;
-  double _minutes = 30;
+  late double _minutes = widget.session?.minutes.toDouble() ?? 30;
+  bool _saving = false;
+
+  Future<void> _save() async {
+    if (_saving) return;
+    final NavigatorState navigator = Navigator.of(context);
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    final int minutes = _minutes.round();
+    if (minutes <= 0) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('운동 시간을 입력해주세요')),
+      );
+      return;
+    }
+    final ExerciseType type = _typeFromIndex(_type);
+    final int calories = _estimateCalories(type, minutes);
+    setState(() => _saving = true);
+    try {
+      // 서버(mock 모드는 drift)에 저장 → 주간 데이터 무효화로 통계·차트·목록 반영.
+      final ExerciseSession? editing = widget.session;
+      if (editing != null && editing.id != null) {
+        await ref
+            .read(exerciseRepositoryProvider)
+            .updateSession(
+              id: editing.id!,
+              type: type,
+              minutes: minutes,
+              calories: calories,
+              dayLabel: editing.dayLabel,
+            );
+      } else {
+        await ref
+            .read(exerciseRepositoryProvider)
+            .addSession(
+              type: type,
+              minutes: minutes,
+              calories: calories,
+              dayLabel: _weekdayLabels[DateTime.now().weekday - 1],
+            );
+      }
+      ref.invalidate(exerciseWeekProvider);
+      navigator.pop();
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(widget.isEdit ? '운동 기록이 수정됐어요' : '운동이 기록됐어요'),
+        ),
+      );
+    } catch (_) {
+      if (mounted) setState(() => _saving = false);
+      messenger.showSnackBar(
+        const SnackBar(content: Text('저장에 실패했어요. 잠시 후 다시 시도해 주세요')),
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -79,7 +182,7 @@ class _ExerciseAddSheetState extends State<_ExerciseAddSheet> {
               children: <Widget>[
                 Expanded(
                   child: Text(
-                    widget.edit ? '운동 기록 수정' : '운동 추가',
+                    widget.isEdit ? '운동 기록 수정' : '운동 추가',
                     style: const TextStyle(
                       fontSize: 18,
                       fontWeight: FontWeight.w800,
@@ -88,16 +191,7 @@ class _ExerciseAddSheetState extends State<_ExerciseAddSheet> {
                   ),
                 ),
                 TextButton(
-                  onPressed: () {
-                    Navigator.of(context).pop();
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text(
-                          widget.edit ? '운동 기록이 수정됐어요' : '운동이 기록됐어요',
-                        ),
-                      ),
-                    );
-                  },
+                  onPressed: _saving ? null : _save,
                   child: const Text(
                     '저장',
                     style: TextStyle(

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
@@ -7,39 +7,43 @@ import 'package:oncare/features/exercise/presentation/controllers/exercise_contr
 
 const List<String> _weekdayLabels = <String>['월', '화', '수', '목', '금', '토', '일'];
 
-/// The "운동 종류" chip order shared by the add/edit sheet.
+/// The "운동 종류" chips, kept 1:1 with [ExerciseType] so a saved type
+/// round-trips losslessly into the edit sheet (labels mirror `_typeLabel`).
 const List<String> _exerciseTypeLabels = <String>[
-  '걷기',
-  '달리기',
-  '스트레칭',
-  '근력운동',
-  '자전거',
-  '기타',
+  '걷기', // walking
+  '유산소', // cardio
+  '근력', // strength
+  '요가', // yoga
+  '스트레칭', // stretching
+  '기타', // other
 ];
 
-/// Chip index → backend [ExerciseType].
+/// Chip index → backend [ExerciseType] (1:1 with [_exerciseTypeLabels]).
 ExerciseType _typeFromIndex(int i) => switch (i) {
   0 => ExerciseType.walking,
   1 => ExerciseType.cardio,
-  2 => ExerciseType.stretching,
-  3 => ExerciseType.strength,
-  4 => ExerciseType.cardio,
+  2 => ExerciseType.strength,
+  3 => ExerciseType.yoga,
+  4 => ExerciseType.stretching,
   _ => ExerciseType.other,
 };
 
-/// [ExerciseType] → chip index (for pre-filling the edit sheet).
+/// [ExerciseType] → chip index (for pre-filling the edit sheet, lossless).
 int _indexFromType(ExerciseType t) => switch (t) {
   ExerciseType.walking => 0,
   ExerciseType.cardio => 1,
-  ExerciseType.stretching => 2,
-  ExerciseType.strength => 3,
-  ExerciseType.yoga => 2,
+  ExerciseType.strength => 2,
+  ExerciseType.yoga => 3,
+  ExerciseType.stretching => 4,
   ExerciseType.other => 5,
 };
 
-/// Rough kcal/min per type, used to estimate burn when the user only logs a
-/// duration (matches the prototype's estimate ranges).
-int _estimateCalories(ExerciseType type, int minutes) {
+/// Per-intensity multiplier for [_levels] (가벼움 / 보통 / 높음).
+const List<double> _intensityFactor = <double>[0.85, 1.0, 1.2];
+
+/// Rough kcal/min per type scaled by intensity, used to estimate burn when the
+/// user logs a duration (matches the prototype's estimate ranges).
+int _estimateCalories(ExerciseType type, int minutes, int level) {
   final double perMin = switch (type) {
     ExerciseType.cardio => 9,
     ExerciseType.strength => 6,
@@ -48,7 +52,10 @@ int _estimateCalories(ExerciseType type, int minutes) {
     ExerciseType.yoga => 3,
     ExerciseType.other => 5,
   };
-  return (perMin * minutes).round();
+  final double factor = (level >= 0 && level < _intensityFactor.length)
+      ? _intensityFactor[level]
+      : 1.0;
+  return (perMin * minutes * factor).round();
 }
 
 Widget _shell(BuildContext context, Widget child) => SafeArea(
@@ -128,12 +135,19 @@ class _ExerciseAddSheetState extends ConsumerState<_ExerciseAddSheet> {
       return;
     }
     final ExerciseType type = _typeFromIndex(_type);
-    final int calories = _estimateCalories(type, minutes);
+    final int calories = _estimateCalories(type, minutes, _level);
+    final ExerciseSession? editing = widget.session;
+    if (editing != null && editing.id == null) {
+      // No id → PUT impossible; don't silently create a duplicate session.
+      messenger.showSnackBar(
+        const SnackBar(content: Text('이 기록은 수정할 수 없어요')),
+      );
+      return;
+    }
     setState(() => _saving = true);
     try {
       // 서버(mock 모드는 drift)에 저장 → 주간 데이터 무효화로 통계·차트·목록 반영.
-      final ExerciseSession? editing = widget.session;
-      if (editing != null && editing.id != null) {
+      if (editing != null) {
         await ref
             .read(exerciseRepositoryProvider)
             .updateSession(
@@ -153,6 +167,8 @@ class _ExerciseAddSheetState extends ConsumerState<_ExerciseAddSheet> {
               dayLabel: _weekdayLabels[DateTime.now().weekday - 1],
             );
       }
+      // Sheet dismissed mid-save → don't pop the page below.
+      if (!mounted) return;
       ref.invalidate(exerciseWeekProvider);
       navigator.pop();
       messenger.showSnackBar(
@@ -170,7 +186,8 @@ class _ExerciseAddSheetState extends ConsumerState<_ExerciseAddSheet> {
 
   @override
   Widget build(BuildContext context) {
-    return _shell(
+    // Block back/drag dismiss while the save request is in flight.
+    final Widget sheet = _shell(
       context,
       Column(
         mainAxisSize: MainAxisSize.min,
@@ -306,6 +323,7 @@ class _ExerciseAddSheetState extends ConsumerState<_ExerciseAddSheet> {
         ],
       ),
     );
+    return PopScope(canPop: !_saving, child: sheet);
   }
 
   Widget _chip(

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
@@ -120,6 +120,10 @@ class _ExerciseAddSheetState extends ConsumerState<_ExerciseAddSheet> {
       ? _indexFromType(widget.session!.type)
       : 1;
   int _level = 0;
+  // Intensity isn't persisted on ExerciseSession, so an edit always opens at
+  // 가벼움. Track whether the user actually changed it so we don't silently
+  // recompute (and downgrade) a stored 보통/높음 record's calories.
+  bool _levelTouched = false;
   late double _minutes = widget.session?.minutes.toDouble() ?? 30;
   bool _saving = false;
 
@@ -135,7 +139,6 @@ class _ExerciseAddSheetState extends ConsumerState<_ExerciseAddSheet> {
       return;
     }
     final ExerciseType type = _typeFromIndex(_type);
-    final int calories = _estimateCalories(type, minutes, _level);
     final ExerciseSession? editing = widget.session;
     if (editing != null && editing.id == null) {
       // No id → PUT impossible; don't silently create a duplicate session.
@@ -144,6 +147,12 @@ class _ExerciseAddSheetState extends ConsumerState<_ExerciseAddSheet> {
       );
       return;
     }
+    // On edit, keep the stored calories unless the user actually changed the
+    // intensity — recomputing at the defaulted 가벼움 would corrupt a 보통/높음
+    // record (intensity isn't persisted yet; see the follow-up issue).
+    final int calories = (editing != null && !_levelTouched)
+        ? editing.calories
+        : _estimateCalories(type, minutes, _level);
     setState(() => _saving = true);
     try {
       // 서버(mock 모드는 drift)에 저장 → 주간 데이터 무효화로 통계·차트·목록 반영.
@@ -273,7 +282,10 @@ class _ExerciseAddSheetState extends ConsumerState<_ExerciseAddSheet> {
                         child: _chip(
                           _levels[i],
                           _level == i,
-                          () => setState(() => _level = i),
+                          () => setState(() {
+                            _level = i;
+                            _levelTouched = true;
+                          }),
                           center: true,
                         ),
                       ),

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
@@ -1,0 +1,1095 @@
+import 'package:flutter/material.dart';
+
+import 'package:oncare/design_system/figma/figma_kit.dart';
+
+Widget _shell(BuildContext context, Widget child) => SafeArea(
+  top: false,
+  child: ConstrainedBox(
+    constraints: BoxConstraints(
+      maxHeight: MediaQuery.of(context).size.height * 0.9,
+      maxWidth: 480,
+    ),
+    child: Container(
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      child: child,
+    ),
+  ),
+);
+
+Widget _handle() => Container(
+  margin: const EdgeInsets.only(top: 12, bottom: 4),
+  width: 36,
+  height: 4,
+  decoration: BoxDecoration(
+    color: const Color(0xFFDDE3EA),
+    borderRadius: BorderRadius.circular(999),
+  ),
+);
+
+// ─────────────────────────────────────────────────────── 운동 추가 ──
+
+/// A compact "운동 추가" sheet: pick a type + duration/intensity, then save.
+Future<void> showExerciseAddSheet(BuildContext context, {bool edit = false}) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    barrierColor: FigmaColors.sheetScrim,
+    builder: (BuildContext ctx) => _ExerciseAddSheet(edit: edit),
+  );
+}
+
+class _ExerciseAddSheet extends StatefulWidget {
+  const _ExerciseAddSheet({required this.edit});
+
+  final bool edit;
+
+  @override
+  State<_ExerciseAddSheet> createState() => _ExerciseAddSheetState();
+}
+
+class _ExerciseAddSheetState extends State<_ExerciseAddSheet> {
+  static const List<String> _types = <String>[
+    '걷기',
+    '달리기',
+    '스트레칭',
+    '근력운동',
+    '자전거',
+    '기타',
+  ];
+  static const List<String> _levels = <String>['가벼움', '보통', '높음'];
+  int _type = 1;
+  int _level = 0;
+  double _minutes = 30;
+
+  @override
+  Widget build(BuildContext context) {
+    return _shell(
+      context,
+      Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Center(child: _handle()),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 8, 20, 8),
+            child: Row(
+              children: <Widget>[
+                Expanded(
+                  child: Text(
+                    widget.edit ? '운동 기록 수정' : '운동 추가',
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w800,
+                      color: FigmaColors.ink,
+                    ),
+                  ),
+                ),
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text(
+                          widget.edit ? '운동 기록이 수정됐어요' : '운동이 기록됐어요',
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text(
+                    '저장',
+                    style: TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w700,
+                      color: FigmaColors.primary,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Flexible(
+            child: ListView(
+              shrinkWrap: true,
+              padding: const EdgeInsets.fromLTRB(20, 4, 20, 28),
+              children: <Widget>[
+                const _Label('운동 종류'),
+                const SizedBox(height: 10),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: <Widget>[
+                    for (int i = 0; i < _types.length; i++)
+                      _chip(
+                        _types[i],
+                        _type == i,
+                        () => setState(() => _type = i),
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 20),
+                Row(
+                  children: <Widget>[
+                    const _Label('운동 시간'),
+                    const Spacer(),
+                    Text(
+                      '${_minutes.round()}분',
+                      style: const TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w800,
+                        color: FigmaColors.primary,
+                      ),
+                    ),
+                  ],
+                ),
+                Slider(
+                  value: _minutes,
+                  min: 5,
+                  max: 120,
+                  divisions: 23,
+                  activeColor: FigmaColors.primary,
+                  onChanged: (double v) => setState(() => _minutes = v),
+                ),
+                const SizedBox(height: 12),
+                const _Label('운동 강도'),
+                const SizedBox(height: 10),
+                Row(
+                  children: <Widget>[
+                    for (int i = 0; i < _levels.length; i++) ...<Widget>[
+                      Expanded(
+                        child: _chip(
+                          _levels[i],
+                          _level == i,
+                          () => setState(() => _level = i),
+                          center: true,
+                        ),
+                      ),
+                      if (i < _levels.length - 1) const SizedBox(width: 8),
+                    ],
+                  ],
+                ),
+                const SizedBox(height: 16),
+                Container(
+                  padding: const EdgeInsets.all(14),
+                  decoration: BoxDecoration(
+                    color: FigmaColors.softBlue,
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  child: Row(
+                    children: <Widget>[
+                      const Icon(
+                        Icons.local_fire_department,
+                        color: FigmaColors.heartOrange,
+                        size: 20,
+                      ),
+                      const SizedBox(width: 10),
+                      const Expanded(
+                        child: Text(
+                          '예상 소모 칼로리',
+                          style: TextStyle(
+                            fontSize: 13,
+                            fontWeight: FontWeight.w600,
+                            color: FigmaColors.textSub,
+                          ),
+                        ),
+                      ),
+                      Text(
+                        '${(_minutes * 6).round()} kcal',
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w800,
+                          color: FigmaColors.primary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _chip(
+    String label,
+    bool on,
+    VoidCallback onTap, {
+    bool center = false,
+  }) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        alignment: center ? Alignment.center : null,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        decoration: BoxDecoration(
+          color: on ? FigmaColors.primaryA(0.10) : Colors.white,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: on ? FigmaColors.primary : FigmaColors.hairline,
+          ),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            color: on ? FigmaColors.primary : FigmaColors.textSub,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Label extends StatelessWidget {
+  const _Label(this.text);
+  final String text;
+  @override
+  Widget build(BuildContext context) => Text(
+    text,
+    style: const TextStyle(
+      fontSize: 14,
+      fontWeight: FontWeight.w700,
+      color: FigmaColors.ink,
+    ),
+  );
+}
+
+// ─────────────────────────────────────────────────────── 헬스장 찾기 ──
+
+/// "헬스장 찾기" — a search field, a map placeholder, and nearby gym cards.
+Future<void> showGymLocatorSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    barrierColor: FigmaColors.sheetScrim,
+    builder: (BuildContext ctx) => _shell(
+      ctx,
+      Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Center(child: _handle()),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 8, 20, 8),
+            child: Row(
+              children: <Widget>[
+                Material(
+                  color: FigmaColors.softBlue,
+                  shape: const CircleBorder(),
+                  clipBehavior: Clip.antiAlias,
+                  child: InkWell(
+                    onTap: () => Navigator.of(ctx).pop(),
+                    child: const SizedBox(
+                      width: 32,
+                      height: 32,
+                      child: Icon(
+                        Icons.close,
+                        size: 16,
+                        color: FigmaColors.primary,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                const Text(
+                  '헬스장 찾기',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w800,
+                    color: FigmaColors.ink,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Flexible(
+            child: ListView(
+              shrinkWrap: true,
+              padding: const EdgeInsets.fromLTRB(20, 4, 20, 28),
+              children: <Widget>[
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 14,
+                    vertical: 12,
+                  ),
+                  decoration: BoxDecoration(
+                    color: FigmaColors.statBg,
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  child: const Row(
+                    children: <Widget>[
+                      Icon(
+                        Icons.search,
+                        size: 16,
+                        color: FigmaColors.textFaint,
+                      ),
+                      SizedBox(width: 8),
+                      Text(
+                        '신촌 · 헬스장, 트레이너',
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: FigmaColors.textFaint,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 12),
+                const _MapPlaceholder(),
+                const SizedBox(height: 16),
+                Row(
+                  children: <Widget>[
+                    const Text(
+                      '주변 헬스장 · O2O 연동',
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w700,
+                        color: FigmaColors.ink,
+                      ),
+                    ),
+                    const SizedBox(width: 6),
+                    AiPill('✦ AI 분석', background: FigmaColors.primaryA(0.10)),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                const _GymResult(
+                  name: '온케어짐 신촌점',
+                  rating: '4.9',
+                  distance: '320m',
+                  meta: 'PT · GX · 24시간 · 트레이너 6명',
+                  reason: '민수님의 혈압 관리 목표에 가장 적합해요. 저강도 유산소 전문 트레이너가 상주해요.',
+                  tags: <String>['혈압 관리 전문 PT', '저강도 프로그램 운영'],
+                  top: true,
+                ),
+                const SizedBox(height: 12),
+                const _GymResult(
+                  name: '파워짐 연세점',
+                  rating: '4.7',
+                  distance: '540m',
+                  meta: 'PT · 필라테스 · 트레이너 4명',
+                  reason: '근력 강화에 특화된 프로그램과 필라테스를 병행할 수 있어요.',
+                  tags: <String>['근력 강화 특화', '필라테스 병행 가능'],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+class _GymResult extends StatelessWidget {
+  const _GymResult({
+    required this.name,
+    required this.rating,
+    required this.distance,
+    required this.meta,
+    required this.reason,
+    required this.tags,
+    this.top = false,
+  });
+
+  final String name;
+  final String rating;
+  final String distance;
+  final String meta;
+  final String reason;
+  final List<String> tags;
+  final bool top;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(
+          color: top ? FigmaColors.primaryA(0.25) : FigmaColors.hairline,
+        ),
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.06),
+            blurRadius: 14,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          if (top) ...<Widget>[
+            const AiPill(
+              '✦ AI 1순위 추천  민수님 건강 목표 기반',
+              background: FigmaColors.primary,
+              color: Colors.white,
+            ),
+            const SizedBox(height: 8),
+          ],
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      name,
+                      style: const TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w800,
+                        color: FigmaColors.ink,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      meta,
+                      style: const TextStyle(
+                        fontSize: 11,
+                        color: FigmaColors.textMuted,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: <Widget>[
+                  Row(
+                    children: <Widget>[
+                      const Icon(
+                        Icons.star,
+                        size: 13,
+                        color: Color(0xFFF5B400),
+                      ),
+                      const SizedBox(width: 2),
+                      Text(
+                        rating,
+                        style: const TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w800,
+                          color: FigmaColors.ink,
+                        ),
+                      ),
+                    ],
+                  ),
+                  Text(
+                    distance,
+                    style: const TextStyle(
+                      fontSize: 11,
+                      color: FigmaColors.textMuted,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Container(
+            padding: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              color: FigmaColors.softBlue,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Wrap(
+                  spacing: 6,
+                  runSpacing: 6,
+                  children: <Widget>[
+                    for (final String t in tags)
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 3,
+                        ),
+                        decoration: BoxDecoration(
+                          color: FigmaColors.primaryA(0.12),
+                          borderRadius: BorderRadius.circular(999),
+                        ),
+                        child: Text(
+                          '✦ AI 추천 이유  $t',
+                          style: const TextStyle(
+                            fontSize: 9.5,
+                            fontWeight: FontWeight.w700,
+                            color: FigmaColors.primary,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  reason,
+                  style: const TextStyle(
+                    fontSize: 11,
+                    height: 1.5,
+                    color: FigmaColors.ink,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: FilledButton(
+                  onPressed: () {},
+                  style: FilledButton.styleFrom(
+                    backgroundColor: FigmaColors.primary,
+                    padding: const EdgeInsets.symmetric(vertical: 10),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: const Text(
+                    '트레이너 채팅',
+                    style: TextStyle(fontSize: 12, fontWeight: FontWeight.w700),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: () {},
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: FigmaColors.primary,
+                    side: BorderSide(color: FigmaColors.primaryA(0.3)),
+                    padding: const EdgeInsets.symmetric(vertical: 10),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: const Text(
+                    '건강 요약 전달',
+                    style: TextStyle(fontSize: 12, fontWeight: FontWeight.w700),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+Widget _closeBtn(BuildContext ctx) => Material(
+  color: const Color(0xFFF4F6F8),
+  shape: const CircleBorder(),
+  clipBehavior: Clip.antiAlias,
+  child: InkWell(
+    onTap: () => Navigator.of(ctx).pop(),
+    child: const SizedBox(
+      width: 32,
+      height: 32,
+      child: Icon(Icons.close, size: 16, color: FigmaColors.textSub),
+    ),
+  ),
+);
+
+Widget _infoRow(IconData icon, String label, String value) => Padding(
+  padding: const EdgeInsets.symmetric(vertical: 6),
+  child: Row(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: <Widget>[
+      Container(
+        width: 32,
+        height: 32,
+        decoration: BoxDecoration(
+          color: FigmaColors.softBlue,
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Icon(icon, size: 16, color: FigmaColors.primary),
+      ),
+      const SizedBox(width: 12),
+      SizedBox(
+        width: 78,
+        child: Padding(
+          padding: const EdgeInsets.only(top: 7),
+          child: Text(
+            label,
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: FigmaColors.textMuted,
+            ),
+          ),
+        ),
+      ),
+      Expanded(
+        child: Padding(
+          padding: const EdgeInsets.only(top: 6),
+          child: Text(
+            value,
+            style: const TextStyle(
+              fontSize: 13.5,
+              fontWeight: FontWeight.w700,
+              color: FigmaColors.ink,
+              height: 1.35,
+            ),
+          ),
+        ),
+      ),
+    ],
+  ),
+);
+
+// ─────────────────────────────────────────────────────── 지도 그래픽 ──
+
+/// A lightweight stylised map (roads, blocks, pins) so the locator reads as a
+/// map area without embedding a live Kakao Map.
+class _MapPlaceholder extends StatelessWidget {
+  const _MapPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(14),
+      child: SizedBox(
+        height: 140,
+        width: double.infinity,
+        child: Stack(
+          children: <Widget>[
+            Positioned.fill(child: CustomPaint(painter: _MapPainter())),
+            Positioned(
+              right: 8,
+              bottom: 8,
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: const Text(
+                  '카카오맵 영역',
+                  style: TextStyle(fontSize: 9, color: FigmaColors.textMuted),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MapPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final double w = size.width;
+    final double h = size.height;
+    canvas.drawRect(
+      Offset.zero & size,
+      Paint()..color = const Color(0xFFEDEEE9),
+    );
+    canvas.drawRect(
+      Rect.fromLTWH(0, h * 0.8, w, h * 0.2),
+      Paint()..color = const Color(0xFFCFE4EF),
+    );
+    final Paint green = Paint()..color = const Color(0xFFCFE0C4);
+    canvas.drawRect(
+      Rect.fromLTWH(w * 0.05, h * 0.08, w * 0.17, h * 0.22),
+      green,
+    );
+    canvas.drawRect(Rect.fromLTWH(w * 0.63, h * 0.5, w * 0.2, h * 0.22), green);
+    final Paint beige = Paint()..color = const Color(0xFFE3D9C7);
+    canvas.drawRect(
+      Rect.fromLTWH(w * 0.31, h * 0.1, w * 0.22, h * 0.26),
+      beige,
+    );
+    canvas.drawRect(
+      Rect.fromLTWH(w * 0.05, h * 0.44, w * 0.2, h * 0.28),
+      beige,
+    );
+    canvas.drawRect(
+      Rect.fromLTWH(w * 0.61, h * 0.08, w * 0.33, h * 0.28),
+      beige,
+    );
+    final Paint road = Paint()
+      ..color = Colors.white
+      ..strokeWidth = 6
+      ..strokeCap = StrokeCap.round;
+    canvas.drawLine(Offset(0, h * 0.4), Offset(w, h * 0.4), road);
+    canvas.drawLine(Offset(0, h * 0.74), Offset(w, h * 0.74), road);
+    canvas.drawLine(Offset(w * 0.28, 0), Offset(w * 0.28, h), road);
+    canvas.drawLine(Offset(w * 0.58, 0), Offset(w * 0.58, h), road);
+    canvas.drawLine(Offset(w * 0.85, 0), Offset(w * 0.85, h), road);
+    _pin(canvas, Offset(w * 0.28, h * 0.4), selected: true);
+    _pin(canvas, Offset(w * 0.58, h * 0.26), selected: false);
+    _pin(canvas, Offset(w * 0.72, h * 0.6), selected: false);
+  }
+
+  void _pin(Canvas c, Offset p, {required bool selected}) {
+    const double r = 7;
+    if (selected) {
+      c.drawCircle(
+        p,
+        r * 2,
+        Paint()..color = FigmaColors.primary.withValues(alpha: 0.18),
+      );
+    }
+    final Path path = Path()
+      ..moveTo(p.dx, p.dy + r * 1.9)
+      ..cubicTo(
+        p.dx - r * 1.2,
+        p.dy + r * 0.2,
+        p.dx - r,
+        p.dy - r,
+        p.dx,
+        p.dy - r,
+      )
+      ..cubicTo(
+        p.dx + r,
+        p.dy - r,
+        p.dx + r * 1.2,
+        p.dy + r * 0.2,
+        p.dx,
+        p.dy + r * 1.9,
+      )
+      ..close();
+    c.drawPath(path, Paint()..color = FigmaColors.primary);
+    c.drawCircle(
+      Offset(p.dx, p.dy - r * 0.15),
+      r * 0.4,
+      Paint()..color = Colors.white,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}
+
+// ─────────────────────────────────────────────────────── 헬스장 정보 ──
+
+/// Gym detail sheet opened from the "헬스장 정보" button.
+Future<void> showGymInfoSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    barrierColor: FigmaColors.sheetScrim,
+    builder: (BuildContext ctx) => _shell(
+      ctx,
+      Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Center(child: _handle()),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 8, 20, 8),
+            child: Row(
+              children: <Widget>[
+                const Expanded(
+                  child: Text(
+                    '헬스장 정보',
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w800,
+                      color: FigmaColors.ink,
+                    ),
+                  ),
+                ),
+                _closeBtn(ctx),
+              ],
+            ),
+          ),
+          Flexible(
+            child: ListView(
+              shrinkWrap: true,
+              padding: const EdgeInsets.fromLTRB(20, 4, 20, 28),
+              children: <Widget>[
+                const _MapPlaceholder(),
+                const SizedBox(height: 14),
+                const Text(
+                  '강남 피트니스 센터',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w800,
+                    color: FigmaColors.ink,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                const Row(
+                  children: <Widget>[
+                    Icon(Icons.star, size: 15, color: Color(0xFFF5B400)),
+                    SizedBox(width: 3),
+                    Text(
+                      '4.8',
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w800,
+                        color: FigmaColors.ink,
+                      ),
+                    ),
+                    SizedBox(width: 6),
+                    Text(
+                      '· 리뷰 213',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: FigmaColors.textMuted,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 14),
+                _infoRow(
+                  Icons.place_outlined,
+                  '주소',
+                  '서울시 강남구 역삼동 123-45 · 0.8km',
+                ),
+                _infoRow(Icons.schedule, '운영시간', '연중무휴 24시간'),
+                _infoRow(Icons.call_outlined, '전화', '02-1234-5678'),
+                _infoRow(Icons.fitness_center, '시설', 'PT · GX · 샤워실 · 주차'),
+                _infoRow(Icons.payments_outlined, '회원권', '3개월 27만원 · 6개월 48만원'),
+                _infoRow(Icons.person_outline, '전담 트레이너', '김트레이너 · 혈압 관리 전문'),
+              ],
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+// ─────────────────────────────────────────────────────── 1:1 상담 ──
+
+/// 1:1 consultation chat with the gym's trainer.
+Future<void> showGymChatSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    barrierColor: FigmaColors.sheetScrim,
+    builder: (BuildContext ctx) => const _GymChatSheet(),
+  );
+}
+
+class _GymMsg {
+  const _GymMsg(this.text, {required this.mine});
+  final String text;
+  final bool mine;
+}
+
+class _GymChatSheet extends StatefulWidget {
+  const _GymChatSheet();
+
+  @override
+  State<_GymChatSheet> createState() => _GymChatSheetState();
+}
+
+class _GymChatSheetState extends State<_GymChatSheet> {
+  final TextEditingController _c = TextEditingController();
+  final List<_GymMsg> _msgs = <_GymMsg>[
+    const _GymMsg('안녕하세요, 김트레이너입니다. 😊\n무엇을 도와드릴까요?', mine: false),
+  ];
+  static const List<String> _chips = <String>['PT 상담', '이용권 문의', '방문 예약'];
+
+  bool get _started => _msgs.any((_GymMsg m) => m.mine);
+
+  @override
+  void dispose() {
+    _c.dispose();
+    super.dispose();
+  }
+
+  void _send([String? preset]) {
+    final String t = (preset ?? _c.text).trim();
+    if (t.isEmpty) return;
+    setState(() {
+      _msgs.add(_GymMsg(t, mine: true));
+      _msgs.add(
+        const _GymMsg(
+          '네, 확인했어요! 담당 트레이너가 곧 답변드릴게요. 편한 방문 시간도 알려주세요. 🙌',
+          mine: false,
+        ),
+      );
+      _c.clear();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _shell(
+      context,
+      Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Center(child: _handle()),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 8, 20, 8),
+            child: Row(
+              children: <Widget>[
+                Container(
+                  width: 38,
+                  height: 38,
+                  decoration: const BoxDecoration(
+                    color: Color(0xFFEEF2F6),
+                    shape: BoxShape.circle,
+                  ),
+                  child: const Icon(
+                    Icons.person,
+                    size: 20,
+                    color: FigmaColors.textMuted,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                const Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        '김트레이너',
+                        style: TextStyle(
+                          fontSize: 15,
+                          fontWeight: FontWeight.w800,
+                          color: FigmaColors.ink,
+                        ),
+                      ),
+                      Text(
+                        '강남 피트니스 센터 · 1:1 상담',
+                        style: TextStyle(
+                          fontSize: 11.5,
+                          color: FigmaColors.primary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                _closeBtn(context),
+              ],
+            ),
+          ),
+          Flexible(
+            child: Container(
+              color: const Color(0xFFF5F7FA),
+              child: ListView(
+                shrinkWrap: true,
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+                children: <Widget>[
+                  for (final _GymMsg m in _msgs) ...<Widget>[
+                    _bubble(m),
+                    const SizedBox(height: 10),
+                  ],
+                  if (!_started)
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: <Widget>[
+                        for (final String q in _chips)
+                          GestureDetector(
+                            onTap: () => _send(q),
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 14,
+                                vertical: 9,
+                              ),
+                              decoration: BoxDecoration(
+                                color: Colors.white,
+                                borderRadius: BorderRadius.circular(999),
+                                border: Border.all(
+                                  color: FigmaColors.primaryA(0.3),
+                                  width: 1.4,
+                                ),
+                              ),
+                              child: Text(
+                                q,
+                                style: const TextStyle(
+                                  fontSize: 13,
+                                  fontWeight: FontWeight.w600,
+                                  color: FigmaColors.primary,
+                                ),
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                ],
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 10, 16, 16),
+            child: Row(
+              children: <Widget>[
+                Expanded(
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 14),
+                    decoration: BoxDecoration(
+                      color: FigmaColors.softBlue,
+                      borderRadius: BorderRadius.circular(14),
+                      border: Border.all(color: FigmaColors.primaryA(0.22)),
+                    ),
+                    child: TextField(
+                      controller: _c,
+                      onSubmitted: (_) => _send(),
+                      decoration: const InputDecoration(
+                        isDense: true,
+                        border: InputBorder.none,
+                        hintText: '메시지를 입력하세요',
+                        hintStyle: TextStyle(
+                          fontSize: 13,
+                          color: FigmaColors.textFaint,
+                        ),
+                        contentPadding: EdgeInsets.symmetric(vertical: 12),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                GestureDetector(
+                  onTap: () => _send(),
+                  child: Container(
+                    width: 42,
+                    height: 42,
+                    decoration: const BoxDecoration(
+                      color: FigmaColors.primary,
+                      shape: BoxShape.circle,
+                    ),
+                    child: const Icon(
+                      Icons.arrow_upward,
+                      size: 18,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _bubble(_GymMsg m) {
+    return Align(
+      alignment: m.mine ? Alignment.centerRight : Alignment.centerLeft,
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 260),
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 11),
+        decoration: BoxDecoration(
+          color: m.mine ? FigmaColors.primary : Colors.white,
+          borderRadius: BorderRadius.circular(16),
+          border: m.mine ? null : Border.all(color: FigmaColors.hairline),
+        ),
+        child: Text(
+          m.text,
+          style: TextStyle(
+            fontSize: 13.5,
+            height: 1.45,
+            fontWeight: FontWeight.w500,
+            color: m.mine ? Colors.white : FigmaColors.ink,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
@@ -1,511 +1,212 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
-import 'package:oncare/core/errors/app_error.dart';
-import 'package:oncare/design_system/atoms/app_avatar.dart';
-import 'package:oncare/design_system/atoms/app_card.dart';
-import 'package:oncare/design_system/tokens/colors.dart';
-import 'package:oncare/design_system/tokens/radius.dart';
-import 'package:oncare/design_system/tokens/spacing.dart';
-import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
+import 'package:oncare/app/router/routes.dart';
+import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/features/auth/presentation/controllers/session_controller.dart';
-import 'package:oncare/features/my_health/domain/entities/health_history.dart';
-import 'package:oncare/features/my_health/presentation/controllers/my_health_controller.dart';
-import 'package:oncare/features/my_health/presentation/widgets/indicator_trend_modal.dart';
-import 'package:oncare/features/my_health/presentation/widgets/settings_modals.dart';
+import 'package:oncare/features/my_health/presentation/widgets/my_flows.dart';
 import 'package:oncare/features/notification/presentation/widgets/notification_panel.dart';
-import 'package:oncare/gen/l10n/app_localizations.dart';
-import 'package:oncare/shared/widgets/error_view.dart';
 import 'package:oncare/shared/widgets/modals/right_slide_panel.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
-import 'package:oncare/shared/widgets/oncare_header.dart';
 
+/// MY tab, rebuilt to the On-Care Figma redesign: profile, role toggle
+/// (the trainer app is intentionally not built), an activity-points banner,
+/// the settings list, and logout.
 class MyHealthPage extends ConsumerWidget {
   const MyHealthPage({super.key});
 
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final l = AppLocalizations.of(context);
-    final async = ref.watch(myHealthStateProvider);
-    return Scaffold(
-      backgroundColor: AppColors.background,
-      body: Column(
-        children: <Widget>[
-          OncareHeader(
-            title: l.pageMyHealthTitle,
-            onNotificationTap: () => showRightSlidePanel<void>(
-              context,
-              content: const NotificationPanelBody(),
-            ),
-            onCalendarTap: () => showScheduleCalendarSheet(context),
-          ),
-          Expanded(
-            child: async.when(
-              data: (s) => _Body(state: s),
-              loading: () => const Center(child: CircularProgressIndicator()),
-              error: (Object e, _) => ErrorView(
-                error: e is AppError ? e : UnknownError(message: e.toString()),
-                onRetry: () => ref.invalidate(myHealthStateProvider),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _Body extends StatelessWidget {
-  const _Body({required this.state});
-  final MyHealthState state;
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 672),
-        child: ListView(
-          padding: const EdgeInsets.fromLTRB(
-            AppSpacing.lg,
-            AppSpacing.xl,
-            AppSpacing.lg,
-            AppSpacing.xxxl,
-          ),
-          children: <Widget>[
-            _ProfileCard(profile: state.profile),
-            const SizedBox(height: AppSpacing.lg),
-            _RiskCard(risk: state.risk),
-            const SizedBox(height: AppSpacing.lg),
-            const _SectionTitle('건강 지표 추이'),
-            const SizedBox(height: AppSpacing.sm),
-            for (final IndicatorTrend t in state.indicators) ...<Widget>[
-              _IndicatorTile(trend: t),
-              const SizedBox(height: AppSpacing.sm),
-            ],
-            const SizedBox(height: AppSpacing.md),
-            _PointsCard(points: state.activityPoints, rank: state.activityRank),
-            const SizedBox(height: AppSpacing.lg),
-            const _SectionTitle('설정'),
-            const SizedBox(height: AppSpacing.sm),
-            AppCard(
-              outlined: true,
-              padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
-              child: Column(
-                children: <Widget>[
-                  for (int i = 0; i < state.settings.length; i++) ...<Widget>[
-                    _SettingsRow(item: state.settings[i]),
-                    if (i < state.settings.length - 1)
-                      const Divider(
-                        height: 1,
-                        color: AppColors.border,
-                        indent: AppSpacing.lg,
-                        endIndent: AppSpacing.lg,
-                      ),
-                  ],
-                ],
-              ),
-            ),
-            const SizedBox(height: AppSpacing.lg),
-            const _SignOutButton(),
-            const SizedBox(height: AppSpacing.sm),
-            const _WithdrawButton(),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _SignOutButton extends ConsumerWidget {
-  const _SignOutButton();
-
-  Future<void> _confirmAndSignOut(BuildContext context, WidgetRef ref) async {
-    final ok = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('로그아웃'),
-        content: const Text('로그아웃 하시겠어요?'),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('취소'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            style: TextButton.styleFrom(foregroundColor: AppColors.destructive),
-            child: const Text('로그아웃'),
-          ),
-        ],
-      ),
-    );
-    if (ok != true) return;
-    // Flipping the session to signed-out lets the router's redirect guard
-    // bounce us back to the sign-in screen automatically.
-    await ref.read(sessionControllerProvider.notifier).signOut();
-  }
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return AppCard(
-      outlined: true,
-      onTap: () => _confirmAndSignOut(context, ref),
-      child: const Row(
-        children: <Widget>[
-          Icon(Icons.logout, size: 20, color: AppColors.destructive),
-          SizedBox(width: AppSpacing.md),
-          Text(
-            '로그아웃',
-            style: TextStyle(
-              color: AppColors.destructive,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _WithdrawButton extends ConsumerWidget {
-  const _WithdrawButton();
-
-  Future<void> _confirmAndWithdraw(BuildContext context, WidgetRef ref) async {
-    final messenger = ScaffoldMessenger.of(context);
-    final ok = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('회원 탈퇴'),
-        content: const Text(
-          '정말 탈퇴하시겠어요?\n'
-          '프로필·식단·운동·건강 기록이 모두 삭제되며 되돌릴 수 없어요.',
-        ),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('취소'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            style: TextButton.styleFrom(foregroundColor: AppColors.destructive),
-            child: const Text('탈퇴하기'),
-          ),
-        ],
-      ),
-    );
-    if (ok != true) return;
-    try {
-      await ref.read(accountRepositoryProvider).deleteAccount();
-      // 세션을 로그아웃 상태로 전환 → 가드가 로그인 화면으로 되돌린다.
-      await ref.read(sessionControllerProvider.notifier).signOut();
-    } catch (_) {
-      messenger.showSnackBar(
-        const SnackBar(content: Text('탈퇴에 실패했어요. 잠시 후 다시 시도해 주세요')),
-      );
+  void _openSetting(BuildContext context, String label) {
+    switch (label) {
+      case '내 프로필':
+        showProfileSheet(context);
+      case '건강 목표':
+        showGoalsSheet(context);
+      case '알림 설정':
+        showNotifSheet(context);
+      case '고객 지원':
+        showSupportSheet(context);
     }
   }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Center(
-      child: TextButton(
-        onPressed: () => _confirmAndWithdraw(context, ref),
-        style: TextButton.styleFrom(foregroundColor: AppColors.mutedForeground),
-        child: const Text(
-          '회원 탈퇴',
-          style: TextStyle(decoration: TextDecoration.underline),
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        bottom: false,
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 720),
+            child: ListView(
+              padding: const EdgeInsets.only(bottom: 108),
+              children: <Widget>[
+                FigmaTabHeader(
+                  title: 'My',
+                  onBell: () => showRightSlidePanel<void>(
+                    context,
+                    content: const NotificationPanelBody(),
+                  ),
+                  onCalendar: () => showScheduleCalendarSheet(context),
+                ),
+                const SizedBox(height: 4),
+                const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 24),
+                  child: _ProfileCard(),
+                ),
+                const SizedBox(height: 20),
+                const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 24),
+                  child: _PointsBanner(),
+                ),
+                const SizedBox(height: 20),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: _Settings(
+                    onTap: (String s) => _openSetting(context, s),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: _LogoutButton(
+                    onTap: () async {
+                      await ref
+                          .read(sessionControllerProvider.notifier)
+                          .signOut();
+                      if (context.mounted) context.go(AppRoutes.signIn);
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
         ),
       ),
     );
   }
-}
-
-class _SectionTitle extends StatelessWidget {
-  const _SectionTitle(this.title);
-  final String title;
-  @override
-  Widget build(BuildContext context) => Text(
-    title,
-    style: Theme.of(
-      context,
-    ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
-  );
 }
 
 class _ProfileCard extends StatelessWidget {
-  const _ProfileCard({required this.profile});
-  final UserProfile profile;
+  const _ProfileCard();
 
   @override
   Widget build(BuildContext context) {
-    return AppCard(
-      outlined: true,
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: FigmaColors.hairline),
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.07),
+            blurRadius: 16,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
       child: Row(
         children: <Widget>[
           Container(
-            padding: const EdgeInsets.all(2),
-            decoration: const BoxDecoration(
+            width: 52,
+            height: 52,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
               shape: BoxShape.circle,
-              gradient: LinearGradient(
+              gradient: const LinearGradient(
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
-                colors: <Color>[AppColors.primary, AppColors.secondary],
+                colors: <Color>[FigmaColors.primary, FigmaColors.primaryDeep],
+              ),
+              border: Border.all(color: FigmaColors.primary, width: 2.5),
+            ),
+            child: const Text(
+              '김',
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.w800,
+                color: Colors.white,
               ),
             ),
-            child: CircleAvatar(
-              radius: 28,
-              backgroundColor: AppColors.background,
-              child: AppAvatar(label: profile.name, size: 52),
-            ),
           ),
-          const SizedBox(width: AppSpacing.md),
-          Expanded(
+          const SizedBox(width: 14),
+          const Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
                 Text(
-                  profile.name,
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w700,
+                  '김민수',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w800,
+                    color: FigmaColors.ink,
                   ),
                 ),
-                const SizedBox(height: 2),
+                SizedBox(height: 2),
                 Text(
-                  profile.email,
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: AppColors.mutedForeground,
+                  'minsu@oncare.com',
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w500,
+                    color: FigmaColors.textMuted,
                   ),
                 ),
               ],
             ),
           ),
-          const Icon(Icons.chevron_right, color: AppColors.mutedForeground),
         ],
       ),
     );
   }
 }
 
-class _RiskCard extends StatelessWidget {
-  const _RiskCard({required this.risk});
-  final RiskAlert risk;
+class _PointsBanner extends StatelessWidget {
+  const _PointsBanner();
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     return Container(
-      padding: const EdgeInsets.all(AppSpacing.lg),
-      decoration: const BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-          colors: <Color>[Color(0xFFFB923C), Color(0xFFEF4444)],
-        ),
-        borderRadius: BorderRadius.all(AppRadius.card),
-      ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          const Icon(Icons.warning_amber_rounded, color: Colors.white),
-          const SizedBox(width: AppSpacing.md),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Text(
-                  risk.title,
-                  style: theme.textTheme.titleSmall?.copyWith(
-                    color: Colors.white,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  risk.body,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: Colors.white.withValues(alpha: 0.9),
-                  ),
-                ),
-              ],
-            ),
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+      decoration: BoxDecoration(
+        color: FigmaColors.primary,
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            color: FigmaColors.primaryA(0.38),
+            blurRadius: 20,
+            offset: const Offset(0, 6),
           ),
         ],
       ),
-    );
-  }
-}
-
-class _IndicatorTile extends StatelessWidget {
-  const _IndicatorTile({required this.trend});
-  final IndicatorTrend trend;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final color = trend.improving ? AppColors.success : AppColors.warning;
-    return AppCard(
-      outlined: true,
-      onTap: () => showIndicatorTrendModal(context, trend),
       child: Row(
         children: <Widget>[
-          SizedBox(
-            width: 80,
-            height: 40,
-            child: CustomPaint(
-              painter: _SparklinePainter(values: trend.last7Days, color: color),
+          const Icon(Icons.star_border_rounded, color: Colors.white, size: 24),
+          const SizedBox(width: 12),
+          const Text(
+            '1240P',
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w800,
+              color: Colors.white,
+              letterSpacing: -0.5,
             ),
           ),
-          const SizedBox(width: AppSpacing.md),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Text(
-                  trend.label,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: AppColors.mutedForeground,
-                  ),
-                ),
-                Text.rich(
-                  TextSpan(
-                    children: <InlineSpan>[
-                      TextSpan(
-                        text: trend.latestValue,
-                        style: theme.textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.w700,
-                        ),
-                      ),
-                      TextSpan(
-                        text: ' ${trend.unit}',
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: AppColors.mutedForeground,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: 2),
-                Row(
-                  children: <Widget>[
-                    Icon(
-                      trend.improving ? Icons.trending_down : Icons.trending_up,
-                      size: 14,
-                      color: color,
-                    ),
-                    const SizedBox(width: 4),
-                    Text(
-                      trend.deltaText,
-                      style: theme.textTheme.bodySmall?.copyWith(color: color),
-                    ),
-                  ],
-                ),
-              ],
+          const Spacer(),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
+            decoration: BoxDecoration(
+              color: Colors.white.withValues(alpha: 0.22),
+              borderRadius: BorderRadius.circular(999),
             ),
-          ),
-          const Icon(
-            Icons.chevron_right,
-            size: 18,
-            color: AppColors.mutedForeground,
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _SparklinePainter extends CustomPainter {
-  _SparklinePainter({required this.values, required this.color});
-  final List<double> values;
-  final Color color;
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    if (values.length < 2) return;
-    final fill = Paint()
-      ..color = color.withValues(alpha: 0.18)
-      ..style = PaintingStyle.fill;
-    final stroke = Paint()
-      ..color = color
-      ..strokeWidth = 2
-      ..style = PaintingStyle.stroke;
-
-    final stepX = size.width / (values.length - 1);
-    Offset point(int i) {
-      final v = values[i].clamp(0, 1).toDouble();
-      return Offset(stepX * i, size.height - v * size.height);
-    }
-
-    final path = Path()..moveTo(0, size.height);
-    for (var i = 0; i < values.length; i++) {
-      path.lineTo(point(i).dx, point(i).dy);
-    }
-    path.lineTo(size.width, size.height);
-    path.close();
-    canvas.drawPath(path, fill);
-
-    final line = Path()..moveTo(point(0).dx, point(0).dy);
-    for (var i = 1; i < values.length; i++) {
-      line.lineTo(point(i).dx, point(i).dy);
-    }
-    canvas.drawPath(line, stroke);
-  }
-
-  @override
-  bool shouldRepaint(covariant _SparklinePainter old) =>
-      old.values != values || old.color != color;
-}
-
-class _PointsCard extends StatelessWidget {
-  const _PointsCard({required this.points, required this.rank});
-  final int points;
-  final int rank;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Container(
-      padding: const EdgeInsets.all(AppSpacing.lg),
-      decoration: const BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-          colors: <Color>[AppColors.primary, AppColors.secondary],
-        ),
-        borderRadius: BorderRadius.all(AppRadius.card),
-      ),
-      child: Row(
-        children: <Widget>[
-          const Icon(Icons.workspace_premium, color: Colors.white, size: 28),
-          const SizedBox(width: AppSpacing.md),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Text(
-                  '활동 포인트',
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: Colors.white.withValues(alpha: 0.9),
-                  ),
-                ),
-                Text(
-                  '${points}P',
-                  style: theme.textTheme.headlineSmall?.copyWith(
-                    color: Colors.white,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          TextButton(
-            onPressed: () {},
-            style: TextButton.styleFrom(
-              backgroundColor: Colors.white.withValues(alpha: 0.20),
-              foregroundColor: Colors.white,
-              shape: const RoundedRectangleBorder(
-                borderRadius: BorderRadius.all(AppRadius.lg),
+            child: const Text(
+              '14위 랭킹',
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+                color: Colors.white,
               ),
             ),
-            child: Text('$rank위 랭킹'),
           ),
         ],
       ),
@@ -513,48 +214,167 @@ class _PointsCard extends StatelessWidget {
   }
 }
 
-class _SettingsRow extends StatelessWidget {
-  const _SettingsRow({required this.item});
-  final SettingsItem item;
+class _SettingItem {
+  const _SettingItem(this.icon, this.label);
+  final IconData icon;
+  final String label;
+}
 
-  void _open(BuildContext context) {
-    switch (item.kind) {
-      case SettingsKind.myProfile:
-        showMyProfileModal(context);
-      case SettingsKind.healthGoal:
-        showHealthGoalModal(context);
-      case SettingsKind.notification:
-        showNotificationSettingsModal(context);
-      case SettingsKind.support:
-        showCustomerSupportModal(context);
-    }
+class _Settings extends StatelessWidget {
+  const _Settings({required this.onTap});
+  final ValueChanged<String> onTap;
+
+  static const List<_SettingItem> _items = <_SettingItem>[
+    _SettingItem(Icons.person_outline, '내 프로필'),
+    _SettingItem(Icons.bar_chart_rounded, '건강 목표'),
+    _SettingItem(Icons.notifications_none_rounded, '알림 설정'),
+    _SettingItem(Icons.chat_bubble_outline_rounded, '고객 지원'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        const Text(
+          '설정',
+          style: TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.w700,
+            color: FigmaColors.ink,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Container(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(color: FigmaColors.hairline),
+            boxShadow: <BoxShadow>[
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.06),
+                blurRadius: 12,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+          clipBehavior: Clip.antiAlias,
+          child: Column(
+            children: <Widget>[
+              for (int i = 0; i < _items.length; i++) ...<Widget>[
+                _SettingRow(
+                  item: _items[i],
+                  onTap: () => onTap(_items[i].label),
+                ),
+                if (i < _items.length - 1)
+                  const Padding(
+                    padding: EdgeInsets.only(left: 56),
+                    child: Divider(height: 1, color: FigmaColors.hairline),
+                  ),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
   }
+}
+
+class _SettingRow extends StatelessWidget {
+  const _SettingRow({required this.item, required this.onTap});
+  final _SettingItem item;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     return InkWell(
-      onTap: () => _open(context),
+      onTap: onTap,
       child: Padding(
-        padding: const EdgeInsets.symmetric(
-          horizontal: AppSpacing.lg,
-          vertical: AppSpacing.md,
-        ),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
         child: Row(
           children: <Widget>[
-            Text(item.icon, style: const TextStyle(fontSize: 20)),
-            const SizedBox(width: AppSpacing.md),
+            Container(
+              width: 32,
+              height: 32,
+              decoration: BoxDecoration(
+                color: FigmaColors.softBlue,
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Icon(item.icon, size: 16, color: FigmaColors.primary),
+            ),
+            const SizedBox(width: 12),
             Expanded(
               child: Text(
                 item.label,
-                style: Theme.of(context).textTheme.bodyMedium,
+                style: const TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                  color: FigmaColors.ink,
+                ),
               ),
             ),
             const Icon(
               Icons.chevron_right,
               size: 18,
-              color: AppColors.mutedForeground,
+              color: FigmaColors.textFaint,
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _LogoutButton extends StatelessWidget {
+  const _LogoutButton({required this.onTap});
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: FigmaColors.hairline),
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.06),
+            blurRadius: 12,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          child: Row(
+            children: <Widget>[
+              Container(
+                width: 32,
+                height: 32,
+                decoration: BoxDecoration(
+                  color: const Color(0x14FF3B30),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: const Icon(
+                  Icons.logout,
+                  size: 16,
+                  color: Color(0xFFFF3B30),
+                ),
+              ),
+              const SizedBox(width: 12),
+              const Text(
+                '로그아웃',
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                  color: Color(0xFFFF3B30),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
@@ -5,6 +5,8 @@ import 'package:go_router/go_router.dart';
 import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/features/auth/presentation/controllers/session_controller.dart';
+import 'package:oncare/features/my_health/domain/entities/health_history.dart';
+import 'package:oncare/features/my_health/presentation/controllers/my_health_controller.dart';
 import 'package:oncare/features/my_health/presentation/widgets/my_flows.dart';
 import 'package:oncare/features/notification/presentation/widgets/notification_panel.dart';
 import 'package:oncare/shared/widgets/modals/right_slide_panel.dart';
@@ -31,6 +33,7 @@ class MyHealthPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final AsyncValue<MyHealthState> health = ref.watch(myHealthStateProvider);
     return Scaffold(
       backgroundColor: Colors.white,
       body: SafeArea(
@@ -42,7 +45,7 @@ class MyHealthPage extends ConsumerWidget {
               padding: const EdgeInsets.only(bottom: 108),
               children: <Widget>[
                 FigmaTabHeader(
-                  title: 'My',
+                  title: 'MY',
                   onBell: () => showRightSlidePanel<void>(
                     context,
                     content: const NotificationPanelBody(),
@@ -50,14 +53,19 @@ class MyHealthPage extends ConsumerWidget {
                   onCalendar: () => showScheduleCalendarSheet(context),
                 ),
                 const SizedBox(height: 4),
-                const Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 24),
-                  child: _ProfileCard(),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: _ProfileCard(
+                    profile: health.valueOrNull?.profile,
+                  ),
                 ),
                 const SizedBox(height: 20),
-                const Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 24),
-                  child: _PointsBanner(),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: _PointsBanner(
+                    points: health.valueOrNull?.activityPoints,
+                    rank: health.valueOrNull?.activityRank,
+                  ),
                 ),
                 const SizedBox(height: 20),
                 Padding(
@@ -71,6 +79,26 @@ class MyHealthPage extends ConsumerWidget {
                   padding: const EdgeInsets.symmetric(horizontal: 24),
                   child: _LogoutButton(
                     onTap: () async {
+                      final bool ok =
+                          await showDialog<bool>(
+                            context: context,
+                            builder: (BuildContext ctx) => AlertDialog(
+                              title: const Text('로그아웃'),
+                              content: const Text('로그아웃 하시겠어요?'),
+                              actions: <Widget>[
+                                TextButton(
+                                  onPressed: () => Navigator.of(ctx).pop(false),
+                                  child: const Text('취소'),
+                                ),
+                                TextButton(
+                                  onPressed: () => Navigator.of(ctx).pop(true),
+                                  child: const Text('로그아웃'),
+                                ),
+                              ],
+                            ),
+                          ) ??
+                          false;
+                      if (!ok) return;
                       await ref
                           .read(sessionControllerProvider.notifier)
                           .signOut();
@@ -88,10 +116,15 @@ class MyHealthPage extends ConsumerWidget {
 }
 
 class _ProfileCard extends StatelessWidget {
-  const _ProfileCard();
+  const _ProfileCard({required this.profile});
+
+  final UserProfile? profile;
 
   @override
   Widget build(BuildContext context) {
+    final String name = profile?.name ?? '';
+    final String email = profile?.email ?? '';
+    final String initial = name.isNotEmpty ? name.substring(0, 1) : '·';
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
       decoration: BoxDecoration(
@@ -121,9 +154,9 @@ class _ProfileCard extends StatelessWidget {
               ),
               border: Border.all(color: FigmaColors.primary, width: 2.5),
             ),
-            child: const Text(
-              '김',
-              style: TextStyle(
+            child: Text(
+              initial,
+              style: const TextStyle(
                 fontSize: 18,
                 fontWeight: FontWeight.w800,
                 color: Colors.white,
@@ -131,22 +164,22 @@ class _ProfileCard extends StatelessWidget {
             ),
           ),
           const SizedBox(width: 14),
-          const Expanded(
+          Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
                 Text(
-                  '김민수',
-                  style: TextStyle(
+                  name.isEmpty ? '사용자' : name,
+                  style: const TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w800,
                     color: FigmaColors.ink,
                   ),
                 ),
-                SizedBox(height: 2),
+                const SizedBox(height: 2),
                 Text(
-                  'minsu@oncare.com',
-                  style: TextStyle(
+                  email,
+                  style: const TextStyle(
                     fontSize: 12,
                     fontWeight: FontWeight.w500,
                     color: FigmaColors.textMuted,
@@ -162,7 +195,10 @@ class _ProfileCard extends StatelessWidget {
 }
 
 class _PointsBanner extends StatelessWidget {
-  const _PointsBanner();
+  const _PointsBanner({required this.points, required this.rank});
+
+  final int? points;
+  final int? rank;
 
   @override
   Widget build(BuildContext context) {
@@ -183,9 +219,9 @@ class _PointsBanner extends StatelessWidget {
         children: <Widget>[
           const Icon(Icons.star_border_rounded, color: Colors.white, size: 24),
           const SizedBox(width: 12),
-          const Text(
-            '1240P',
-            style: TextStyle(
+          Text(
+            points != null ? '${points}P' : '—P',
+            style: const TextStyle(
               fontSize: 18,
               fontWeight: FontWeight.w800,
               color: Colors.white,
@@ -193,21 +229,22 @@ class _PointsBanner extends StatelessWidget {
             ),
           ),
           const Spacer(),
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
-            decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.22),
-              borderRadius: BorderRadius.circular(999),
-            ),
-            child: const Text(
-              '14위 랭킹',
-              style: TextStyle(
-                fontSize: 12,
-                fontWeight: FontWeight.w700,
-                color: Colors.white,
+          if (rank != null)
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
+              decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.22),
+                borderRadius: BorderRadius.circular(999),
+              ),
+              child: Text(
+                '$rank위 랭킹',
+                style: const TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  color: Colors.white,
+                ),
               ),
             ),
-          ),
         ],
       ),
     );

--- a/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
@@ -1,0 +1,408 @@
+import 'package:flutter/material.dart';
+
+import 'package:oncare/design_system/figma/figma_kit.dart';
+
+Widget _shell(BuildContext context, String title, List<Widget> children) {
+  return SafeArea(
+    top: false,
+    child: ConstrainedBox(
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.9,
+        maxWidth: 560,
+      ),
+      child: Container(
+        decoration: const BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Container(
+              margin: const EdgeInsets.only(top: 12, bottom: 4),
+              width: 36,
+              height: 4,
+              decoration: BoxDecoration(
+                color: const Color(0xFFDDE3EA),
+                borderRadius: BorderRadius.circular(999),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 8, 20, 8),
+              child: Row(
+                children: <Widget>[
+                  Expanded(
+                    child: Text(
+                      title,
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.w800,
+                        color: FigmaColors.ink,
+                      ),
+                    ),
+                  ),
+                  Material(
+                    color: const Color(0xFFF4F6F8),
+                    shape: const CircleBorder(),
+                    clipBehavior: Clip.antiAlias,
+                    child: InkWell(
+                      onTap: () => Navigator.of(context).pop(),
+                      child: const SizedBox(
+                        width: 32,
+                        height: 32,
+                        child: Icon(
+                          Icons.close,
+                          size: 16,
+                          color: FigmaColors.textSub,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Flexible(
+              child: ListView(
+                shrinkWrap: true,
+                padding: const EdgeInsets.fromLTRB(20, 4, 20, 28),
+                children: children,
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> _open(BuildContext context, String title, List<Widget> body) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    barrierColor: FigmaColors.sheetScrim,
+    builder: (BuildContext ctx) => _shell(ctx, title, body),
+  );
+}
+
+Widget _card(List<Widget> children) => Container(
+  padding: const EdgeInsets.all(16),
+  decoration: BoxDecoration(
+    color: FigmaColors.statBg,
+    borderRadius: BorderRadius.circular(16),
+  ),
+  child: Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: children,
+  ),
+);
+
+Widget _field(String label, String value) => Padding(
+  padding: const EdgeInsets.symmetric(vertical: 8),
+  child: Row(
+    children: <Widget>[
+      SizedBox(
+        width: 84,
+        child: Text(
+          label,
+          style: const TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            color: FigmaColors.textMuted,
+          ),
+        ),
+      ),
+      Expanded(
+        child: Text(
+          value,
+          style: const TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.w700,
+            color: FigmaColors.ink,
+          ),
+        ),
+      ),
+    ],
+  ),
+);
+
+// ───────────────────────────────────────────────────────── 내 프로필 ──
+
+/// Profile detail — mirrors the profile card + body basics shown in the app.
+Future<void> showProfileSheet(BuildContext context) {
+  return _open(context, '내 프로필', <Widget>[
+    Center(
+      child: Container(
+        width: 64,
+        height: 64,
+        alignment: Alignment.center,
+        decoration: const BoxDecoration(
+          shape: BoxShape.circle,
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: <Color>[FigmaColors.primary, FigmaColors.primaryDeep],
+          ),
+        ),
+        child: const Text(
+          '김',
+          style: TextStyle(
+            fontSize: 22,
+            fontWeight: FontWeight.w800,
+            color: Colors.white,
+          ),
+        ),
+      ),
+    ),
+    const SizedBox(height: 16),
+    _card(<Widget>[
+      _field('이름', '김민수'),
+      const Divider(height: 1, color: FigmaColors.hairline),
+      _field('이메일', 'minsu@oncare.com'),
+      const Divider(height: 1, color: FigmaColors.hairline),
+      _field('생년월일', '1996. 03. 21.'),
+    ]),
+    const SizedBox(height: 12),
+    _card(<Widget>[
+      _field('키', '172 cm'),
+      const Divider(height: 1, color: FigmaColors.hairline),
+      _field('체중', '68 kg'),
+      const Divider(height: 1, color: FigmaColors.hairline),
+      _field('관리 목표', '혈압 관리 · 체중 감량'),
+    ]),
+    const SizedBox(height: 16),
+    _saveButton(context, '프로필이 저장되었어요'),
+  ]);
+}
+
+// ───────────────────────────────────────────────────────── 건강 목표 ──
+
+/// Health goals — the daily targets that drive the home/diet summaries.
+Future<void> showGoalsSheet(BuildContext context) {
+  return _open(context, '건강 목표', <Widget>[
+    const Text(
+      '앱 곳곳의 요약·피드백이 이 목표를 기준으로 계산돼요.',
+      style: TextStyle(fontSize: 12, color: FigmaColors.textMuted),
+    ),
+    const SizedBox(height: 12),
+    _card(<Widget>[
+      _goalRow('일일 칼로리', '1,800', 'kcal'),
+      const Divider(height: 1, color: FigmaColors.hairline),
+      _goalRow('나트륨', '2,000', 'mg 이하'),
+      const Divider(height: 1, color: FigmaColors.hairline),
+      _goalRow('당류', '50', 'g 이하'),
+    ]),
+    const SizedBox(height: 12),
+    _card(<Widget>[
+      _goalRow('운동 소모', '500', 'kcal/일'),
+      const Divider(height: 1, color: FigmaColors.hairline),
+      _goalRow('걸음 수', '8,000', '보'),
+      const Divider(height: 1, color: FigmaColors.hairline),
+      _goalRow('주간 운동', '5', '회'),
+    ]),
+    const SizedBox(height: 16),
+    _saveButton(context, '건강 목표가 저장되었어요'),
+  ]);
+}
+
+Widget _goalRow(String label, String value, String unit) => Padding(
+  padding: const EdgeInsets.symmetric(vertical: 10),
+  child: Row(
+    children: <Widget>[
+      Expanded(
+        child: Text(
+          label,
+          style: const TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.w600,
+            color: FigmaColors.ink,
+          ),
+        ),
+      ),
+      Text(
+        value,
+        style: const TextStyle(
+          fontSize: 16,
+          fontWeight: FontWeight.w800,
+          color: FigmaColors.primary,
+        ),
+      ),
+      const SizedBox(width: 4),
+      Text(
+        unit,
+        style: const TextStyle(fontSize: 11, color: FigmaColors.textMuted),
+      ),
+    ],
+  ),
+);
+
+// ───────────────────────────────────────────────────────── 알림 설정 ──
+
+/// Notification preferences.
+Future<void> showNotifSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    barrierColor: FigmaColors.sheetScrim,
+    builder: (BuildContext ctx) => const _NotifSheet(),
+  );
+}
+
+class _NotifSheet extends StatefulWidget {
+  const _NotifSheet();
+
+  @override
+  State<_NotifSheet> createState() => _NotifSheetState();
+}
+
+class _NotifSheetState extends State<_NotifSheet> {
+  final Map<String, bool> _on = <String, bool>{
+    '식단 기록 알림': true,
+    '운동 리마인더': true,
+    '트레이너 메시지': true,
+    'AI 코칭 조언': true,
+    '주간 리포트': false,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return _shell(context, '알림 설정', <Widget>[
+      _card(<Widget>[
+        for (final MapEntry<String, bool> e in _on.entries) ...<Widget>[
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: Text(
+                  e.key,
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: FigmaColors.ink,
+                  ),
+                ),
+              ),
+              Switch.adaptive(
+                value: e.value,
+                activeThumbColor: FigmaColors.primary,
+                onChanged: (bool v) => setState(() => _on[e.key] = v),
+              ),
+            ],
+          ),
+          if (e.key != _on.keys.last)
+            const Divider(height: 1, color: FigmaColors.hairline),
+        ],
+      ]),
+    ]);
+  }
+}
+
+// ───────────────────────────────────────────────────────── 고객 지원 ──
+
+/// Customer support entries.
+Future<void> showSupportSheet(BuildContext context) {
+  return _open(context, '고객 지원', <Widget>[
+    _supportRow(context, Icons.help_outline, '자주 묻는 질문'),
+    _supportRow(context, Icons.chat_bubble_outline, '1:1 문의'),
+    _supportRow(context, Icons.description_outlined, '이용약관'),
+    _supportRow(context, Icons.privacy_tip_outlined, '개인정보 처리방침'),
+    const SizedBox(height: 12),
+    const Center(
+      child: Text(
+        'On-Care · 버전 1.0.0',
+        style: TextStyle(fontSize: 12, color: FigmaColors.textFaint),
+      ),
+    ),
+  ]);
+}
+
+Widget _supportRow(BuildContext context, IconData icon, String label) {
+  return Padding(
+    padding: const EdgeInsets.only(bottom: 8),
+    child: Material(
+      color: FigmaColors.statBg,
+      borderRadius: BorderRadius.circular(14),
+      child: InkWell(
+        onTap: () {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text('$label은(는) 준비 중이에요')));
+        },
+        borderRadius: BorderRadius.circular(14),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+          child: Row(
+            children: <Widget>[
+              Icon(icon, size: 18, color: FigmaColors.primary),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  label,
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: FigmaColors.ink,
+                  ),
+                ),
+              ),
+              const Icon(
+                Icons.chevron_right,
+                size: 18,
+                color: FigmaColors.textFaint,
+              ),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Widget _saveButton(BuildContext context, String message) => Row(
+  children: <Widget>[
+    Expanded(
+      child: OutlinedButton.icon(
+        onPressed: () {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(const SnackBar(content: Text('항목을 눌러 값을 수정할 수 있어요')));
+        },
+        style: OutlinedButton.styleFrom(
+          foregroundColor: FigmaColors.primary,
+          side: BorderSide(color: FigmaColors.primaryA(0.4)),
+          padding: const EdgeInsets.symmetric(vertical: 14),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(14),
+          ),
+        ),
+        icon: const Icon(Icons.edit_outlined, size: 16),
+        label: const Text(
+          '수정',
+          style: TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
+        ),
+      ),
+    ),
+    const SizedBox(width: 12),
+    Expanded(
+      child: FilledButton(
+        onPressed: () {
+          Navigator.of(context).pop();
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text(message)));
+        },
+        style: FilledButton.styleFrom(
+          backgroundColor: FigmaColors.primary,
+          padding: const EdgeInsets.symmetric(vertical: 14),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(14),
+          ),
+        ),
+        child: const Text(
+          '저장',
+          style: TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
+        ),
+      ),
+    ),
+  ],
+);

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -101,7 +101,7 @@ abstract class AppLocalizations {
   /// Application name shown in window/AppBar titles.
   ///
   /// In en, this message translates to:
-  /// **'Oncare'**
+  /// **'On-Care'**
   String get appTitle;
 
   /// No description provided for @navDashboard.
@@ -125,7 +125,7 @@ abstract class AppLocalizations {
   /// No description provided for @navMyHealth.
   ///
   /// In en, this message translates to:
-  /// **'My'**
+  /// **'MY'**
   String get navMyHealth;
 
   /// No description provided for @pageDashboardTitle.

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -9,7 +9,7 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
-  String get appTitle => 'Oncare';
+  String get appTitle => 'On-Care';
 
   @override
   String get navDashboard => 'Home';
@@ -21,7 +21,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get navExercise => 'Exercise';
 
   @override
-  String get navMyHealth => 'My';
+  String get navMyHealth => 'MY';
 
   @override
   String get pageDashboardTitle => 'Home';

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -9,7 +9,7 @@ class AppLocalizationsKo extends AppLocalizations {
   AppLocalizationsKo([String locale = 'ko']) : super(locale);
 
   @override
-  String get appTitle => 'Oncare';
+  String get appTitle => 'On-Care';
 
   @override
   String get navDashboard => '홈';
@@ -21,7 +21,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get navExercise => '운동';
 
   @override
-  String get navMyHealth => 'My';
+  String get navMyHealth => 'MY';
 
   @override
   String get pageDashboardTitle => '홈';

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -1,6 +1,6 @@
 {
   "@@locale": "en",
-  "appTitle": "Oncare",
+  "appTitle": "On-Care",
   "@appTitle": {
     "description": "Application name shown in window/AppBar titles."
   },
@@ -8,7 +8,7 @@
   "navDashboard": "Home",
   "navDiet": "Diet",
   "navExercise": "Exercise",
-  "navMyHealth": "My",
+  "navMyHealth": "MY",
 
   "pageDashboardTitle": "Home",
   "pageDietTitle": "Diet",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -1,11 +1,11 @@
 {
   "@@locale": "ko",
-  "appTitle": "Oncare",
+  "appTitle": "On-Care",
 
   "navDashboard": "홈",
   "navDiet": "식단",
   "navExercise": "운동",
-  "navMyHealth": "My",
+  "navMyHealth": "MY",
 
   "pageDashboardTitle": "홈",
   "pageDietTitle": "식단",

--- a/frontend/flutter/lib/shared/widgets/coaching_sheet.dart
+++ b/frontend/flutter/lib/shared/widgets/coaching_sheet.dart
@@ -1,0 +1,310 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:oncare/app/router/routes.dart';
+import 'package:oncare/design_system/figma/figma_kit.dart';
+
+/// "AI 건강 도우미" bottom sheet — the daily coaching digest opened from the
+/// floating Oni button and the Home coaching banner. Its CTA hands off to the
+/// AI chat. Mirrors the Figma `CoachingSheet`.
+Future<void> showCoachingSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    barrierColor: FigmaColors.sheetScrim,
+    builder: (BuildContext ctx) => const _CoachingSheet(),
+  );
+}
+
+class _CoachCard {
+  const _CoachCard({
+    required this.tag,
+    required this.tagColor,
+    required this.title,
+    required this.body,
+    required this.done,
+  });
+  final String tag;
+  final Color tagColor;
+  final String title;
+  final String body;
+  final bool done;
+}
+
+const List<_CoachCard> _cards = <_CoachCard>[
+  _CoachCard(
+    tag: '식단',
+    tagColor: FigmaColors.orange,
+    title: '저녁은 나트륨을 조금 줄여보세요.',
+    body: '구이나 샐러드가 좋아요.',
+    done: true,
+  ),
+  _CoachCard(
+    tag: '운동',
+    tagColor: FigmaColors.greenTag,
+    title: '저녁 산책 20분.',
+    body: '식후 가벼운 산책은 혈당 관리에 도움이 돼요.',
+    done: true,
+  ),
+  _CoachCard(
+    tag: '수분',
+    tagColor: FigmaColors.primary,
+    title: '물 한 잔 더 마시기.',
+    body: '오늘 활동량이 많았어요.',
+    done: false,
+  ),
+];
+
+class _CoachingSheet extends StatelessWidget {
+  const _CoachingSheet();
+
+  @override
+  Widget build(BuildContext context) {
+    final int done = _cards.where((_CoachCard c) => c.done).length;
+    final double pct = done / _cards.length;
+
+    return SafeArea(
+      top: false,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.of(context).size.height * 0.88,
+          maxWidth: 480,
+        ),
+        child: Container(
+          decoration: const BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              const SizedBox(height: 12),
+              Container(
+                width: 36,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: const Color(0xFFDDE3EA),
+                  borderRadius: BorderRadius.circular(999),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 12, 20, 12),
+                child: Row(
+                  children: <Widget>[
+                    const OniAvatar(size: 44),
+                    const SizedBox(width: 12),
+                    const Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Text(
+                            'AI 건강 도우미',
+                            style: TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w600,
+                              color: FigmaColors.primary,
+                            ),
+                          ),
+                          SizedBox(height: 1),
+                          Text(
+                            '오늘의 맞춤 조언을 모아봤어요',
+                            style: TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w700,
+                              color: FigmaColors.ink,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    _CloseButton(onTap: () => Navigator.of(context).pop()),
+                  ],
+                ),
+              ),
+              Flexible(
+                child: ListView.separated(
+                  shrinkWrap: true,
+                  padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
+                  itemCount: _cards.length,
+                  separatorBuilder: (_, _) => const SizedBox(height: 10),
+                  itemBuilder: (_, int i) => _CoachCardTile(card: _cards[i]),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 8, 20, 12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: <Widget>[
+                        const Text(
+                          '오늘의 추천 진행도',
+                          style: TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w500,
+                            color: FigmaColors.textMuted,
+                          ),
+                        ),
+                        Text(
+                          '$done/${_cards.length} 완료',
+                          style: const TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w700,
+                            color: FigmaColors.primary,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(999),
+                      child: LinearProgressIndicator(
+                        value: pct,
+                        minHeight: 8,
+                        backgroundColor: const Color(0xFFEEF2F6),
+                        valueColor: const AlwaysStoppedAnimation<Color>(
+                          FigmaColors.primary,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
+                child: SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                      context.push(AppRoutes.aiCoach);
+                    },
+                    style: FilledButton.styleFrom(
+                      backgroundColor: FigmaColors.primary,
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(vertical: 15),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                    ),
+                    icon: const Icon(Icons.chat_bubble_outline_rounded, size: 19),
+                    label: const Text(
+                      'AI와 대화하기',
+                      style: TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CoachCardTile extends StatelessWidget {
+  const _CoachCardTile({required this.card});
+  final _CoachCard card;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: FigmaColors.hairline),
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.06),
+            blurRadius: 12,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+            decoration: BoxDecoration(
+              color: card.tagColor.withValues(alpha: 0.12),
+              borderRadius: BorderRadius.circular(999),
+            ),
+            child: Text(
+              card.tag,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+                color: card.tagColor,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  card.title,
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: FigmaColors.ink,
+                    height: 1.3,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  card.body,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    color: FigmaColors.textMuted,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (card.done) ...<Widget>[
+            const SizedBox(width: 8),
+            Container(
+              width: 20,
+              height: 20,
+              decoration: const BoxDecoration(
+                color: FigmaColors.primary,
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(Icons.check, size: 13, color: Colors.white),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _CloseButton extends StatelessWidget {
+  const _CloseButton({required this.onTap});
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: const Color(0xFFF4F6F8),
+      shape: const CircleBorder(),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: const SizedBox(
+          width: 32,
+          height: 32,
+          child: Icon(Icons.close, size: 16, color: FigmaColors.textSub),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/flutter/lib/shared/widgets/oni_fab.dart
+++ b/frontend/flutter/lib/shared/widgets/oni_fab.dart
@@ -19,6 +19,7 @@ class OniFab extends StatelessWidget {
         width: 56,
         height: 56,
         child: Stack(
+          alignment: Alignment.center,
           clipBehavior: Clip.none,
           children: <Widget>[
             Container(
@@ -50,7 +51,7 @@ class OniFab extends StatelessWidget {
                     border: Border.all(color: Colors.white, width: 2),
                   ),
                   child: Text(
-                    '$badgeCount',
+                    badgeCount > 9 ? '9+' : '$badgeCount',
                     style: const TextStyle(
                       fontSize: 10,
                       fontWeight: FontWeight.w800,

--- a/frontend/flutter/lib/shared/widgets/oni_fab.dart
+++ b/frontend/flutter/lib/shared/widgets/oni_fab.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+import 'package:oncare/design_system/figma/figma_kit.dart';
+
+/// The floating "Oni" assistant button shown on every main tab. Taps open the
+/// coaching sheet. A red badge shows the number of pending suggestions.
+/// Mirrors the Figma FAB.
+class OniFab extends StatelessWidget {
+  const OniFab({super.key, required this.onTap, this.badgeCount = 3});
+
+  final VoidCallback onTap;
+  final int badgeCount;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: SizedBox(
+        width: 56,
+        height: 56,
+        child: Stack(
+          clipBehavior: Clip.none,
+          children: <Widget>[
+            Container(
+              width: 52,
+              height: 52,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                boxShadow: <BoxShadow>[
+                  BoxShadow(
+                    color: FigmaColors.primary.withValues(alpha: 0.55),
+                    blurRadius: 22,
+                    offset: const Offset(0, 6),
+                  ),
+                ],
+              ),
+              child: const OniAvatar(size: 52, shadow: false),
+            ),
+            if (badgeCount > 0)
+              Positioned(
+                top: -2,
+                right: -2,
+                child: Container(
+                  width: 20,
+                  height: 20,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: FigmaColors.redDot,
+                    shape: BoxShape.circle,
+                    border: Border.all(color: Colors.white, width: 2),
+                  ),
+                  child: Text(
+                    '$badgeCount',
+                    style: const TextStyle(
+                      fontSize: 10,
+                      fontWeight: FontWeight.w800,
+                      color: Colors.white,
+                      height: 1,
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/flutter/web/index.html
+++ b/frontend/flutter/web/index.html
@@ -18,19 +18,70 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="Oncare prototype reconstructed in Flutter (Android / iOS / Web).">
+  <meta name="description" content="On-Care — 사진 한 장으로 식단을 기록하고, 트레이너에게 자동 요약 리포트를 전달하는 헬스케어 앱.">
 
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="oncare">
+  <meta name="apple-mobile-web-app-title" content="On-Care">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>oncare</title>
+  <title>On-Care</title>
   <link rel="manifest" href="manifest.json">
+
+  <!-- Ensure full Korean + emoji glyph coverage for the HTML web renderer.
+       Flutter renders text inside the <flt-glass-pane> shadow DOM with an empty
+       font-family, which can drop some Hangul/emoji glyphs. Setting the font on
+       the shadow HOST (flt-glass-pane / flutter-view / body) lets the shadow
+       content inherit it. Native (iOS/Android) rendering is unaffected. -->
+  <style>
+    flt-glass-pane, flutter-view, body {
+      font-family: 'Apple SD Gothic Neo', 'AppleGothic', 'Malgun Gothic',
+        'Noto Sans KR', 'Apple Color Emoji', 'Segoe UI Emoji',
+        'Noto Color Emoji', sans-serif !important;
+    }
+  </style>
+  <script>
+    // Flutter's HTML web renderer draws text inside the <flt-glass-pane> shadow
+    // DOM and does not re-pick-up the inherited font until a style recalc; dev
+    // (DDC) loads also render well after any fixed timeout. A MutationObserver
+    // re-asserts the font whenever the shadow DOM changes, so it works at any
+    // load speed and after scroll/navigation. Native/CanvasKit are unaffected.
+    (function () {
+      var STACK =
+        "'Apple SD Gothic Neo','AppleGothic','Malgun Gothic','Noto Sans KR','Apple Color Emoji','Segoe UI Emoji','Noto Color Emoji',sans-serif";
+      var el, pending = false;
+      function reapply() {
+        pending = false;
+        if (el) el.remove();
+        el = document.createElement('style');
+        el.textContent =
+          'flt-glass-pane, flutter-view, body { font-family: ' + STACK + ' !important; }';
+        document.head.appendChild(el);
+      }
+      function schedule() {
+        if (pending) return;
+        pending = true;
+        requestAnimationFrame(reapply);
+      }
+      (function watch() {
+        var gp = document.querySelector('flt-glass-pane');
+        if (gp && gp.shadowRoot) {
+          new MutationObserver(schedule).observe(gp.shadowRoot, {
+            childList: true,
+            subtree: true,
+            characterData: true,
+          });
+          reapply();
+        } else {
+          setTimeout(watch, 150);
+        }
+      })();
+    })();
+  </script>
 </head>
 <body>
   <script src="flutter_bootstrap.js" async></script>

--- a/frontend/flutter/web/manifest.json
+++ b/frontend/flutter/web/manifest.json
@@ -1,11 +1,11 @@
 {
-    "name": "oncare",
-    "short_name": "oncare",
+    "name": "On-Care",
+    "short_name": "On-Care",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",
     "theme_color": "#0175C2",
-    "description": "Oncare prototype reconstructed in Flutter (Android / iOS / Web).",
+    "description": "On-Care — 사진 한 장으로 식단을 기록하고, 트레이너에게 자동 요약 리포트를 전달하는 헬스케어 앱.",
     "orientation": "portrait-primary",
     "prefer_related_applications": false,
     "icons": [


### PR DESCRIPTION
## Summary
새 Figma 디자인에 맞춰 On-Care 사용자(회원) 앱 UI를 전면 재구성했습니다. 메인 색상 `#3EAFDF` 기반 새 디자인 토큰으로 홈·식단·운동·MY·AI 코치 화면과 하단 내비게이션을 다시 만들었습니다.

Closes #188

## Changes
- **디자인 시스템**: Figma 토큰(FigmaColors)·공용 위젯(코칭 시트·Oni FAB)
- **홈**: 요약 카드(식단/운동)·영양 현황·AI 코칭 배너 — 기존 건강지표·수면 코칭 카드 제거
- **식단**: 오늘 날짜 중앙 정렬 주간 달력, 식단 카드, 추가·결과·수정 플로우
- **운동**: 기록/헬스장 서브탭, 운동 추가·수정, 헬스장 정보·1:1 상담
- **MY**: 프로필·건강 목표·알림·고객지원 상세
- **AI 코치**: 채팅 화면
- **내비게이션**: 하단 탭 중앙 `+` 버튼(새 기록 추가 시트)·전역 코칭 FAB
- 표기 Oncare→On-Care, My→MY
- 웹 HTML 렌더러 한글·이모지 폰트 커버리지 보정

## Commits
1. `feat(design-system)`: Figma 토큰·공용 위젯
2. `feat(home)`: 홈 탭 재구성
3. `feat(diet)`: 식단 탭 재구성
4. `feat(exercise)`: 운동 탭 재구성
5. `feat(my)`: MY 탭 재구성
6. `feat(ai-coach)`: AI 코치 채팅 재구성
7. `feat(nav)`: 하단 + 버튼·새 기록 추가·코칭 FAB
8. `chore(l10n)`: Oncare→On-Care 표기
9. `fix(web)`: 폰트 커버리지·메타

## Notes
- 메인 색상 `#3EAFDF`, 탭 아이콘 모양 유지
- 트레이너 앱·소개(랜딩) 페이지(#187)는 범위 외
- `flutter analyze` 이슈 0, 모바일 웹 프리뷰로 홈/식단/운동/MY/코치 및 하단 `+` 버튼 동작 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 홈 하단에 중앙 “+” 버튼을 추가하고, 코칭 시트와 함께 기록 추가/식단·운동 추가·분석·수정을 하단 시트로 제공합니다.
  * AI 건강 코치의 요약 바텀시트와 채팅 화면을 신규 제공했습니다.
* **개선**
  * 대시보드·식단·운동·마이 건강 화면을 피그마 기반 UI로 재구성하고, 알림/캘린더/설정 진입 방식을 통일했습니다.
* **문구/디자인**
  * “On-Care” 표기와 일부 내비게이션 문구를 정리했으며, 디자인 시스템 컴포넌트를 확장했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->