### PR TITLE
fix(trainer): 고객 상세 로딩/오류/미존재 상태 + 서브탭 키보드 접근성

### DIFF
--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
@@ -259,25 +259,33 @@ class _SubTabs extends StatelessWidget {
         children: <Widget>[
           for (var i = 0; i < _labels.length; i++) ...<Widget>[
             Expanded(
-              child: GestureDetector(
-                onTap: () => onChanged(i),
-                child: Container(
-                  height: 34,
-                  alignment: Alignment.center,
-                  decoration: BoxDecoration(
-                    color: current == i
-                        ? AppColors.accent
-                        : AppColors.inputBackground,
+              // InkWell (over a Material) instead of GestureDetector so the
+              // sub-tabs are keyboard-focusable and activate on Enter/Space
+              // — desktop/web users can traverse them (CodeRabbit review).
+              child: Semantics(
+                button: true,
+                selected: current == i,
+                child: Material(
+                  color: current == i
+                      ? AppColors.accent
+                      : AppColors.inputBackground,
+                  borderRadius: const BorderRadius.all(AppRadius.md),
+                  child: InkWell(
+                    onTap: () => onChanged(i),
                     borderRadius: const BorderRadius.all(AppRadius.md),
-                  ),
-                  child: Text(
-                    _labels[i],
-                    style: TextStyle(
-                      fontSize: 12,
-                      fontWeight: FontWeight.w700,
-                      color: current == i
-                          ? AppColors.accentForeground
-                          : AppColors.subtleForeground,
+                    child: Container(
+                      height: 34,
+                      alignment: Alignment.center,
+                      child: Text(
+                        _labels[i],
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w700,
+                          color: current == i
+                              ? AppColors.accentForeground
+                              : AppColors.subtleForeground,
+                        ),
+                      ),
                     ),
                   ),
                 ),

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
@@ -51,24 +51,46 @@ class _ClientDetailViewState extends ConsumerState<ClientDetailView> {
 
   @override
   Widget build(BuildContext context) {
-    final clients = ref.watch(clientsProvider).valueOrNull ?? const [];
-    final match = clients.where((c) => c.id == widget.clientId);
-    final client = match.isNotEmpty ? match.first : null;
+    // Distinguish loading / error / loaded instead of flattening them
+    // into an empty list (an unknown id used to render a nameless
+    // "고객" chat and never-ending 식단/운동 spinners — codex review).
+    final clientsAsync = ref.watch(clientsProvider);
+    return clientsAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => _StatusView(
+        message: '고객 정보를 불러오지 못했어요',
+        showBack: widget.showBack,
+        // Re-subscribes the stream for a fresh attempt.
+        onRetry: () => ref.invalidate(clientsProvider),
+      ),
+      data: (clients) {
+        final match = clients.where((c) => c.id == widget.clientId);
+        if (match.isEmpty) {
+          // Stale deep link / removed client.
+          return _StatusView(
+            message: '고객을 찾을 수 없어요',
+            showBack: widget.showBack,
+            onRetry: null,
+          );
+        }
+        final client = match.first;
 
-    return Column(
-      children: <Widget>[
-        _Header(
-          client: client,
-          showBack: widget.showBack,
-          onClose: widget.onClose,
-        ),
-        _SubTabs(current: _tab, onChanged: (i) => setState(() => _tab = i)),
-        Expanded(child: _body(client)),
-      ],
+        return Column(
+          children: <Widget>[
+            _Header(
+              client: client,
+              showBack: widget.showBack,
+              onClose: widget.onClose,
+            ),
+            _SubTabs(current: _tab, onChanged: (i) => setState(() => _tab = i)),
+            Expanded(child: _body(client)),
+          ],
+        );
+      },
     );
   }
 
-  Widget _body(TrainerClient? client) {
+  Widget _body(TrainerClient client) {
     // Key the sub-views by client so per-client state (chat draft,
     // scroll position) resets when the split view swaps clients —
     // otherwise a message drafted for one client would linger in
@@ -79,18 +101,57 @@ class _ClientDetailViewState extends ConsumerState<ClientDetailView> {
         return ChatView(
           key: key,
           clientId: widget.clientId,
-          clientAvatar: client?.avatar ?? '',
-          clientName: client?.name ?? '고객',
+          clientAvatar: client.avatar,
+          clientName: client.name,
         );
       case 1:
-        return client == null
-            ? const Center(child: CircularProgressIndicator())
-            : DietView(key: key, client: client);
+        return DietView(key: key, client: client);
       default:
-        return client == null
-            ? const Center(child: CircularProgressIndicator())
-            : WorkoutView(key: key, client: client);
+        return WorkoutView(key: key, client: client);
     }
+  }
+}
+
+/// Fallback body for the error and not-found states: a message, an
+/// optional 다시 시도 button, and a way back to the 고객 list.
+class _StatusView extends StatelessWidget {
+  const _StatusView({
+    required this.message,
+    required this.showBack,
+    required this.onRetry,
+  });
+
+  final String message;
+  final bool showBack;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Text(
+            message,
+            style: const TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: AppColors.mutedForeground,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          if (onRetry != null)
+            TextButton(onPressed: onRetry, child: const Text('다시 시도')),
+          if (showBack)
+            TextButton(
+              onPressed: () => context.canPop()
+                  ? context.pop()
+                  : context.go(AppRoutes.clients),
+              child: const Text('고객 목록으로'),
+            ),
+        ],
+      ),
+    );
   }
 }
 
@@ -101,7 +162,7 @@ class _Header extends StatelessWidget {
     required this.onClose,
   });
 
-  final TrainerClient? client;
+  final TrainerClient client;
   final bool showBack;
   final VoidCallback? onClose;
 
@@ -128,29 +189,28 @@ class _Header extends StatelessWidget {
                   ? context.pop()
                   : context.go(AppRoutes.clients),
             ),
-          ClientAvatar(label: client?.avatar ?? '', size: 36),
+          ClientAvatar(label: client.avatar, size: 36),
           const SizedBox(width: AppSpacing.md),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
                 Text(
-                  client?.name ?? '고객',
+                  client.name,
                   style: const TextStyle(
                     fontSize: 14,
                     fontWeight: FontWeight.w700,
                     color: AppColors.foreground,
                   ),
                 ),
-                if (client != null)
-                  Text(
-                    client!.goal,
-                    style: const TextStyle(
-                      fontSize: 10.5,
-                      color: AppColors.subtleForeground,
-                      fontWeight: FontWeight.w500,
-                    ),
+                Text(
+                  client.goal,
+                  style: const TextStyle(
+                    fontSize: 10.5,
+                    color: AppColors.subtleForeground,
+                    fontWeight: FontWeight.w500,
                   ),
+                ),
               ],
             ),
           ),
@@ -159,7 +219,7 @@ class _Header extends StatelessWidget {
             height: 10,
             decoration: BoxDecoration(
               shape: BoxShape.circle,
-              color: (client?.active ?? false)
+              color: client.active
                   ? AppColors.success
                   : AppColors.disabledForeground,
             ),

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
@@ -262,28 +262,35 @@ class _SubTabs extends StatelessWidget {
               // InkWell (over a Material) instead of GestureDetector so the
               // sub-tabs are keyboard-focusable and activate on Enter/Space
               // — desktop/web users can traverse them (CodeRabbit review).
-              child: Semantics(
-                button: true,
-                selected: current == i,
-                child: Material(
-                  color: current == i
-                      ? AppColors.accent
-                      : AppColors.inputBackground,
-                  borderRadius: const BorderRadius.all(AppRadius.md),
-                  child: InkWell(
-                    onTap: () => onChanged(i),
+              //
+              // MergeSemantics folds this into the InkWell's own tap/focus
+              // node so a screen reader announces the selected state on the
+              // node it actually reads (review PR 216).
+              child: MergeSemantics(
+                child: Semantics(
+                  button: true,
+                  selected: current == i,
+                  inMutuallyExclusiveGroup: true,
+                  child: Material(
+                    color: current == i
+                        ? AppColors.accent
+                        : AppColors.inputBackground,
                     borderRadius: const BorderRadius.all(AppRadius.md),
-                    child: Container(
-                      height: 34,
-                      alignment: Alignment.center,
-                      child: Text(
-                        _labels[i],
-                        style: TextStyle(
-                          fontSize: 12,
-                          fontWeight: FontWeight.w700,
-                          color: current == i
-                              ? AppColors.accentForeground
-                              : AppColors.subtleForeground,
+                    child: InkWell(
+                      onTap: () => onChanged(i),
+                      borderRadius: const BorderRadius.all(AppRadius.md),
+                      child: Container(
+                        height: 34,
+                        alignment: Alignment.center,
+                        child: Text(
+                          _labels[i],
+                          style: TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w700,
+                            color: current == i
+                                ? AppColors.accentForeground
+                                : AppColors.subtleForeground,
+                          ),
                         ),
                       ),
                     ),

--- a/frontend/flutter_trainer/test/features/clients/client_detail_states_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_states_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -56,27 +57,43 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('sub-tabs are focusable buttons (keyboard-accessible)', (
+  testWidgets('sub-tabs are keyboard-reachable and activate on Enter', (
     tester,
   ) async {
     await pumpTrainerApp(tester, token: 'demo-trainer-token');
     await tester.tap(find.text('김민수'));
     await settle(tester);
     expect(find.text('채팅'), findsOneWidget);
+    // Start on the 채팅 sub-tab (default), not the 식단 view.
+    expect(find.text('오늘 영양 요약'), findsNothing);
 
-    // Each sub-tab now sits in an InkWell (focus traversal + Enter/Space
-    // activation) wrapped in Semantics(button: true), not a bare
-    // GestureDetector — so it is keyboard-reachable on desktop/web.
-    for (final label in <String>['채팅', '식단', '운동기록']) {
-      expect(
-        find.ancestor(of: find.text(label), matching: find.byType(InkWell)),
-        findsOneWidget,
-        reason: '$label 탭이 포커스 가능한 InkWell 안에 있어야 함',
-      );
+    // Whether the 식단 sub-tab currently holds keyboard focus.
+    bool sikdanFocused() {
+      final ctx = FocusManager.instance.primaryFocus?.context;
+      if (ctx == null) return false;
+      return find
+          .descendant(
+            of: find.byElementPredicate((e) => e == ctx),
+            matching: find.text('식단'),
+          )
+          .evaluate()
+          .isNotEmpty;
     }
 
-    // Activation still switches the tab (pointer path unchanged).
-    await tester.tap(find.text('식단'));
+    // Tab through the focus order until the 식단 sub-tab is focused —
+    // proves it participates in keyboard traversal (was unreachable as a
+    // bare GestureDetector).
+    var reached = false;
+    for (var i = 0; i < 12 && !reached; i++) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      reached = sikdanFocused();
+    }
+    expect(reached, isTrue, reason: '키보드 Tab으로 식단 탭에 도달할 수 있어야 함');
+
+    // Enter activates the focused tab — the 식단 view appears with no
+    // pointer tap.
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
     await settle(tester);
     expect(find.text('오늘 영양 요약'), findsOneWidget);
   });

--- a/frontend/flutter_trainer/test/features/clients/client_detail_states_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_states_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show Tristate;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -57,44 +59,68 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('sub-tabs are keyboard-reachable and activate on Enter', (
+  // Both activation keys a focusable button must honour (review PR 216).
+  for (final activation in <(String, LogicalKeyboardKey)>[
+    ('Enter', LogicalKeyboardKey.enter),
+    ('Space', LogicalKeyboardKey.space),
+  ]) {
+    final (keyName, key) = activation;
+    testWidgets('sub-tabs are keyboard-reachable and activate on $keyName', (
+      tester,
+    ) async {
+      await pumpTrainerApp(tester, token: 'demo-trainer-token');
+      await tester.tap(find.text('김민수'));
+      await settle(tester);
+      expect(find.text('채팅'), findsOneWidget);
+      // Start on the 채팅 sub-tab (default), not the 식단 view.
+      expect(find.text('오늘 영양 요약'), findsNothing);
+
+      // Whether the 식단 sub-tab currently holds keyboard focus.
+      bool sikdanFocused() {
+        final ctx = FocusManager.instance.primaryFocus?.context;
+        if (ctx == null) return false;
+        return find
+            .descendant(
+              of: find.byElementPredicate((e) => e == ctx),
+              matching: find.text('식단'),
+            )
+            .evaluate()
+            .isNotEmpty;
+      }
+
+      // Tab through the focus order until the 식단 sub-tab is focused —
+      // proves it participates in keyboard traversal (was unreachable as
+      // a bare GestureDetector).
+      var reached = false;
+      for (var i = 0; i < 12 && !reached; i++) {
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        reached = sikdanFocused();
+      }
+      expect(reached, isTrue, reason: '키보드 Tab으로 식단 탭에 도달할 수 있어야 함');
+
+      // The activation key switches the tab — no pointer involved.
+      await tester.sendKeyEvent(key);
+      await settle(tester);
+      expect(find.text('오늘 영양 요약'), findsOneWidget);
+    });
+  }
+
+  testWidgets('the selected sub-tab exposes its state on the focus node', (
     tester,
   ) async {
     await pumpTrainerApp(tester, token: 'demo-trainer-token');
     await tester.tap(find.text('김민수'));
     await settle(tester);
-    expect(find.text('채팅'), findsOneWidget);
-    // Start on the 채팅 sub-tab (default), not the 식단 view.
-    expect(find.text('오늘 영양 요약'), findsNothing);
 
-    // Whether the 식단 sub-tab currently holds keyboard focus.
-    bool sikdanFocused() {
-      final ctx = FocusManager.instance.primaryFocus?.context;
-      if (ctx == null) return false;
-      return find
-          .descendant(
-            of: find.byElementPredicate((e) => e == ctx),
-            matching: find.text('식단'),
-          )
-          .evaluate()
-          .isNotEmpty;
-    }
-
-    // Tab through the focus order until the 식단 sub-tab is focused —
-    // proves it participates in keyboard traversal (was unreachable as a
-    // bare GestureDetector).
-    var reached = false;
-    for (var i = 0; i < 12 && !reached; i++) {
-      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
-      await tester.pump();
-      reached = sikdanFocused();
-    }
-    expect(reached, isTrue, reason: '키보드 Tab으로 식단 탭에 도달할 수 있어야 함');
-
-    // Enter activates the focused tab — the 식단 view appears with no
-    // pointer tap.
-    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-    await settle(tester);
-    expect(find.text('오늘 영양 요약'), findsOneWidget);
+    // MergeSemantics folds the selected/button flags into the node the
+    // reader actually hits, so one node carries label + state.
+    final flags = tester.getSemantics(find.text('채팅')).flagsCollection;
+    expect(
+      flags.isSelected,
+      Tristate.isTrue,
+      reason: '기본 선택된 채팅 탭이 selected 로 안내돼야 함',
+    );
+    expect(flags.isButton, isTrue);
   });
 }

--- a/frontend/flutter_trainer/test/features/clients/client_detail_states_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_states_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/shared/models/trainer_client.dart';
+import 'package:oncare_trainer/shared/services/client_repository.dart';
+
+import '../../helpers/pump_app.dart';
+
+/// Loading / error / not-found handling for the client detail body.
+void main() {
+  testWidgets('an unknown client id shows the not-found message instead '
+      'of a nameless chat', (tester) async {
+    await pumpTrainerApp(tester, token: 'demo-trainer-token');
+
+    // Deep-link to a client that doesn't exist (stale link).
+    final ctx = tester.element(find.text('고객 관리'));
+    GoRouter.of(ctx).push(AppRoutes.clientDetail('no-such-client'));
+    await settle(tester);
+
+    expect(find.text('고객을 찾을 수 없어요'), findsOneWidget);
+    // No chat composer / sub-tabs for a client that doesn't exist.
+    expect(find.byType(TextField), findsNothing);
+    expect(find.text('채팅'), findsNothing);
+
+    // The escape hatch returns to the client list.
+    await tester.tap(find.text('고객 목록으로'));
+    await settle(tester);
+    expect(find.text('고객 관리'), findsOneWidget);
+  });
+
+  testWidgets('a provider error shows the failure message with 다시 시도', (
+    tester,
+  ) async {
+    await pumpTrainerApp(
+      tester,
+      token: 'demo-trainer-token',
+      extraOverrides: <Override>[
+        clientsProvider.overrideWith(
+          (ref) => Stream<List<TrainerClient>>.error(StateError('db down')),
+        ),
+      ],
+    );
+
+    final ctx = tester.element(find.byType(Scaffold).first);
+    GoRouter.of(ctx).push(AppRoutes.clientDetail('seed-client-1'));
+    await settle(tester);
+
+    expect(find.text('고객 정보를 불러오지 못했어요'), findsOneWidget);
+    expect(find.text('다시 시도'), findsOneWidget);
+    // Retry re-subscribes the stream — tapping must not throw.
+    await tester.tap(find.text('다시 시도'));
+    await settle(tester);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/frontend/flutter_trainer/test/features/clients/client_detail_states_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_states_test.dart
@@ -55,4 +55,29 @@ void main() {
     await settle(tester);
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('sub-tabs are focusable buttons (keyboard-accessible)', (
+    tester,
+  ) async {
+    await pumpTrainerApp(tester, token: 'demo-trainer-token');
+    await tester.tap(find.text('김민수'));
+    await settle(tester);
+    expect(find.text('채팅'), findsOneWidget);
+
+    // Each sub-tab now sits in an InkWell (focus traversal + Enter/Space
+    // activation) wrapped in Semantics(button: true), not a bare
+    // GestureDetector — so it is keyboard-reachable on desktop/web.
+    for (final label in <String>['채팅', '식단', '운동기록']) {
+      expect(
+        find.ancestor(of: find.text(label), matching: find.byType(InkWell)),
+        findsOneWidget,
+        reason: '$label 탭이 포커스 가능한 InkWell 안에 있어야 함',
+      );
+    }
+
+    // Activation still switches the tab (pointer path unchanged).
+    await tester.tap(find.text('식단'));
+    await settle(tester);
+    expect(find.text('오늘 영양 요약'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
* `ClientDetailView`가 `clientsProvider.when(...)`으로 로딩/오류/정상을 분리합니다. 미존재 ID → "고객을 찾을 수 없어요", 오류 → "불러오지 못했어요" + 다시 시도(`ref.invalidate`).
* 서브탭(채팅/식단/운동기록)을 `Semantics(button)+InkWell`로 바꿔 데스크톱/웹에서 포커스 순회·Enter/Space 활성화가 됩니다.

## Changes
### 🐛 Fixes
* 로딩/오류/미존재 상태 분리 — 고객 확정 후에만 하위 뷰 생성
* 서브탭 키보드 접근성(GestureDetector → 포커스 가능 버튼)
* 서브탭 Semantics를 `MergeSemantics`로 병합 — 선택 상태가 스크린리더가 읽는 노드에 실림 (리뷰 반영)

## Commits
1. `ca9cbd5` fix: distinct loading/error/not-found states for client detail
2. `a7a504d` fix(a11y): make client-detail sub-tabs keyboard-focusable
3. `685b557` test(a11y): assert real keyboard traversal + Enter activation of sub-tabs
4. `0a7bc09` fix(a11y): merge sub-tab semantics so selected state reaches the read node
5. `3782750` fix: build the ?c= panel location through Uri  *(#212 )*

## Notes
* 키보드 테스트를 실제 Tab→Enter로 강화(리뷰 반영) — InkWell 존재 확인만 하던 이전 테스트 대체.

## Test Plan
* [ ] 기능 정상 동작 확인
* [ ] 예외 케이스 확인
* [ ] UI 확인
* [ ] 빌드 성공
* [ ] 관련 테스트 통과
### Manual Test Steps
1. 주소창에 `/client/없는id` 직접 입력 → 미존재 안내 + 목록 복귀 확인

## Related Issues
Closes #215 

## Checklist
* [ ] 코드 리뷰 준비 완료
* [ ] 불필요한 코드 제거
* [ ] 하드코딩 값 점검
* [ ] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인