### PR TITLE
feat(ui): 사용자 앱 나머지 실데이터 재연결

### DIFF
--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
+import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/features/exercise/presentation/widgets/exercise_flows.dart';
 import 'package:oncare/features/notification/presentation/widgets/notification_panel.dart';
@@ -1096,7 +1097,7 @@ class _LogCard extends StatelessWidget {
 
 // ───────────────────────────────────────────────────────── 헬스장 ──
 
-class _GymTab extends StatelessWidget {
+class _GymTab extends ConsumerWidget {
   const _GymTab({
     required this.selectedSlot,
     required this.onSlot,
@@ -1108,7 +1109,8 @@ class _GymTab extends StatelessWidget {
   final VoidCallback onFind;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AsyncValue<Gym?> gymAsync = ref.watch(myGymProvider);
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 20),
       child: Column(
@@ -1133,263 +1135,427 @@ class _GymTab extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 20),
-          Container(
-            padding: const EdgeInsets.all(16),
-            decoration: BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.circular(20),
-              border: Border.all(color: FigmaColors.hairline),
-              boxShadow: <BoxShadow>[
-                BoxShadow(
-                  color: Colors.black.withValues(alpha: 0.09),
-                  blurRadius: 24,
-                  offset: const Offset(0, 4),
+          gymAsync.when(
+            loading: () => const _GymLoading(),
+            error: (Object e, StackTrace _) =>
+                _GymError(onRetry: () => ref.invalidate(myGymProvider)),
+            data: (Gym? gym) => gym == null
+                ? const _GymEmpty()
+                : _MyGymCard(
+                    gym: gym,
+                    selectedSlot: selectedSlot,
+                    onSlot: onSlot,
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The "내 헬스장" card, driven by a real [Gym] from `myGymProvider` while
+/// keeping the Figma styling (white card, trainer row, AI 예약 배너, actions).
+class _MyGymCard extends StatelessWidget {
+  const _MyGymCard({
+    required this.gym,
+    required this.selectedSlot,
+    required this.onSlot,
+  });
+
+  final Gym gym;
+  final String? selectedSlot;
+  final ValueChanged<String> onSlot;
+
+  @override
+  Widget build(BuildContext context) {
+    final String trainer = gym.trainerName ?? '트레이너';
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: FigmaColors.hairline),
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.09),
+            blurRadius: 24,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          const Row(
+            children: <Widget>[
+              Icon(
+                Icons.place_outlined,
+                size: 15,
+                color: FigmaColors.primary,
+              ),
+              SizedBox(width: 6),
+              Text(
+                '내 헬스장',
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: FigmaColors.textMuted,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Text(
+            gym.name,
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w800,
+              color: FigmaColors.ink,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            '📍 ${gym.address} · ${gym.distanceKm.toStringAsFixed(1)}km',
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w500,
+              color: FigmaColors.textMuted,
+            ),
+          ),
+          if (gym.weekdayHours != null) ...<Widget>[
+            const SizedBox(height: 2),
+            Text(
+              '🕐 평일 ${gym.weekdayHours}'
+              '${gym.weekendHours != null ? ' · 주말 ${gym.weekendHours}' : ''}',
+              style: const TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+                color: FigmaColors.textMuted,
+              ),
+            ),
+          ],
+          if (gym.phone != null) ...<Widget>[
+            const SizedBox(height: 2),
+            Text(
+              '📞 ${gym.phone}',
+              style: const TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+                color: FigmaColors.textMuted,
+              ),
+            ),
+          ],
+          if (gym.trainerName != null) ...<Widget>[
+            const SizedBox(height: 14),
+            Row(
+              children: <Widget>[
+                Container(
+                  width: 36,
+                  height: 36,
+                  decoration: const BoxDecoration(
+                    color: Color(0xFFEEF2F6),
+                    shape: BoxShape.circle,
+                  ),
+                  child: const Icon(
+                    Icons.person_outline,
+                    size: 18,
+                    color: FigmaColors.textFaint,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      gym.trainerName!,
+                      style: const TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                        color: FigmaColors.ink,
+                      ),
+                    ),
+                    Text(
+                      gym.trainerRole ?? '전담 트레이너',
+                      style: const TextStyle(
+                        fontSize: 11,
+                        color: FigmaColors.textMuted,
+                      ),
+                    ),
+                  ],
                 ),
               ],
+            ),
+          ],
+          if (gym.tags.isNotEmpty) ...<Widget>[
+            const SizedBox(height: 14),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: <Widget>[
+                for (final String t in gym.tags)
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 5,
+                    ),
+                    decoration: BoxDecoration(
+                      color: FigmaColors.primaryA(0.10),
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                    child: Text(
+                      t,
+                      style: const TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                        color: FigmaColors.primary,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ],
+          const SizedBox(height: 14),
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              gradient: const LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: <Color>[
+                  FigmaColors.bannerStart,
+                  FigmaColors.bannerEnd,
+                ],
+              ),
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: FigmaColors.primaryA(0.18)),
             ),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-                const Row(
+                Row(
                   children: <Widget>[
-                    Icon(
-                      Icons.place_outlined,
-                      size: 15,
-                      color: FigmaColors.primary,
-                    ),
-                    SizedBox(width: 6),
-                    Text(
-                      '내 헬스장',
+                    const Text(
+                      '✦ AI 추천 예약 시간',
                       style: TextStyle(
-                        fontSize: 12,
-                        fontWeight: FontWeight.w600,
+                        fontSize: 10.5,
+                        fontWeight: FontWeight.w700,
+                        color: FigmaColors.primary,
+                      ),
+                    ),
+                    const SizedBox(width: 6),
+                    Text(
+                      '$trainer 빈 시간',
+                      style: const TextStyle(
+                        fontSize: 9,
+                        fontWeight: FontWeight.w500,
                         color: FigmaColors.textMuted,
                       ),
                     ),
                   ],
                 ),
                 const SizedBox(height: 10),
-                const Text(
-                  '강남 피트니스 센터',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w800,
-                    color: FigmaColors.ink,
-                  ),
-                ),
-                const SizedBox(height: 2),
-                const Text(
-                  '📍 서울시 강남구 역삼동 123-45 · 0.8km',
-                  style: TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w500,
-                    color: FigmaColors.textMuted,
-                  ),
-                ),
-                const SizedBox(height: 14),
-                Row(
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
                   children: <Widget>[
-                    Container(
-                      width: 36,
-                      height: 36,
-                      decoration: const BoxDecoration(
-                        color: Color(0xFFEEF2F6),
-                        shape: BoxShape.circle,
-                      ),
-                      child: const Icon(
-                        Icons.person_outline,
-                        size: 18,
-                        color: FigmaColors.textFaint,
-                      ),
-                    ),
-                    const SizedBox(width: 10),
-                    const Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        Text(
-                          '김트레이너',
-                          style: TextStyle(
-                            fontSize: 12,
-                            fontWeight: FontWeight.w700,
-                            color: FigmaColors.ink,
-                          ),
-                        ),
-                        Text(
-                          '전담 트레이너',
-                          style: TextStyle(
-                            fontSize: 11,
-                            color: FigmaColors.textMuted,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 14),
-                Row(
-                  children: <Widget>[
-                    for (final String t in <String>['다이어트', '재활운동'])
-                      Padding(
-                        padding: const EdgeInsets.only(right: 8),
-                        child: Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 12,
-                            vertical: 5,
-                          ),
-                          decoration: BoxDecoration(
-                            color: FigmaColors.primaryA(0.10),
-                            borderRadius: BorderRadius.circular(999),
-                          ),
-                          child: Text(
-                            t,
-                            style: const TextStyle(
-                              fontSize: 12,
-                              fontWeight: FontWeight.w700,
-                              color: FigmaColors.primary,
-                            ),
-                          ),
-                        ),
+                    for (final List<String> s in const <List<String>>[
+                      <String>['오늘 19:00', '잔여 1자리'],
+                      <String>['내일 07:30', '여유 있음'],
+                      <String>['내일 20:00', '잔여 2자리'],
+                    ])
+                      _SlotChip(
+                        label: s[0],
+                        sub: s[1],
+                        selected: selectedSlot == s[0],
+                        onTap: () => onSlot(s[0]),
                       ),
                   ],
                 ),
-                const SizedBox(height: 14),
-                Container(
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    gradient: const LinearGradient(
-                      begin: Alignment.topLeft,
-                      end: Alignment.bottomRight,
-                      colors: <Color>[
-                        FigmaColors.bannerStart,
-                        FigmaColors.bannerEnd,
-                      ],
+                if (selectedSlot != null) ...<Widget>[
+                  const SizedBox(height: 10),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton(
+                      onPressed: () {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text(
+                              '$selectedSlot · ${gym.name} 예약이 확정됐어요',
+                            ),
+                          ),
+                        );
+                      },
+                      style: FilledButton.styleFrom(
+                        backgroundColor: FigmaColors.primary,
+                        padding: const EdgeInsets.symmetric(vertical: 10),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      child: Text(
+                        '$selectedSlot 예약 확정',
+                        style: const TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
                     ),
-                    borderRadius: BorderRadius.circular(12),
-                    border: Border.all(color: FigmaColors.primaryA(0.18)),
                   ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: <Widget>[
-                      const Row(
-                        children: <Widget>[
-                          Text(
-                            '✦ AI 추천 예약 시간',
-                            style: TextStyle(
-                              fontSize: 10.5,
-                              fontWeight: FontWeight.w700,
-                              color: FigmaColors.primary,
-                            ),
-                          ),
-                          SizedBox(width: 6),
-                          Text(
-                            '김트레이너 빈 시간',
-                            style: TextStyle(
-                              fontSize: 9,
-                              fontWeight: FontWeight.w500,
-                              color: FigmaColors.textMuted,
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 10),
-                      Wrap(
-                        spacing: 8,
-                        runSpacing: 8,
-                        children: <Widget>[
-                          for (final List<String> s in const <List<String>>[
-                            <String>['오늘 19:00', '잔여 1자리'],
-                            <String>['내일 07:30', '여유 있음'],
-                            <String>['내일 20:00', '잔여 2자리'],
-                          ])
-                            _SlotChip(
-                              label: s[0],
-                              sub: s[1],
-                              selected: selectedSlot == s[0],
-                              onTap: () => onSlot(s[0]),
-                            ),
-                        ],
-                      ),
-                      if (selectedSlot != null) ...<Widget>[
-                        const SizedBox(height: 10),
-                        SizedBox(
-                          width: double.infinity,
-                          child: FilledButton(
-                            onPressed: () {
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(
-                                  content: Text('$selectedSlot 예약이 확정됐어요'),
-                                ),
-                              );
-                            },
-                            style: FilledButton.styleFrom(
-                              backgroundColor: FigmaColors.primary,
-                              padding: const EdgeInsets.symmetric(vertical: 10),
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(12),
-                              ),
-                            ),
-                            child: Text(
-                              '$selectedSlot 예약 확정',
-                              style: const TextStyle(
-                                fontSize: 12,
-                                fontWeight: FontWeight.w700,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ],
-                  ),
-                ),
-                const SizedBox(height: 14),
-                const Divider(height: 1, color: FigmaColors.hairline),
-                const SizedBox(height: 12),
-                Row(
-                  children: <Widget>[
-                    Expanded(
-                      child: OutlinedButton(
-                        onPressed: () => showGymInfoSheet(context),
-                        style: OutlinedButton.styleFrom(
-                          foregroundColor: FigmaColors.primary,
-                          backgroundColor: FigmaColors.softBlue,
-                          side: BorderSide(color: FigmaColors.primaryA(0.18)),
-                          padding: const EdgeInsets.symmetric(vertical: 11),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                        ),
-                        child: const Text(
-                          '헬스장 정보',
-                          style: TextStyle(
-                            fontSize: 12,
-                            fontWeight: FontWeight.w700,
-                          ),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: 8),
-                    Expanded(
-                      child: FilledButton(
-                        onPressed: () => showGymChatSheet(context),
-                        style: FilledButton.styleFrom(
-                          backgroundColor: FigmaColors.primary,
-                          padding: const EdgeInsets.symmetric(vertical: 11),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                        ),
-                        child: const Text(
-                          '💬 1:1 상담',
-                          style: TextStyle(
-                            fontSize: 12,
-                            fontWeight: FontWeight.w700,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
+                ],
               ],
+            ),
+          ),
+          const SizedBox(height: 14),
+          const Divider(height: 1, color: FigmaColors.hairline),
+          const SizedBox(height: 12),
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: () => showGymInfoSheet(context, gym),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: FigmaColors.primary,
+                    backgroundColor: FigmaColors.softBlue,
+                    side: BorderSide(color: FigmaColors.primaryA(0.18)),
+                    padding: const EdgeInsets.symmetric(vertical: 11),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: const Text(
+                    '헬스장 정보',
+                    style: TextStyle(fontSize: 12, fontWeight: FontWeight.w700),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: FilledButton(
+                  onPressed: () => showGymChatSheet(context, gym: gym),
+                  style: FilledButton.styleFrom(
+                    backgroundColor: FigmaColors.primary,
+                    padding: const EdgeInsets.symmetric(vertical: 11),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: const Text(
+                    '💬 1:1 상담',
+                    style: TextStyle(fontSize: 12, fontWeight: FontWeight.w700),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Spinner shown while `myGymProvider` resolves.
+class _GymLoading extends StatelessWidget {
+  const _GymLoading();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.symmetric(vertical: 48),
+      child: Center(
+        child: SizedBox(
+          width: 28,
+          height: 28,
+          child: CircularProgressIndicator(strokeWidth: 3),
+        ),
+      ),
+    );
+  }
+}
+
+/// Retry state shown when `myGymProvider` fails.
+class _GymError extends StatelessWidget {
+  const _GymError({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 40),
+      child: Column(
+        children: <Widget>[
+          const Text(
+            '헬스장 정보를 불러오지 못했어요.',
+            style: TextStyle(fontSize: 13, color: FigmaColors.textMuted),
+          ),
+          const SizedBox(height: 14),
+          OutlinedButton(
+            onPressed: onRetry,
+            style: OutlinedButton.styleFrom(
+              foregroundColor: FigmaColors.primary,
+              side: BorderSide(color: FigmaColors.primaryA(0.4)),
+            ),
+            child: const Text('다시 시도'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Empty state shown when the user has no registered gym.
+class _GymEmpty extends StatelessWidget {
+  const _GymEmpty();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: FigmaColors.hairline),
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.09),
+            blurRadius: 24,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Column(
+        children: <Widget>[
+          Container(
+            width: 56,
+            height: 56,
+            decoration: BoxDecoration(
+              color: FigmaColors.primaryA(0.10),
+              shape: BoxShape.circle,
+            ),
+            alignment: Alignment.center,
+            child: const Icon(
+              Icons.fitness_center,
+              size: 24,
+              color: FigmaColors.primary,
+            ),
+          ),
+          const SizedBox(height: 14),
+          const Text(
+            '등록된 헬스장이 없어요',
+            style: TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w700,
+              color: FigmaColors.ink,
+            ),
+          ),
+          const SizedBox(height: 4),
+          const Text(
+            '헬스장 찾기로 주변 헬스장을 등록해 보세요',
+            style: TextStyle(
+              fontSize: 12.5,
+              fontWeight: FontWeight.w500,
+              color: FigmaColors.textMuted,
             ),
           ),
         ],

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
+import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 
 const List<String> _weekdayLabels = <String>['월', '화', '수', '목', '금', '토', '일'];
@@ -355,15 +356,53 @@ class _Label extends StatelessWidget {
 
 // ─────────────────────────────────────────────────────── 헬스장 찾기 ──
 
-/// "헬스장 찾기" — a search field, a map placeholder, and nearby gym cards.
+/// "헬스장 찾기" — a live search field, a map placeholder, and the nearby
+/// gym list from [nearbyGymsProvider], filtered by the query.
 Future<void> showGymLocatorSheet(BuildContext context) {
   return showModalBottomSheet<void>(
     context: context,
     isScrollControlled: true,
     backgroundColor: Colors.transparent,
     barrierColor: FigmaColors.sheetScrim,
-    builder: (BuildContext ctx) => _shell(
-      ctx,
+    builder: (BuildContext ctx) => const _GymLocatorSheet(),
+  );
+}
+
+class _GymLocatorSheet extends ConsumerStatefulWidget {
+  const _GymLocatorSheet();
+
+  @override
+  ConsumerState<_GymLocatorSheet> createState() => _GymLocatorSheetState();
+}
+
+class _GymLocatorSheetState extends ConsumerState<_GymLocatorSheet> {
+  final TextEditingController _search = TextEditingController();
+  String _query = '';
+
+  @override
+  void dispose() {
+    _search.dispose();
+    super.dispose();
+  }
+
+  /// Case-insensitive match on gym name or address; empty query returns all.
+  List<Gym> _filter(List<Gym> gyms) {
+    final String q = _query.trim().toLowerCase();
+    if (q.isEmpty) return gyms;
+    return gyms
+        .where(
+          (Gym g) =>
+              g.name.toLowerCase().contains(q) ||
+              g.address.toLowerCase().contains(q),
+        )
+        .toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AsyncValue<List<Gym>> async = ref.watch(nearbyGymsProvider);
+    return _shell(
+      context,
       Column(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
@@ -377,7 +416,7 @@ Future<void> showGymLocatorSheet(BuildContext context) {
                   shape: const CircleBorder(),
                   clipBehavior: Clip.antiAlias,
                   child: InkWell(
-                    onTap: () => Navigator.of(ctx).pop(),
+                    onTap: () => Navigator.of(context).pop(),
                     child: const SizedBox(
                       width: 32,
                       height: 32,
@@ -407,29 +446,56 @@ Future<void> showGymLocatorSheet(BuildContext context) {
               padding: const EdgeInsets.fromLTRB(20, 4, 20, 28),
               children: <Widget>[
                 Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 14,
-                    vertical: 12,
-                  ),
+                  padding: const EdgeInsets.symmetric(horizontal: 14),
                   decoration: BoxDecoration(
                     color: FigmaColors.statBg,
                     borderRadius: BorderRadius.circular(14),
                   ),
-                  child: const Row(
+                  child: Row(
                     children: <Widget>[
-                      Icon(
+                      const Icon(
                         Icons.search,
                         size: 16,
                         color: FigmaColors.textFaint,
                       ),
-                      SizedBox(width: 8),
-                      Text(
-                        '신촌 · 헬스장, 트레이너',
-                        style: TextStyle(
-                          fontSize: 13,
-                          color: FigmaColors.textFaint,
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: TextField(
+                          controller: _search,
+                          onChanged: (String v) => setState(() => _query = v),
+                          textInputAction: TextInputAction.search,
+                          style: const TextStyle(
+                            fontSize: 13,
+                            color: FigmaColors.ink,
+                          ),
+                          decoration: const InputDecoration(
+                            isDense: true,
+                            border: InputBorder.none,
+                            hintText: '헬스장, 지역으로 검색',
+                            hintStyle: TextStyle(
+                              fontSize: 13,
+                              color: FigmaColors.textFaint,
+                            ),
+                            contentPadding: EdgeInsets.symmetric(vertical: 12),
+                          ),
                         ),
                       ),
+                      if (_query.isNotEmpty)
+                        GestureDetector(
+                          behavior: HitTestBehavior.opaque,
+                          onTap: () {
+                            _search.clear();
+                            setState(() => _query = '');
+                          },
+                          child: const Padding(
+                            padding: EdgeInsets.only(left: 6),
+                            child: Icon(
+                              Icons.close,
+                              size: 15,
+                              color: FigmaColors.textFaint,
+                            ),
+                          ),
+                        ),
                     ],
                   ),
                 ),
@@ -451,51 +517,107 @@ Future<void> showGymLocatorSheet(BuildContext context) {
                   ],
                 ),
                 const SizedBox(height: 12),
-                const _GymResult(
-                  name: '온케어짐 신촌점',
-                  rating: '4.9',
-                  distance: '320m',
-                  meta: 'PT · GX · 24시간 · 트레이너 6명',
-                  reason: '민수님의 혈압 관리 목표에 가장 적합해요. 저강도 유산소 전문 트레이너가 상주해요.',
-                  tags: <String>['혈압 관리 전문 PT', '저강도 프로그램 운영'],
-                  top: true,
-                ),
-                const SizedBox(height: 12),
-                const _GymResult(
-                  name: '파워짐 연세점',
-                  rating: '4.7',
-                  distance: '540m',
-                  meta: 'PT · 필라테스 · 트레이너 4명',
-                  reason: '근력 강화에 특화된 프로그램과 필라테스를 병행할 수 있어요.',
-                  tags: <String>['근력 강화 특화', '필라테스 병행 가능'],
+                ...async.when(
+                  data: (List<Gym> gyms) {
+                    final List<Gym> results = _filter(gyms);
+                    if (results.isEmpty) {
+                      return <Widget>[
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 32),
+                          child: Center(
+                            child: Text(
+                              "'$_query'에 맞는 헬스장이 없어요",
+                              style: const TextStyle(
+                                fontSize: 13,
+                                fontWeight: FontWeight.w500,
+                                color: FigmaColors.textMuted,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ];
+                    }
+                    return <Widget>[
+                      for (int i = 0; i < results.length; i++) ...<Widget>[
+                        _GymResult(
+                          gym: results[i],
+                          top: _query.trim().isEmpty && i == 0,
+                        ),
+                        const SizedBox(height: 12),
+                      ],
+                    ];
+                  },
+                  loading: () => const <Widget>[
+                    Padding(
+                      padding: EdgeInsets.symmetric(vertical: 40),
+                      child: Center(
+                        child: SizedBox(
+                          width: 26,
+                          height: 26,
+                          child: CircularProgressIndicator(strokeWidth: 3),
+                        ),
+                      ),
+                    ),
+                  ],
+                  error: (Object e, StackTrace _) => <Widget>[
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 32),
+                      child: Column(
+                        children: <Widget>[
+                          const Text(
+                            '헬스장을 불러오지 못했어요.',
+                            style: TextStyle(
+                              fontSize: 13,
+                              color: FigmaColors.textMuted,
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          OutlinedButton(
+                            onPressed: () =>
+                                ref.invalidate(nearbyGymsProvider),
+                            style: OutlinedButton.styleFrom(
+                              foregroundColor: FigmaColors.primary,
+                              side: BorderSide(color: FigmaColors.primaryA(0.4)),
+                            ),
+                            child: const Text('다시 시도'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
                 ),
               ],
             ),
           ),
         ],
       ),
-    ),
-  );
+    );
+  }
 }
 
+/// A nearby-gym result card driven by a real [Gym]. The two actions wire to
+/// local flows (there is no O2O endpoint): 트레이너 채팅 opens the 1:1 상담
+/// sheet, 건강 요약 전달 confirms then shows a success SnackBar.
 class _GymResult extends StatelessWidget {
-  const _GymResult({
-    required this.name,
-    required this.rating,
-    required this.distance,
-    required this.meta,
-    required this.reason,
-    required this.tags,
-    this.top = false,
-  });
+  const _GymResult({required this.gym, this.top = false});
 
-  final String name;
-  final String rating;
-  final String distance;
-  final String meta;
-  final String reason;
-  final List<String> tags;
+  final Gym gym;
   final bool top;
+
+  /// A short, real-data reason line for the AI-styled highlight box.
+  String get _reason {
+    if (gym.trainerName != null) {
+      final String role = gym.trainerRole != null ? ' · ${gym.trainerRole}' : '';
+      return '전담 트레이너 ${gym.trainerName}$role 상주';
+    }
+    if (gym.weekdayHours != null) {
+      final String weekend = gym.weekendHours != null
+          ? ' · 주말 ${gym.weekendHours}'
+          : '';
+      return '평일 ${gym.weekdayHours}$weekend 운영';
+    }
+    return '';
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -520,7 +642,7 @@ class _GymResult extends StatelessWidget {
         children: <Widget>[
           if (top) ...<Widget>[
             const AiPill(
-              '✦ AI 1순위 추천  민수님 건강 목표 기반',
+              '✦ AI 추천 1순위',
               background: FigmaColors.primary,
               color: Colors.white,
             ),
@@ -534,7 +656,7 @@ class _GymResult extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
                     Text(
-                      name,
+                      gym.name,
                       style: const TextStyle(
                         fontSize: 15,
                         fontWeight: FontWeight.w800,
@@ -543,7 +665,7 @@ class _GymResult extends StatelessWidget {
                     ),
                     const SizedBox(height: 2),
                     Text(
-                      meta,
+                      gym.address,
                       style: const TextStyle(
                         fontSize: 11,
                         color: FigmaColors.textMuted,
@@ -564,7 +686,7 @@ class _GymResult extends StatelessWidget {
                       ),
                       const SizedBox(width: 2),
                       Text(
-                        rating,
+                        gym.rating.toStringAsFixed(1),
                         style: const TextStyle(
                           fontSize: 13,
                           fontWeight: FontWeight.w800,
@@ -574,7 +696,7 @@ class _GymResult extends StatelessWidget {
                     ],
                   ),
                   Text(
-                    distance,
+                    '${gym.distanceKm.toStringAsFixed(1)}km',
                     style: const TextStyle(
                       fontSize: 11,
                       color: FigmaColors.textMuted,
@@ -584,59 +706,63 @@ class _GymResult extends StatelessWidget {
               ),
             ],
           ),
-          const SizedBox(height: 10),
-          Container(
-            padding: const EdgeInsets.all(10),
-            decoration: BoxDecoration(
-              color: FigmaColors.softBlue,
-              borderRadius: BorderRadius.circular(12),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Wrap(
-                  spacing: 6,
-                  runSpacing: 6,
-                  children: <Widget>[
-                    for (final String t in tags)
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 8,
-                          vertical: 3,
-                        ),
-                        decoration: BoxDecoration(
-                          color: FigmaColors.primaryA(0.12),
-                          borderRadius: BorderRadius.circular(999),
-                        ),
-                        child: Text(
-                          '✦ AI 추천 이유  $t',
-                          style: const TextStyle(
-                            fontSize: 9.5,
-                            fontWeight: FontWeight.w700,
-                            color: FigmaColors.primary,
+          if (gym.tags.isNotEmpty) ...<Widget>[
+            const SizedBox(height: 10),
+            Container(
+              padding: const EdgeInsets.all(10),
+              decoration: BoxDecoration(
+                color: FigmaColors.softBlue,
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Wrap(
+                    spacing: 6,
+                    runSpacing: 6,
+                    children: <Widget>[
+                      for (final String t in gym.tags)
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 8,
+                            vertical: 3,
+                          ),
+                          decoration: BoxDecoration(
+                            color: FigmaColors.primaryA(0.12),
+                            borderRadius: BorderRadius.circular(999),
+                          ),
+                          child: Text(
+                            t,
+                            style: const TextStyle(
+                              fontSize: 9.5,
+                              fontWeight: FontWeight.w700,
+                              color: FigmaColors.primary,
+                            ),
                           ),
                         ),
-                      ),
-                  ],
-                ),
-                const SizedBox(height: 6),
-                Text(
-                  reason,
-                  style: const TextStyle(
-                    fontSize: 11,
-                    height: 1.5,
-                    color: FigmaColors.ink,
+                    ],
                   ),
-                ),
-              ],
+                  if (_reason.isNotEmpty) ...<Widget>[
+                    const SizedBox(height: 6),
+                    Text(
+                      _reason,
+                      style: const TextStyle(
+                        fontSize: 11,
+                        height: 1.5,
+                        color: FigmaColors.ink,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
             ),
-          ),
+          ],
           const SizedBox(height: 12),
           Row(
             children: <Widget>[
               Expanded(
                 child: FilledButton(
-                  onPressed: () {},
+                  onPressed: () => showGymChatSheet(context, gym: gym),
                   style: FilledButton.styleFrom(
                     backgroundColor: FigmaColors.primary,
                     padding: const EdgeInsets.symmetric(vertical: 10),
@@ -653,7 +779,7 @@ class _GymResult extends StatelessWidget {
               const SizedBox(width: 8),
               Expanded(
                 child: OutlinedButton(
-                  onPressed: () {},
+                  onPressed: () => _sendHealthSummary(context, gym.name),
                   style: OutlinedButton.styleFrom(
                     foregroundColor: FigmaColors.primary,
                     side: BorderSide(color: FigmaColors.primaryA(0.3)),
@@ -674,6 +800,55 @@ class _GymResult extends StatelessWidget {
       ),
     );
   }
+}
+
+/// Confirms and "sends" the user's health summary to the gym/trainer. There is
+/// no O2O backend yet, so this is a local confirm dialog + success SnackBar.
+Future<void> _sendHealthSummary(BuildContext context, String gymName) async {
+  final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+  final bool? confirmed = await showDialog<bool>(
+    context: context,
+    builder: (BuildContext ctx) => AlertDialog(
+      backgroundColor: Colors.white,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+      ),
+      title: const Text(
+        '건강 요약 전달',
+        style: TextStyle(
+          fontSize: 16,
+          fontWeight: FontWeight.w800,
+          color: FigmaColors.ink,
+        ),
+      ),
+      content: Text(
+        '최근 운동 기록과 건강 프로필 요약을\n$gymName 트레이너에게 전달할까요?',
+        style: const TextStyle(
+          fontSize: 13,
+          height: 1.5,
+          color: FigmaColors.textSub,
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(ctx).pop(false),
+          child: const Text(
+            '취소',
+            style: TextStyle(color: FigmaColors.textMuted),
+          ),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(ctx).pop(true),
+          style: FilledButton.styleFrom(backgroundColor: FigmaColors.primary),
+          child: const Text('전달하기'),
+        ),
+      ],
+    ),
+  );
+  if (confirmed != true) return;
+  messenger.showSnackBar(
+    SnackBar(content: Text('$gymName에 건강 요약을 전달했어요')),
+  );
 }
 
 Widget _closeBtn(BuildContext ctx) => Material(
@@ -864,8 +1039,15 @@ class _MapPainter extends CustomPainter {
 
 // ─────────────────────────────────────────────────────── 헬스장 정보 ──
 
-/// Gym detail sheet opened from the "헬스장 정보" button.
-Future<void> showGymInfoSheet(BuildContext context) {
+/// Gym detail sheet opened from the "헬스장 정보" button, driven by [gym].
+Future<void> showGymInfoSheet(BuildContext context, Gym gym) {
+  final String hours = gym.weekdayHours != null
+      ? '평일 ${gym.weekdayHours}'
+            '${gym.weekendHours != null ? '\n주말 ${gym.weekendHours}' : ''}'
+      : '';
+  final String trainer = gym.trainerName != null
+      ? '${gym.trainerName}${gym.trainerRole != null ? ' · ${gym.trainerRole}' : ''}'
+      : '';
   return showModalBottomSheet<void>(
     context: context,
     isScrollControlled: true,
@@ -902,33 +1084,25 @@ Future<void> showGymInfoSheet(BuildContext context) {
               children: <Widget>[
                 const _MapPlaceholder(),
                 const SizedBox(height: 14),
-                const Text(
-                  '강남 피트니스 센터',
-                  style: TextStyle(
+                Text(
+                  gym.name,
+                  style: const TextStyle(
                     fontSize: 18,
                     fontWeight: FontWeight.w800,
                     color: FigmaColors.ink,
                   ),
                 ),
                 const SizedBox(height: 4),
-                const Row(
+                Row(
                   children: <Widget>[
-                    Icon(Icons.star, size: 15, color: Color(0xFFF5B400)),
-                    SizedBox(width: 3),
+                    const Icon(Icons.star, size: 15, color: Color(0xFFF5B400)),
+                    const SizedBox(width: 3),
                     Text(
-                      '4.8',
-                      style: TextStyle(
+                      gym.rating.toStringAsFixed(1),
+                      style: const TextStyle(
                         fontSize: 13,
                         fontWeight: FontWeight.w800,
                         color: FigmaColors.ink,
-                      ),
-                    ),
-                    SizedBox(width: 6),
-                    Text(
-                      '· 리뷰 213',
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: FigmaColors.textMuted,
                       ),
                     ),
                   ],
@@ -937,13 +1111,20 @@ Future<void> showGymInfoSheet(BuildContext context) {
                 _infoRow(
                   Icons.place_outlined,
                   '주소',
-                  '서울시 강남구 역삼동 123-45 · 0.8km',
+                  '${gym.address} · ${gym.distanceKm.toStringAsFixed(1)}km',
                 ),
-                _infoRow(Icons.schedule, '운영시간', '연중무휴 24시간'),
-                _infoRow(Icons.call_outlined, '전화', '02-1234-5678'),
-                _infoRow(Icons.fitness_center, '시설', 'PT · GX · 샤워실 · 주차'),
-                _infoRow(Icons.payments_outlined, '회원권', '3개월 27만원 · 6개월 48만원'),
-                _infoRow(Icons.person_outline, '전담 트레이너', '김트레이너 · 혈압 관리 전문'),
+                if (hours.isNotEmpty)
+                  _infoRow(Icons.schedule, '운영시간', hours),
+                if (gym.phone != null)
+                  _infoRow(Icons.call_outlined, '전화', gym.phone!),
+                if (gym.tags.isNotEmpty)
+                  _infoRow(
+                    Icons.fitness_center,
+                    '전문 분야',
+                    gym.tags.join(' · '),
+                  ),
+                if (trainer.isNotEmpty)
+                  _infoRow(Icons.person_outline, '전담 트레이너', trainer),
               ],
             ),
           ),
@@ -955,14 +1136,15 @@ Future<void> showGymInfoSheet(BuildContext context) {
 
 // ─────────────────────────────────────────────────────── 1:1 상담 ──
 
-/// 1:1 consultation chat with the gym's trainer.
-Future<void> showGymChatSheet(BuildContext context) {
+/// 1:1 consultation chat with the gym's trainer, personalised from [gym].
+Future<void> showGymChatSheet(BuildContext context, {Gym? gym}) {
   return showModalBottomSheet<void>(
     context: context,
     isScrollControlled: true,
     backgroundColor: Colors.transparent,
     barrierColor: FigmaColors.sheetScrim,
-    builder: (BuildContext ctx) => const _GymChatSheet(),
+    builder: (BuildContext ctx) =>
+        _GymChatSheet(trainerName: gym?.trainerName, gymName: gym?.name),
   );
 }
 
@@ -973,7 +1155,10 @@ class _GymMsg {
 }
 
 class _GymChatSheet extends StatefulWidget {
-  const _GymChatSheet();
+  const _GymChatSheet({this.trainerName, this.gymName});
+
+  final String? trainerName;
+  final String? gymName;
 
   @override
   State<_GymChatSheet> createState() => _GymChatSheetState();
@@ -981,8 +1166,10 @@ class _GymChatSheet extends StatefulWidget {
 
 class _GymChatSheetState extends State<_GymChatSheet> {
   final TextEditingController _c = TextEditingController();
-  final List<_GymMsg> _msgs = <_GymMsg>[
-    const _GymMsg('안녕하세요, 김트레이너입니다. 😊\n무엇을 도와드릴까요?', mine: false),
+  late final String _trainer = widget.trainerName ?? '김트레이너';
+  late final String _gym = widget.gymName ?? '강남 피트니스 센터';
+  late final List<_GymMsg> _msgs = <_GymMsg>[
+    _GymMsg('안녕하세요, $_trainer입니다. 😊\n무엇을 도와드릴까요?', mine: false),
   ];
   static const List<String> _chips = <String>['PT 상담', '이용권 문의', '방문 예약'];
 
@@ -1035,21 +1222,21 @@ class _GymChatSheetState extends State<_GymChatSheet> {
                   ),
                 ),
                 const SizedBox(width: 10),
-                const Expanded(
+                Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
                       Text(
-                        '김트레이너',
-                        style: TextStyle(
+                        _trainer,
+                        style: const TextStyle(
                           fontSize: 15,
                           fontWeight: FontWeight.w800,
                           color: FigmaColors.ink,
                         ),
                       ),
                       Text(
-                        '강남 피트니스 센터 · 1:1 상담',
-                        style: TextStyle(
+                        '$_gym · 1:1 상담',
+                        style: const TextStyle(
                           fontSize: 11.5,
                           color: FigmaColors.primary,
                           fontWeight: FontWeight.w600,

--- a/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
@@ -1,6 +1,11 @@
 import 'package:flutter/material.dart';
-
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:oncare/core/storage/prefs_store.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/features/account/domain/entities/user_profile.dart';
+import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 Widget _shell(BuildContext context, String title, List<Widget> children) {
   return SafeArea(
@@ -97,13 +102,31 @@ Widget _card(List<Widget> children) => Container(
   ),
 );
 
-Widget _field(String label, String value) => Padding(
-  padding: const EdgeInsets.symmetric(vertical: 8),
-  child: Row(
-    children: <Widget>[
-      SizedBox(
-        width: 84,
-        child: Text(
+/// Figma-styled label + editable text field used by the profile and goal
+/// sheets. White fill on the `statBg` card, brand-blue focus ring.
+class _SheetField extends StatelessWidget {
+  const _SheetField({
+    required this.label,
+    required this.controller,
+    this.keyboardType,
+    this.inputFormatters,
+    this.suffix,
+    this.hintText,
+  });
+
+  final String label;
+  final TextEditingController controller;
+  final TextInputType? keyboardType;
+  final List<TextInputFormatter>? inputFormatters;
+  final String? suffix;
+  final String? hintText;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
           label,
           style: const TextStyle(
             fontSize: 12,
@@ -111,134 +134,445 @@ Widget _field(String label, String value) => Padding(
             color: FigmaColors.textMuted,
           ),
         ),
-      ),
-      Expanded(
-        child: Text(
-          value,
+        const SizedBox(height: 6),
+        TextField(
+          controller: controller,
+          keyboardType: keyboardType,
+          inputFormatters: inputFormatters,
           style: const TextStyle(
             fontSize: 14,
             fontWeight: FontWeight.w700,
             color: FigmaColors.ink,
           ),
+          decoration: InputDecoration(
+            isDense: true,
+            filled: true,
+            fillColor: Colors.white,
+            hintText: hintText,
+            hintStyle: const TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+              color: FigmaColors.textFaint,
+            ),
+            suffixText: suffix,
+            suffixStyle: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: FigmaColors.textMuted,
+            ),
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: 14,
+              vertical: 12,
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: const BorderSide(color: FigmaColors.hairline),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: const BorderSide(color: FigmaColors.primary, width: 1.4),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// The gradient profile disc with the member's initial.
+class _Avatar extends StatelessWidget {
+  const _Avatar({required this.initial});
+  final String initial;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 64,
+      height: 64,
+      alignment: Alignment.center,
+      decoration: const BoxDecoration(
+        shape: BoxShape.circle,
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: <Color>[FigmaColors.primary, FigmaColors.primaryDeep],
+        ),
+      ),
+      child: Text(
+        initial,
+        style: const TextStyle(
+          fontSize: 22,
+          fontWeight: FontWeight.w800,
+          color: Colors.white,
+        ),
+      ),
+    );
+  }
+}
+
+/// Spinner shown inside a sheet while `profileProvider` is loading.
+class _SheetLoader extends StatelessWidget {
+  const _SheetLoader();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.symmetric(vertical: 40),
+      child: Center(child: CircularProgressIndicator(color: FigmaColors.primary)),
+    );
+  }
+}
+
+/// The 취소 · 저장 footer shared by the profile and goal sheets. The primary
+/// button shows a spinner and both buttons disable while [saving].
+Widget _saveRow({
+  required BuildContext context,
+  required bool saving,
+  required VoidCallback onSave,
+}) {
+  return Row(
+    children: <Widget>[
+      Expanded(
+        child: OutlinedButton(
+          onPressed: saving ? null : () => Navigator.of(context).pop(),
+          style: OutlinedButton.styleFrom(
+            foregroundColor: FigmaColors.textSub,
+            side: const BorderSide(color: FigmaColors.hairline),
+            padding: const EdgeInsets.symmetric(vertical: 14),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(14),
+            ),
+          ),
+          child: const Text(
+            '취소',
+            style: TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
+          ),
+        ),
+      ),
+      const SizedBox(width: 12),
+      Expanded(
+        child: FilledButton(
+          onPressed: saving ? null : onSave,
+          style: FilledButton.styleFrom(
+            backgroundColor: FigmaColors.primary,
+            padding: const EdgeInsets.symmetric(vertical: 14),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(14),
+            ),
+          ),
+          child: saving
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: Colors.white,
+                  ),
+                )
+              : const Text(
+                  '저장',
+                  style: TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
+                ),
         ),
       ),
     ],
-  ),
-);
+  );
+}
 
 // ───────────────────────────────────────────────────────── 내 프로필 ──
 
-/// Profile detail — mirrors the profile card + body basics shown in the app.
+/// Profile editor — pre-fills from `profileProvider` and persists via
+/// `AccountRepository.updateProfile`.
 Future<void> showProfileSheet(BuildContext context) {
-  return _open(context, '내 프로필', <Widget>[
-    Center(
-      child: Container(
-        width: 64,
-        height: 64,
-        alignment: Alignment.center,
-        decoration: const BoxDecoration(
-          shape: BoxShape.circle,
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: <Color>[FigmaColors.primary, FigmaColors.primaryDeep],
-          ),
-        ),
-        child: const Text(
-          '김',
-          style: TextStyle(
-            fontSize: 22,
-            fontWeight: FontWeight.w800,
-            color: Colors.white,
-          ),
-        ),
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    barrierColor: FigmaColors.sheetScrim,
+    builder: (BuildContext ctx) => const _ProfileSheet(),
+  );
+}
+
+class _ProfileSheet extends ConsumerWidget {
+  const _ProfileSheet();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AsyncValue<UserProfile> profile = ref.watch(profileProvider);
+    return profile.when(
+      data: (UserProfile p) => _ProfileForm(initial: p),
+      loading: () => _shell(context, '내 프로필', const <Widget>[_SheetLoader()]),
+      error: (_, _) => const _ProfileForm(
+        initial: UserProfile(id: '', name: '', email: ''),
       ),
-    ),
-    const SizedBox(height: 16),
-    _card(<Widget>[
-      _field('이름', '김민수'),
-      const Divider(height: 1, color: FigmaColors.hairline),
-      _field('이메일', 'minsu@oncare.com'),
-      const Divider(height: 1, color: FigmaColors.hairline),
-      _field('생년월일', '1996. 03. 21.'),
-    ]),
-    const SizedBox(height: 12),
-    _card(<Widget>[
-      _field('키', '172 cm'),
-      const Divider(height: 1, color: FigmaColors.hairline),
-      _field('체중', '68 kg'),
-      const Divider(height: 1, color: FigmaColors.hairline),
-      _field('관리 목표', '혈압 관리 · 체중 감량'),
-    ]),
-    const SizedBox(height: 16),
-    _saveButton(context, '프로필이 저장되었어요'),
-  ]);
+    );
+  }
+}
+
+class _ProfileForm extends ConsumerStatefulWidget {
+  const _ProfileForm({required this.initial});
+  final UserProfile initial;
+
+  @override
+  ConsumerState<_ProfileForm> createState() => _ProfileFormState();
+}
+
+class _ProfileFormState extends ConsumerState<_ProfileForm> {
+  late final TextEditingController _name = TextEditingController(
+    text: widget.initial.name,
+  );
+  late final TextEditingController _email = TextEditingController(
+    text: widget.initial.email,
+  );
+  late final TextEditingController _phone = TextEditingController(
+    text: widget.initial.phone,
+  );
+  late final TextEditingController _birth = TextEditingController(
+    text: widget.initial.birthDate,
+  );
+  bool _saving = false;
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _email.dispose();
+    _phone.dispose();
+    _birth.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    if (_saving) return;
+    final NavigatorState navigator = Navigator.of(context);
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    setState(() => _saving = true);
+    try {
+      await ref.read(accountRepositoryProvider).updateProfile(
+        name: _name.text.trim(),
+        email: _email.text.trim(),
+        phone: _phone.text.trim(),
+        birthDate: _birth.text.trim(),
+      );
+      ref.invalidate(profileProvider);
+      navigator.pop();
+      messenger.showSnackBar(
+        const SnackBar(content: Text('프로필이 저장되었어요')),
+      );
+    } catch (_) {
+      if (mounted) setState(() => _saving = false);
+      messenger.showSnackBar(
+        const SnackBar(content: Text('저장에 실패했어요. 잠시 후 다시 시도해 주세요')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final String name = widget.initial.name.trim();
+    final String initial = name.isNotEmpty ? name.substring(0, 1) : '·';
+    return _shell(context, '내 프로필', <Widget>[
+      Center(child: _Avatar(initial: initial)),
+      const SizedBox(height: 16),
+      _card(<Widget>[
+        _SheetField(label: '이름', controller: _name),
+        const SizedBox(height: 12),
+        _SheetField(
+          label: '이메일',
+          controller: _email,
+          keyboardType: TextInputType.emailAddress,
+        ),
+        const SizedBox(height: 12),
+        _SheetField(
+          label: '전화번호',
+          controller: _phone,
+          keyboardType: TextInputType.phone,
+        ),
+        const SizedBox(height: 12),
+        _SheetField(
+          label: '생년월일',
+          controller: _birth,
+          hintText: '1996-03-21',
+        ),
+      ]),
+      const SizedBox(height: 16),
+      _saveRow(context: context, saving: _saving, onSave: _save),
+    ]);
+  }
 }
 
 // ───────────────────────────────────────────────────────── 건강 목표 ──
 
-/// Health goals — the daily targets that drive the home/diet summaries.
+/// Health goals editor — pre-fills from `profileProvider` and persists via
+/// `AccountRepository.updateHealthGoals`.
 Future<void> showGoalsSheet(BuildContext context) {
-  return _open(context, '건강 목표', <Widget>[
-    const Text(
-      '앱 곳곳의 요약·피드백이 이 목표를 기준으로 계산돼요.',
-      style: TextStyle(fontSize: 12, color: FigmaColors.textMuted),
-    ),
-    const SizedBox(height: 12),
-    _card(<Widget>[
-      _goalRow('일일 칼로리', '1,800', 'kcal'),
-      const Divider(height: 1, color: FigmaColors.hairline),
-      _goalRow('나트륨', '2,000', 'mg 이하'),
-      const Divider(height: 1, color: FigmaColors.hairline),
-      _goalRow('당류', '50', 'g 이하'),
-    ]),
-    const SizedBox(height: 12),
-    _card(<Widget>[
-      _goalRow('운동 소모', '500', 'kcal/일'),
-      const Divider(height: 1, color: FigmaColors.hairline),
-      _goalRow('걸음 수', '8,000', '보'),
-      const Divider(height: 1, color: FigmaColors.hairline),
-      _goalRow('주간 운동', '5', '회'),
-    ]),
-    const SizedBox(height: 16),
-    _saveButton(context, '건강 목표가 저장되었어요'),
-  ]);
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    barrierColor: FigmaColors.sheetScrim,
+    builder: (BuildContext ctx) => const _GoalsSheet(),
+  );
 }
 
-Widget _goalRow(String label, String value, String unit) => Padding(
-  padding: const EdgeInsets.symmetric(vertical: 10),
-  child: Row(
-    children: <Widget>[
-      Expanded(
-        child: Text(
-          label,
-          style: const TextStyle(
-            fontSize: 14,
-            fontWeight: FontWeight.w600,
-            color: FigmaColors.ink,
-          ),
+class _GoalsSheet extends ConsumerWidget {
+  const _GoalsSheet();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AsyncValue<UserProfile> profile = ref.watch(profileProvider);
+    return profile.when(
+      data: (UserProfile p) => _GoalsForm(initial: p),
+      loading: () => _shell(context, '건강 목표', const <Widget>[_SheetLoader()]),
+      error: (_, _) => const _GoalsForm(
+        initial: UserProfile(id: '', name: '', email: ''),
+      ),
+    );
+  }
+}
+
+class _GoalsForm extends ConsumerStatefulWidget {
+  const _GoalsForm({required this.initial});
+  final UserProfile initial;
+
+  @override
+  ConsumerState<_GoalsForm> createState() => _GoalsFormState();
+}
+
+class _GoalsFormState extends ConsumerState<_GoalsForm> {
+  late final TextEditingController _weight = TextEditingController(
+    text: '${(widget.initial.goalWeightKg ?? 70).round()}',
+  );
+  late final TextEditingController _bp = TextEditingController(
+    text: '${widget.initial.goalBpSystolic ?? 120}',
+  );
+  late final TextEditingController _sugar = TextEditingController(
+    text: '${widget.initial.goalBloodSugar ?? 100}',
+  );
+  late final TextEditingController _kcal = TextEditingController(
+    text: '${widget.initial.dailyCalories ?? 2000}',
+  );
+  late final TextEditingController _sodium = TextEditingController(
+    text: '${widget.initial.dailySodiumMg ?? 2000}',
+  );
+  bool _saving = false;
+
+  @override
+  void dispose() {
+    _weight.dispose();
+    _bp.dispose();
+    _sugar.dispose();
+    _kcal.dispose();
+    _sodium.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    if (_saving) return;
+    final NavigatorState navigator = Navigator.of(context);
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    setState(() => _saving = true);
+    try {
+      await ref.read(accountRepositoryProvider).updateHealthGoals(
+        goalWeightKg: int.tryParse(_weight.text.trim()),
+        goalBpSystolic: int.tryParse(_bp.text.trim()),
+        goalBloodSugar: int.tryParse(_sugar.text.trim()),
+        dailyCalories: int.tryParse(_kcal.text.trim()),
+        dailySodiumMg: int.tryParse(_sodium.text.trim()),
+      );
+      ref.invalidate(profileProvider);
+      navigator.pop();
+      messenger.showSnackBar(
+        const SnackBar(content: Text('건강 목표가 저장되었어요')),
+      );
+    } catch (_) {
+      if (mounted) setState(() => _saving = false);
+      messenger.showSnackBar(
+        const SnackBar(content: Text('저장에 실패했어요. 잠시 후 다시 시도해 주세요')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final List<TextInputFormatter> digitsOnly = <TextInputFormatter>[
+      FilteringTextInputFormatter.digitsOnly,
+    ];
+    return _shell(context, '건강 목표', <Widget>[
+      const Text(
+        '앱 곳곳의 요약·피드백이 이 목표를 기준으로 계산돼요.',
+        style: TextStyle(fontSize: 12, color: FigmaColors.textMuted),
+      ),
+      const SizedBox(height: 12),
+      _card(<Widget>[
+        _SheetField(
+          label: '목표 체중',
+          controller: _weight,
+          suffix: 'kg',
+          keyboardType: TextInputType.number,
+          inputFormatters: digitsOnly,
         ),
-      ),
-      Text(
-        value,
-        style: const TextStyle(
-          fontSize: 16,
-          fontWeight: FontWeight.w800,
-          color: FigmaColors.primary,
+        const SizedBox(height: 12),
+        _SheetField(
+          label: '목표 혈압 (수축기)',
+          controller: _bp,
+          suffix: 'mmHg',
+          keyboardType: TextInputType.number,
+          inputFormatters: digitsOnly,
         ),
-      ),
-      const SizedBox(width: 4),
-      Text(
-        unit,
-        style: const TextStyle(fontSize: 11, color: FigmaColors.textMuted),
-      ),
-    ],
-  ),
-);
+        const SizedBox(height: 12),
+        _SheetField(
+          label: '목표 혈당',
+          controller: _sugar,
+          suffix: 'mg/dL',
+          keyboardType: TextInputType.number,
+          inputFormatters: digitsOnly,
+        ),
+      ]),
+      const SizedBox(height: 12),
+      _card(<Widget>[
+        _SheetField(
+          label: '일일 칼로리',
+          controller: _kcal,
+          suffix: 'kcal',
+          keyboardType: TextInputType.number,
+          inputFormatters: digitsOnly,
+        ),
+        const SizedBox(height: 12),
+        _SheetField(
+          label: '나트륨 제한',
+          controller: _sodium,
+          suffix: 'mg',
+          keyboardType: TextInputType.number,
+          inputFormatters: digitsOnly,
+        ),
+      ]),
+      const SizedBox(height: 16),
+      _saveRow(context: context, saving: _saving, onSave: _save),
+    ]);
+  }
+}
 
 // ───────────────────────────────────────────────────────── 알림 설정 ──
 
-/// Notification preferences.
+/// One notification toggle: Figma label, SharedPreferences key, and the
+/// default used before the user has ever changed it.
+class _NotifItem {
+  const _NotifItem(this.label, this.prefKey, this.fallback);
+  final String label;
+  final String prefKey;
+  final bool fallback;
+}
+
+const List<_NotifItem> _notifItems = <_NotifItem>[
+  _NotifItem('식단 기록 알림', 'notif_diet_log', true),
+  _NotifItem('운동 리마인더', 'notif_exercise_reminder', true),
+  _NotifItem('트레이너 메시지', 'notif_trainer_message', true),
+  _NotifItem('AI 코칭 조언', 'notif_ai_coaching', true),
+  _NotifItem('주간 리포트', 'notif_weekly_report', false),
+];
+
+/// Notification preferences — toggles load from and persist to
+/// SharedPreferences so they survive a reload.
 Future<void> showNotifSheet(BuildContext context) {
   return showModalBottomSheet<void>(
     context: context,
@@ -249,32 +583,41 @@ Future<void> showNotifSheet(BuildContext context) {
   );
 }
 
-class _NotifSheet extends StatefulWidget {
+class _NotifSheet extends ConsumerStatefulWidget {
   const _NotifSheet();
 
   @override
-  State<_NotifSheet> createState() => _NotifSheetState();
+  ConsumerState<_NotifSheet> createState() => _NotifSheetState();
 }
 
-class _NotifSheetState extends State<_NotifSheet> {
-  final Map<String, bool> _on = <String, bool>{
-    '식단 기록 알림': true,
-    '운동 리마인더': true,
-    '트레이너 메시지': true,
-    'AI 코칭 조언': true,
-    '주간 리포트': false,
-  };
+class _NotifSheetState extends ConsumerState<_NotifSheet> {
+  late final SharedPreferences _prefs;
+  final Map<String, bool> _on = <String, bool>{};
+
+  @override
+  void initState() {
+    super.initState();
+    _prefs = ref.read(sharedPreferencesProvider);
+    for (final _NotifItem item in _notifItems) {
+      _on[item.prefKey] = _prefs.getBool(item.prefKey) ?? item.fallback;
+    }
+  }
+
+  void _persist(String key, bool value) {
+    setState(() => _on[key] = value);
+    _prefs.setBool(key, value);
+  }
 
   @override
   Widget build(BuildContext context) {
     return _shell(context, '알림 설정', <Widget>[
       _card(<Widget>[
-        for (final MapEntry<String, bool> e in _on.entries) ...<Widget>[
+        for (int i = 0; i < _notifItems.length; i++) ...<Widget>[
           Row(
             children: <Widget>[
               Expanded(
                 child: Text(
-                  e.key,
+                  _notifItems[i].label,
                   style: const TextStyle(
                     fontSize: 14,
                     fontWeight: FontWeight.w600,
@@ -283,13 +626,13 @@ class _NotifSheetState extends State<_NotifSheet> {
                 ),
               ),
               Switch.adaptive(
-                value: e.value,
+                value: _on[_notifItems[i].prefKey] ?? _notifItems[i].fallback,
                 activeThumbColor: FigmaColors.primary,
-                onChanged: (bool v) => setState(() => _on[e.key] = v),
+                onChanged: (bool v) => _persist(_notifItems[i].prefKey, v),
               ),
             ],
           ),
-          if (e.key != _on.keys.last)
+          if (i < _notifItems.length - 1)
             const Divider(height: 1, color: FigmaColors.hairline),
         ],
       ]),
@@ -302,10 +645,26 @@ class _NotifSheetState extends State<_NotifSheet> {
 /// Customer support entries.
 Future<void> showSupportSheet(BuildContext context) {
   return _open(context, '고객 지원', <Widget>[
-    _supportRow(context, Icons.help_outline, '자주 묻는 질문'),
-    _supportRow(context, Icons.chat_bubble_outline, '1:1 문의'),
-    _supportRow(context, Icons.description_outlined, '이용약관'),
-    _supportRow(context, Icons.privacy_tip_outlined, '개인정보 처리방침'),
+    _supportRow(
+      Icons.help_outline,
+      '자주 묻는 질문',
+      () => _comingSoon(context, '자주 묻는 질문'),
+    ),
+    _supportRow(
+      Icons.chat_bubble_outline,
+      '1:1 문의',
+      () => _comingSoon(context, '1:1 문의'),
+    ),
+    _supportRow(
+      Icons.description_outlined,
+      '이용약관',
+      () => _openLegal(context, _LegalDoc.terms),
+    ),
+    _supportRow(
+      Icons.privacy_tip_outlined,
+      '개인정보 처리방침',
+      () => _openLegal(context, _LegalDoc.privacy),
+    ),
     const SizedBox(height: 12),
     const Center(
       child: Text(
@@ -316,18 +675,30 @@ Future<void> showSupportSheet(BuildContext context) {
   ]);
 }
 
-Widget _supportRow(BuildContext context, IconData icon, String label) {
+void _comingSoon(BuildContext context, String label) {
+  ScaffoldMessenger.of(
+    context,
+  ).showSnackBar(SnackBar(content: Text('$label은(는) 준비 중이에요')));
+}
+
+void _openLegal(BuildContext context, _LegalDoc doc) {
+  showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    barrierColor: FigmaColors.sheetScrim,
+    builder: (BuildContext ctx) => _LegalDocSheet(doc: doc),
+  );
+}
+
+Widget _supportRow(IconData icon, String label, VoidCallback onTap) {
   return Padding(
     padding: const EdgeInsets.only(bottom: 8),
     child: Material(
       color: FigmaColors.statBg,
       borderRadius: BorderRadius.circular(14),
       child: InkWell(
-        onTap: () {
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(SnackBar(content: Text('$label은(는) 준비 중이에요')));
-        },
+        onTap: onTap,
         borderRadius: BorderRadius.circular(14),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
@@ -358,51 +729,82 @@ Widget _supportRow(BuildContext context, IconData icon, String label) {
   );
 }
 
-Widget _saveButton(BuildContext context, String message) => Row(
-  children: <Widget>[
-    Expanded(
-      child: OutlinedButton.icon(
-        onPressed: () {
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(const SnackBar(content: Text('항목을 눌러 값을 수정할 수 있어요')));
-        },
-        style: OutlinedButton.styleFrom(
-          foregroundColor: FigmaColors.primary,
-          side: BorderSide(color: FigmaColors.primaryA(0.4)),
-          padding: const EdgeInsets.symmetric(vertical: 14),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(14),
+/// The in-app legal documents surfaced from 고객 지원.
+enum _LegalDoc {
+  terms('이용약관', _termsBody),
+  privacy('개인정보 처리방침', _privacyBody);
+
+  const _LegalDoc(this.title, this.body);
+  final String title;
+  final String body;
+}
+
+class _LegalDocSheet extends StatelessWidget {
+  const _LegalDocSheet({required this.doc});
+  final _LegalDoc doc;
+
+  @override
+  Widget build(BuildContext context) {
+    return _shell(context, doc.title, <Widget>[
+      _card(<Widget>[
+        Text(
+          doc.body,
+          style: const TextStyle(
+            fontSize: 13,
+            height: 1.7,
+            fontWeight: FontWeight.w500,
+            color: FigmaColors.textBody,
           ),
         ),
-        icon: const Icon(Icons.edit_outlined, size: 16),
-        label: const Text(
-          '수정',
-          style: TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
+      ]),
+      const SizedBox(height: 12),
+      const Center(
+        child: Text(
+          '시행일 2026. 01. 01.',
+          style: TextStyle(fontSize: 11, color: FigmaColors.textFaint),
         ),
       ),
-    ),
-    const SizedBox(width: 12),
-    Expanded(
-      child: FilledButton(
-        onPressed: () {
-          Navigator.of(context).pop();
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(SnackBar(content: Text(message)));
-        },
-        style: FilledButton.styleFrom(
-          backgroundColor: FigmaColors.primary,
-          padding: const EdgeInsets.symmetric(vertical: 14),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(14),
-          ),
-        ),
-        child: const Text(
-          '저장',
-          style: TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
-        ),
-      ),
-    ),
-  ],
-);
+    ]);
+  }
+}
+
+const String _termsBody =
+    '제1조 (목적)\n'
+    '이 약관은 On-Care(이하 "회사")가 제공하는 건강 관리 서비스(이하 "서비스")의 이용과 관련하여 '
+    '회사와 회원 간의 권리, 의무 및 책임사항을 규정함을 목적으로 합니다.\n\n'
+    '제2조 (약관의 효력 및 변경)\n'
+    '① 이 약관은 서비스를 이용하는 모든 회원에게 효력이 발생합니다.\n'
+    '② 회사는 관련 법령을 위반하지 않는 범위에서 이 약관을 변경할 수 있으며, 변경 시 적용일자와 '
+    '변경 사유를 명시하여 서비스 내에 공지합니다.\n\n'
+    '제3조 (서비스의 제공)\n'
+    '회사는 식단 기록, 운동 기록, 건강 지표 관리, AI 코칭 등 회원의 건강 관리를 돕는 기능을 '
+    '제공합니다. 서비스의 구체적인 내용은 회사의 정책에 따라 변경될 수 있습니다.\n\n'
+    '제4조 (회원의 의무)\n'
+    '회원은 본인의 건강 정보를 정확하게 입력하여야 하며, 서비스가 제공하는 정보는 의학적 진단이나 '
+    '치료를 대체하지 않습니다. 건강상 문제가 있는 경우 반드시 전문 의료기관의 진료를 받으시기 바랍니다.\n\n'
+    '제5조 (책임의 제한)\n'
+    '회사는 회원이 서비스를 통해 얻은 정보에 기반하여 내린 판단과 그 결과에 대하여 법령이 허용하는 '
+    '범위 내에서 책임을 부담하지 않습니다.\n\n'
+    '부칙\n'
+    '이 약관은 2026년 1월 1일부터 시행합니다.';
+
+const String _privacyBody =
+    'On-Care(이하 "회사")는 「개인정보 보호법」 등 관련 법령을 준수하며, 회원의 개인정보를 소중히 '
+    '보호합니다.\n\n'
+    '1. 수집하는 개인정보 항목\n'
+    '회사는 회원가입 및 서비스 제공을 위하여 이름, 이메일, 전화번호, 생년월일과 함께 식단·운동·건강 '
+    '지표 등 건강 관련 정보를 수집합니다.\n\n'
+    '2. 개인정보의 수집 및 이용 목적\n'
+    '수집한 개인정보는 회원 식별, 건강 관리 기능 제공, 맞춤형 AI 코칭, 서비스 개선 및 고객 문의 '
+    '응대의 목적으로만 이용됩니다.\n\n'
+    '3. 개인정보의 보유 및 이용 기간\n'
+    '회원의 개인정보는 원칙적으로 회원 탈퇴 시 지체 없이 파기합니다. 다만 관련 법령에 따라 보존할 '
+    '필요가 있는 경우 해당 기간 동안 안전하게 보관합니다.\n\n'
+    '4. 개인정보의 제3자 제공\n'
+    '회사는 회원의 동의 없이 개인정보를 외부에 제공하지 않습니다. 다만 법령에 특별한 규정이 있는 '
+    '경우는 예외로 합니다.\n\n'
+    '5. 이용자의 권리\n'
+    '회원은 언제든지 자신의 개인정보를 조회·수정하거나 처리 정지 및 삭제를 요청할 수 있습니다.\n\n'
+    '6. 개인정보 보호책임자\n'
+    '개인정보와 관련한 문의는 고객 지원(support@oncare.com)으로 연락하실 수 있습니다.\n\n'
+    '시행일: 2026년 1월 1일';

--- a/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
@@ -7,8 +7,13 @@ import 'package:oncare/features/account/domain/entities/user_profile.dart';
 import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-Widget _shell(BuildContext context, String title, List<Widget> children) {
-  return SafeArea(
+Widget _shell(
+  BuildContext context,
+  String title,
+  List<Widget> children, {
+  bool saving = false,
+}) {
+  final Widget sheet = SafeArea(
     top: false,
     child: ConstrainedBox(
       constraints: BoxConstraints(
@@ -51,7 +56,8 @@ Widget _shell(BuildContext context, String title, List<Widget> children) {
                     shape: const CircleBorder(),
                     clipBehavior: Clip.antiAlias,
                     child: InkWell(
-                      onTap: () => Navigator.of(context).pop(),
+                      // Disabled while a save is in flight (blocks dismiss).
+                      onTap: saving ? null : () => Navigator.of(context).pop(),
                       child: const SizedBox(
                         width: 32,
                         height: 32,
@@ -78,6 +84,7 @@ Widget _shell(BuildContext context, String title, List<Widget> children) {
       ),
     ),
   );
+  return PopScope(canPop: !saving, child: sheet);
 }
 
 Future<void> _open(BuildContext context, String title, List<Widget> body) {
@@ -353,6 +360,8 @@ class _ProfileFormState extends ConsumerState<_ProfileForm> {
         phone: _phone.text.trim(),
         birthDate: _birth.text.trim(),
       );
+      // Sheet dismissed mid-save → don't touch ref/pop the page below.
+      if (!mounted) return;
       ref.invalidate(profileProvider);
       navigator.pop();
       messenger.showSnackBar(
@@ -396,7 +405,7 @@ class _ProfileFormState extends ConsumerState<_ProfileForm> {
       ]),
       const SizedBox(height: 16),
       _saveRow(context: context, saving: _saving, onSave: _save),
-    ]);
+    ], saving: _saving);
   }
 }
 
@@ -479,6 +488,8 @@ class _GoalsFormState extends ConsumerState<_GoalsForm> {
         dailyCalories: int.tryParse(_kcal.text.trim()),
         dailySodiumMg: int.tryParse(_sodium.text.trim()),
       );
+      // Sheet dismissed mid-save → don't touch ref/pop the page below.
+      if (!mounted) return;
       ref.invalidate(profileProvider);
       navigator.pop();
       messenger.showSnackBar(
@@ -548,7 +559,7 @@ class _GoalsFormState extends ConsumerState<_GoalsForm> {
       ]),
       const SizedBox(height: 16),
       _saveRow(context: context, saving: _saving, onSave: _save),
-    ]);
+    ], saving: _saving);
   }
 }
 


### PR DESCRIPTION
## Summary

#189(Figma 재구성) 후속. 재구성 과정에서 하드코딩 데모로 남아 있던 나머지 화면(운동 헬스장 탭, MY 설정 시트)을 실 provider/repository에 재연결합니다. 앱은 `useMockApi`(기본 true) + `LocalApiInterceptor`라 데모/웹에서도 안전하게 동작합니다.

Closes #200

## Changes

### 운동 · 헬스장 탭
- 내 헬스장 카드 → `myGymProvider`(이름·주소·거리·운영시간·전화·트레이너·태그), 로딩/에러/미등록 상태 처리
- 헬스장 찾기 → 정적 컨테이너를 실 `TextField` 검색(이름/주소 필터)으로, `nearbyGymsProvider` 목록 렌더링
- `트레이너 채팅`·`건강 요약 전달` 빈 콜백 → 상담 시트/확인 다이얼로그로 연결

### MY 설정 시트 (`my_flows`)
- 내 프로필·건강 목표 → `profileProvider` 표시 + `accountRepository.updateProfile`/`updateHealthGoals` 저장 후 `invalidate`
- 알림 설정 → 토글 상태를 `prefs_store`(SharedPreferences)에 저장(재실행에도 유지)
- 고객지원 → 이용약관·개인정보 처리방침을 앱 내 문서 시트로 연결(자주 묻는 질문·1:1 문의는 준비 중 유지)

## Verification
- `flutter analyze` 0건
- 모바일 웹 프리뷰: 헬스장 카드 실데이터, 검색 필터(`헬스메이트` → 해당 헬스장만), 내 프로필 폼 실데이터(김민수/이메일/전화/생년월일) 확인

## Notes
- #189 위에 쌓인 스택 PR(base: `feature/188-figma-user-app`). #189 병합 후 base를 `main`으로 바꿔 순차 병합합니다.
- 신규 문구 현지화(l10n, 약 378개 문자열)는 규모가 커 #201로 분리했습니다.
