### PR TITLE
fix(trainer): 채팅 전송 가드 — 중복 전송·disposed 접근 방지

### DIFF
--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
@@ -63,6 +63,9 @@ class _ChatViewState extends ConsumerState<ChatView> {
           .read(chatRepositoryProvider)
           .sendTrainerMessage(clientId: widget.clientId, text: text);
     } catch (_) {
+      // Guard the failure path too: a slow send that fails after the
+      // user left would otherwise touch a disposed messenger.
+      if (!mounted) return;
       // Keep the draft in the input and tell the user it didn't go out.
       messenger.showSnackBar(
         const SnackBar(content: Text('메시지 전송에 실패했어요. 다시 시도해 주세요')),

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
@@ -37,6 +37,14 @@ class _ChatViewState extends ConsumerState<ChatView> {
   final TextEditingController _input = TextEditingController();
   final ScrollController _scroll = ScrollController();
 
+  /// A send is in flight — blocks re-entry (button mash / IME send)
+  /// from inserting the same message twice.
+  bool _sending = false;
+
+  /// Message count at the last auto-scroll, so the thread only scrolls
+  /// when a message actually arrives (not on every rebuild).
+  int _lastCount = -1;
+
   @override
   void dispose() {
     _input.dispose();
@@ -45,9 +53,11 @@ class _ChatViewState extends ConsumerState<ChatView> {
   }
 
   Future<void> _send() async {
+    if (_sending) return;
     final text = _input.text;
     if (text.trim().isEmpty) return;
     final messenger = ScaffoldMessenger.of(context);
+    setState(() => _sending = true);
     try {
       await ref
           .read(chatRepositoryProvider)
@@ -58,7 +68,12 @@ class _ChatViewState extends ConsumerState<ChatView> {
         const SnackBar(content: Text('메시지 전송에 실패했어요. 다시 시도해 주세요')),
       );
       return;
+    } finally {
+      if (mounted) setState(() => _sending = false);
     }
+    // The insert may outlive this widget (user navigated away while
+    // awaiting) — don't touch disposed controllers.
+    if (!mounted) return;
     // Clear only after the insert succeeds so the text isn't lost on error.
     _input.clear();
     _scrollToBottom();
@@ -66,7 +81,7 @@ class _ChatViewState extends ConsumerState<ChatView> {
 
   void _scrollToBottom() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!_scroll.hasClients) return;
+      if (!mounted || !_scroll.hasClients) return;
       _scroll.animateTo(
         _scroll.position.maxScrollExtent,
         duration: const Duration(milliseconds: 250),
@@ -91,7 +106,11 @@ class _ChatViewState extends ConsumerState<ChatView> {
               ),
             ),
             data: (list) {
-              _scrollToBottom();
+              // Auto-scroll only when a message arrived, not every build.
+              if (list.length != _lastCount) {
+                _lastCount = list.length;
+                _scrollToBottom();
+              }
               return ListView(
                 controller: _scroll,
                 padding: const EdgeInsets.all(AppSpacing.lg),
@@ -108,7 +127,7 @@ class _ChatViewState extends ConsumerState<ChatView> {
             },
           ),
         ),
-        _InputBar(controller: _input, onSend: _send),
+        _InputBar(controller: _input, sending: _sending, onSend: _send),
       ],
     );
   }
@@ -279,9 +298,17 @@ class _Bubble extends StatelessWidget {
 }
 
 class _InputBar extends StatelessWidget {
-  const _InputBar({required this.controller, required this.onSend});
+  const _InputBar({
+    required this.controller,
+    required this.sending,
+    required this.onSend,
+  });
 
   final TextEditingController controller;
+
+  /// Disables the field and the send button while an insert is in flight.
+  final bool sending;
+
   final Future<void> Function() onSend;
 
   @override
@@ -302,6 +329,7 @@ class _InputBar extends StatelessWidget {
           Expanded(
             child: TextField(
               controller: controller,
+              enabled: !sending,
               textInputAction: TextInputAction.send,
               onSubmitted: (_) => onSend(),
               decoration: InputDecoration(
@@ -322,11 +350,11 @@ class _InputBar extends StatelessWidget {
           ),
           const SizedBox(width: AppSpacing.sm),
           Material(
-            color: AppColors.accent,
+            color: sending ? AppColors.disabledForeground : AppColors.accent,
             shape: const CircleBorder(),
             child: InkWell(
               customBorder: const CircleBorder(),
-              onTap: onSend,
+              onTap: sending ? null : onSend,
               child: const Padding(
                 padding: EdgeInsets.all(AppSpacing.sm),
                 child: Icon(

--- a/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -22,6 +23,21 @@ class _SlowChatRepository extends ChatRepository {
     await Future<void>.delayed(const Duration(milliseconds: 400));
     return super.sendTrainerMessage(clientId: clientId, text: text);
   }
+}
+
+/// Blocks on a caller-controlled future so the test can decide exactly
+/// when (and whether) the send fails — used to fail AFTER the widget is
+/// disposed, deterministically exercising the catch path.
+class _ControllableChatRepository extends ChatRepository {
+  const _ControllableChatRepository(super.db, this.gate);
+
+  final Future<void> gate;
+
+  @override
+  Future<void> sendTrainerMessage({
+    required String clientId,
+    required String text,
+  }) => gate;
 }
 
 void main() {
@@ -166,6 +182,45 @@ void main() {
       // Back on the list without a disposed-controller exception.
       expect(find.text('고객 관리'), findsOneWidget);
       expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('a send that FAILS after the screen is disposed does not '
+        'touch a disposed messenger', (tester) async {
+      final gate = Completer<void>();
+      addTearDown(() {
+        if (!gate.isCompleted) gate.complete();
+      });
+      await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        extraOverrides: <Override>[
+          chatRepositoryProvider.overrideWith(
+            (ref) => _ControllableChatRepository(
+              ref.watch(appDatabaseProvider),
+              gate.future,
+            ),
+          ),
+        ],
+      );
+      await tester.tap(find.text('김민수'));
+      await settle(tester);
+
+      await tester.enterText(find.byType(TextField), '이탈 중 실패');
+      await tester.tap(find.byIcon(Icons.send));
+      await tester.pump(const Duration(milliseconds: 50));
+      // Fully leave the chat (route popped + ChatView disposed) BEFORE
+      // the send resolves.
+      await tester.tap(find.byIcon(Icons.arrow_back_ios_new));
+      await settle(tester);
+      expect(find.text('고객 관리'), findsOneWidget);
+
+      // Now fail — the catch must bail on !mounted, not show a snackbar.
+      gate.completeError(Exception('send failed'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('메시지 전송에 실패했어요. 다시 시도해 주세요'), findsNothing);
     });
 
     testWidgets('switching sub-tabs shows the 식단 and 운동기록 views', (

--- a/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
@@ -1,5 +1,6 @@
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oncare_trainer/core/storage/app_database.dart';
@@ -8,6 +9,20 @@ import 'package:oncare_trainer/features/clients/data/repositories/chat_repositor
 import 'package:oncare_trainer/features/clients/domain/entities/client_chat_message.dart';
 
 import '../../helpers/pump_app.dart';
+
+/// Delays every insert so tests can act while a send is in flight.
+class _SlowChatRepository extends ChatRepository {
+  const _SlowChatRepository(super.db);
+
+  @override
+  Future<void> sendTrainerMessage({
+    required String clientId,
+    required String text,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 400));
+    return super.sendTrainerMessage(clientId: clientId, text: text);
+  }
+}
 
 void main() {
   group('ChatRepository', () {
@@ -96,6 +111,61 @@ void main() {
       await settle(tester);
 
       expect(find.text('다음 세션 때 봐요!'), findsOneWidget);
+    });
+
+    testWidgets('mashing send while an insert is in flight stores one '
+        'message', (tester) async {
+      await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        extraOverrides: <Override>[
+          chatRepositoryProvider.overrideWith(
+            (ref) => _SlowChatRepository(ref.watch(appDatabaseProvider)),
+          ),
+        ],
+      );
+      await tester.tap(find.text('김민수'));
+      await settle(tester);
+
+      await tester.enterText(find.byType(TextField), '중복 방지 확인');
+      await tester.tap(find.byIcon(Icons.send));
+      await tester.pump(const Duration(milliseconds: 50));
+      // Second tap lands while the first insert is still awaiting.
+      await tester.tap(
+        find.byIcon(Icons.send),
+        warnIfMissed: false, // button is disabled mid-flight
+      );
+      await settle(tester);
+
+      expect(find.text('중복 방지 확인'), findsOneWidget);
+    });
+
+    testWidgets('leaving the screen during a slow send does not throw', (
+      tester,
+    ) async {
+      await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        extraOverrides: <Override>[
+          chatRepositoryProvider.overrideWith(
+            (ref) => _SlowChatRepository(ref.watch(appDatabaseProvider)),
+          ),
+        ],
+      );
+      await tester.tap(find.text('김민수'));
+      await settle(tester);
+
+      await tester.enterText(find.byType(TextField), '이탈 중 전송');
+      await tester.tap(find.byIcon(Icons.send));
+      await tester.pump(const Duration(milliseconds: 50));
+      // Navigate back while the insert is still in flight — the widget
+      // is disposed before the await completes.
+      await tester.tap(find.byIcon(Icons.arrow_back_ios_new));
+      await settle(tester);
+
+      // Back on the list without a disposed-controller exception.
+      expect(find.text('고객 관리'), findsOneWidget);
+      expect(tester.takeException(), isNull);
     });
 
     testWidgets('switching sub-tabs shows the 식단 and 운동기록 views', (

--- a/frontend/flutter_trainer/test/helpers/pump_app.dart
+++ b/frontend/flutter_trainer/test/helpers/pump_app.dart
@@ -22,6 +22,7 @@ Future<ProviderContainer> pumpTrainerApp(
   WidgetTester tester, {
   String? token,
   bool seed = true,
+  List<Override> extraOverrides = const <Override>[],
 }) async {
   final values = <String, Object>{};
   if (token != null) values['trainer_access_token'] = token;
@@ -36,6 +37,7 @@ Future<ProviderContainer> pumpTrainerApp(
     overrides: <Override>[
       sharedPreferencesProvider.overrideWithValue(prefs),
       appDatabaseProvider.overrideWithValue(db),
+      ...extraOverrides,
     ],
   );
   addTearDown(container.dispose);


### PR DESCRIPTION
## Summary
* 전송 중 재진입(버튼 연타/IME) 시 중복 저장을 막고(`_sending`), 입력창·버튼을 비활성화합니다.
* 성공·실패 경로 모두 `await` 이후 `mounted`를 확인해 화면 이탈 후 완료돼도 dispose된 컨트롤러/메신저를 건드리지 않습니다.
* 자동 스크롤은 메시지 개수가 바뀔 때만 수행합니다.

## Changes
### 🐛 Fixes
* 실패 경로(catch)에도 `if (!mounted) return` 가드 추가 — 느린 전송이 이탈 후 실패해도 disposed messenger 접근 없음
* 중복 전송 가드·성공 경로 mounted 검사·메시지 도착 시에만 자동 스크롤
### 🔧 Improvements
* `pumpTrainerApp`에 `extraOverrides` 훅 추가 — 지연 리포지토리 주입용 (`pump_app.dart`)

## Commits
1. `029d9d1` fix: guard chat send against double-submit and disposed lifecycle
2. `0cab6f4` fix: guard chat send failure path against a disposed messenger
3. `3782750` fix: build the ?c= panel location through Uri [#212 ]

## Notes
* 회귀 테스트: 연타 시 1건만 저장 / 느린 성공·실패 전송 중 이탈 시 예외 없음(Completer로 dispose 후 실패 결정적 재현).

## Test Plan
* [ ] 기능 정상 동작 확인
* [ ] 예외 케이스 확인
* [ ] UI 확인
* [ ] 빌드 성공
* [ ] 관련 테스트 통과
### Manual Test Steps
1. 채팅에서 메시지 입력 → 전송 버튼 빠르게 2번 클릭 → 1건만 추가 확인
2. 전송 직후 즉시 뒤로가기 → 오류 없이 리스트 복귀 확인

## Related Issues
Closes #213 

## Checklist
* [ ] 코드 리뷰 준비 완료
* [ ] 불필요한 코드 제거
* [ ] 하드코딩 값 점검
* [ ] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인