### PR TITLE
feat(trainer): 스케줄 추가·수정·삭제와 예정 세션 계획 미리보기

### DIFF
--- a/frontend/flutter_trainer/lib/features/schedule/data/repositories/schedule_repository.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/data/repositories/schedule_repository.dart
@@ -22,10 +22,65 @@ class ScheduleRepository {
   Stream<List<ScheduleSession>> watchToday() {
     final query = _db.select(_db.trainerScheduleEntries)
       ..where((t) => t.date.equals(ymd(DateTime.now())))
+      // Time first (zero-padded HH:MM sorts lexicographically) so
+      // trainer-added sessions land at the right timeline position;
+      // sortOrder only breaks ties between seed rows.
       ..orderBy(<OrderingTerm Function($TrainerScheduleEntriesTable)>[
+        (t) => OrderingTerm(expression: t.time),
         (t) => OrderingTerm(expression: t.sortOrder),
       ]);
     return query.watch().map((rows) => rows.map(_toEntity).toList());
+  }
+
+  /// Books a new session on today's timeline (status 예정). The
+  /// non-`seed-` id survives the daily re-seed.
+  Future<void> addSession({
+    required String clientName,
+    required String time,
+    required String type,
+    required int durationMinutes,
+  }) async {
+    await _db
+        .into(_db.trainerScheduleEntries)
+        .insert(
+          TrainerScheduleEntriesCompanion.insert(
+            id: 'sched-${DateTime.now().microsecondsSinceEpoch}',
+            date: ymd(DateTime.now()),
+            time: time,
+            clientName: Value(clientName),
+            type: Value(type),
+            durationMinutes: Value(durationMinutes),
+            status: '예정',
+            programJson: const Value('[]'),
+          ),
+        );
+  }
+
+  /// Edits a booked session's time/client/type/duration.
+  Future<void> updateSession(
+    String id, {
+    required String clientName,
+    required String time,
+    required String type,
+    required int durationMinutes,
+  }) async {
+    await (_db.update(
+      _db.trainerScheduleEntries,
+    )..where((t) => t.id.equals(id))).write(
+      TrainerScheduleEntriesCompanion(
+        clientName: Value(clientName),
+        time: Value(time),
+        type: Value(type),
+        durationMinutes: Value(durationMinutes),
+      ),
+    );
+  }
+
+  /// Removes a session from the timeline.
+  Future<void> deleteSession(String id) async {
+    await (_db.delete(
+      _db.trainerScheduleEntries,
+    )..where((t) => t.id.equals(id))).go();
   }
 
   ScheduleSession _toEntity(TrainerScheduleRow row) {

--- a/frontend/flutter_trainer/lib/features/schedule/domain/entities/schedule_session.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/domain/entities/schedule_session.dart
@@ -63,9 +63,14 @@ class ScheduleSession {
   /// Whether this is an empty ("빈 시간") slot.
   bool get isGap => status == '공백';
 
-  /// Whether the session is done — only these expand to show the program.
+  /// Whether the session is done.
   bool get isDone => status == '완료';
 
-  /// Whether the card can expand (done + has a program to show).
-  bool get expandable => isDone && program.isNotEmpty;
+  /// Whether the session is still upcoming (예정).
+  bool get isUpcoming => status == '예정';
+
+  /// Whether the card can expand. Every booked session opens: 완료 shows
+  /// the finished program, 예정 shows the plan (or a no-plan hint), and
+  /// both expose the manage/chat actions.
+  bool get expandable => !isGap;
 }

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -299,24 +299,47 @@ class _SessionSheetState extends ConsumerState<_SessionSheet> {
   late int _duration;
   bool _saving = false;
 
+  // Option lists always CONTAIN the edited session's own values. Falling
+  // back to a default instead would silently rewrite the session on an
+  // otherwise no-op save — e.g. a 상담 booked for '신규 회원' (not a
+  // registered client) would be reassigned to the first client, and a
+  // 50-minute session would become 60 (review PR 218).
+  late List<String> _clientOptions;
+  late List<String> _typeOptions;
+  late List<int> _hourOptions;
+  late List<int> _minuteOptions;
+  late List<int> _durationOptions;
+
+  /// [base] plus [current] when it isn't already offered.
+  static List<T> _withCurrent<T>(List<T> base, T? current) {
+    if (current == null || base.contains(current)) return List<T>.of(base);
+    return <T>[...base, current];
+  }
+
   @override
   void initState() {
     super.initState();
     final e = widget.existing;
-    _client = e != null && widget.clientNames.contains(e.clientName)
-        ? e.clientName
+
+    _client = e?.clientName.isNotEmpty ?? false
+        ? e!.clientName
         : widget.clientNames.first;
-    _type = e != null && _types.contains(e.type) ? e.type : _types.first;
+    _clientOptions = _withCurrent(widget.clientNames, _client);
+
+    _type = e != null && e.type.isNotEmpty ? e.type : _types.first;
+    _typeOptions = _withCurrent(_types, _type);
+
     final parts = e?.time.split(':');
     _hour = parts != null ? int.tryParse(parts[0]) ?? 10 : 10;
     _minute = parts != null && parts.length > 1
         ? int.tryParse(parts[1]) ?? 0
         : 0;
-    // Snap legacy values onto the 15-minute grid the picker offers.
-    _minute = (_minute ~/ 15) * 15;
-    _duration = e != null && _durations.contains(e.durationMinutes)
-        ? e.durationMinutes
-        : 60;
+    _hourOptions = _withCurrent(<int>[for (var h = 6; h <= 22; h++) h], _hour)
+      ..sort();
+    _minuteOptions = _withCurrent(const <int>[0, 15, 30, 45], _minute)..sort();
+
+    _duration = e?.durationMinutes ?? 60;
+    _durationOptions = _withCurrent(_durations, _duration)..sort();
   }
 
   String get _time =>
@@ -391,7 +414,7 @@ class _SessionSheetState extends ConsumerState<_SessionSheet> {
               isExpanded: true,
               underline: const SizedBox.shrink(),
               items: <DropdownMenuItem<String>>[
-                for (final name in widget.clientNames)
+                for (final name in _clientOptions)
                   DropdownMenuItem<String>(value: name, child: Text(name)),
               ],
               onChanged: (v) => setState(() => _client = v ?? _client),
@@ -404,7 +427,7 @@ class _SessionSheetState extends ConsumerState<_SessionSheet> {
               isExpanded: true,
               underline: const SizedBox.shrink(),
               items: <DropdownMenuItem<String>>[
-                for (final t in _types)
+                for (final t in _typeOptions)
                   DropdownMenuItem<String>(value: t, child: Text(t)),
               ],
               onChanged: (v) => setState(() => _type = v ?? _type),
@@ -420,7 +443,7 @@ class _SessionSheetState extends ConsumerState<_SessionSheet> {
                     isExpanded: true,
                     underline: const SizedBox.shrink(),
                     items: <DropdownMenuItem<int>>[
-                      for (var h = 6; h <= 22; h++)
+                      for (final h in _hourOptions)
                         DropdownMenuItem<int>(
                           value: h,
                           child: Text('${h.toString().padLeft(2, '0')}시'),
@@ -435,11 +458,12 @@ class _SessionSheetState extends ConsumerState<_SessionSheet> {
                     value: _minute,
                     isExpanded: true,
                     underline: const SizedBox.shrink(),
-                    items: const <DropdownMenuItem<int>>[
-                      DropdownMenuItem<int>(value: 0, child: Text('00분')),
-                      DropdownMenuItem<int>(value: 15, child: Text('15분')),
-                      DropdownMenuItem<int>(value: 30, child: Text('30분')),
-                      DropdownMenuItem<int>(value: 45, child: Text('45분')),
+                    items: <DropdownMenuItem<int>>[
+                      for (final m in _minuteOptions)
+                        DropdownMenuItem<int>(
+                          value: m,
+                          child: Text('${m.toString().padLeft(2, '0')}분'),
+                        ),
                     ],
                     onChanged: (v) => setState(() => _minute = v ?? _minute),
                   ),
@@ -454,7 +478,7 @@ class _SessionSheetState extends ConsumerState<_SessionSheet> {
               isExpanded: true,
               underline: const SizedBox.shrink(),
               items: <DropdownMenuItem<int>>[
-                for (final d in _durations)
+                for (final d in _durationOptions)
                   DropdownMenuItem<int>(value: d, child: Text('$d분')),
               ],
               onChanged: (v) => setState(() => _duration = v ?? _duration),

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -106,7 +106,15 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
       ),
     );
     if (ok != true || !mounted) return;
-    await ref.read(scheduleRepositoryProvider).deleteSession(s.id);
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref.read(scheduleRepositoryProvider).deleteSession(s.id);
+    } catch (_) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        const SnackBar(content: Text('일정 삭제에 실패했어요. 다시 시도해 주세요')),
+      );
+    }
   }
 
   /// Jumps to the client's 채팅 — the split panel on wide viewports,
@@ -320,6 +328,7 @@ class _SessionSheetState extends ConsumerState<_SessionSheet> {
     setState(() => _saving = true);
     final repo = ref.read(scheduleRepositoryProvider);
     final navigator = Navigator.of(context);
+    final messenger = ScaffoldMessenger.of(context);
     try {
       final e = widget.existing;
       if (e == null) {
@@ -338,9 +347,16 @@ class _SessionSheetState extends ConsumerState<_SessionSheet> {
           durationMinutes: _duration,
         );
       }
-    } finally {
+    } catch (_) {
+      // Surface the failure and keep the sheet open so the input isn't
+      // lost (review PR 218).
       if (mounted) setState(() => _saving = false);
+      messenger.showSnackBar(
+        const SnackBar(content: Text('일정 저장에 실패했어요. 다시 시도해 주세요')),
+      );
+      return;
     }
+    if (mounted) setState(() => _saving = false);
     if (!mounted) return;
     navigator.pop();
   }

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -2,19 +2,24 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
+import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/layout.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
 import 'package:oncare_trainer/shared/models/trainer_profile.dart';
+import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
 import 'package:oncare_trainer/shared/widgets/content_frame.dart';
 
-/// 스케줄 tab — today's PT timeline. Completed sessions expand to show
-/// the program + trainer note and can be sent to the client (mock:
-/// in-memory sent state with a confirmation flash).
+/// 스케줄 tab — today's PT timeline. Every booked session expands:
+/// 완료 shows the finished program and can be sent to the client (mock),
+/// 예정 shows the plan (or a no-plan hint) with a chat shortcut. The
+/// trainer can add, edit (15-minute steps), and delete sessions.
 class SchedulePage extends ConsumerStatefulWidget {
   /// Creates the schedule tab.
   const SchedulePage({super.key});
@@ -56,49 +61,433 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
     });
   }
 
+  /// Opens the add/edit sheet. Passing [existing] prefills it and turns
+  /// the save into an update.
+  Future<void> _openSessionSheet({ScheduleSession? existing}) async {
+    final clients = ref.read(clientsProvider).valueOrNull ?? const [];
+    if (clients.isEmpty) return;
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: AppColors.card,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: AppRadius.card),
+      ),
+      builder: (context) => _SessionSheet(
+        clientNames: clients.map((c) => c.name).toList(),
+        existing: existing,
+      ),
+    );
+  }
+
+  Future<void> _confirmDelete(ScheduleSession s) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: AppColors.card,
+        title: const Text('일정 삭제', style: TextStyle(fontSize: 16)),
+        content: Text(
+          '${s.time} ${s.clientName}님 세션을 삭제할까요?',
+          style: const TextStyle(fontSize: 13),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('취소'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text(
+              '삭제',
+              style: TextStyle(color: AppColors.destructive),
+            ),
+          ),
+        ],
+      ),
+    );
+    if (ok != true || !mounted) return;
+    await ref.read(scheduleRepositoryProvider).deleteSession(s.id);
+  }
+
+  /// Jumps to the client's 채팅 — the split panel on wide viewports,
+  /// the full-screen detail elsewhere. Falls back to the 고객 tab when
+  /// the name can't be resolved (e.g. a renamed client).
+  void _openChat(ScheduleSession s) {
+    final clients = ref.read(clientsProvider).valueOrNull ?? const [];
+    final match = clients.where((c) => c.name == s.clientName);
+    if (match.isEmpty) {
+      context.go(AppRoutes.clients);
+      return;
+    }
+    final id = match.first.id;
+    final wide = MediaQuery.sizeOf(context).width >= AppLayout.splitBreakpoint;
+    if (wide) {
+      context.go('${AppRoutes.clients}?c=$id');
+    } else {
+      context.go(AppRoutes.clients);
+      context.push(AppRoutes.clientDetail(id));
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final schedule = ref.watch(todayScheduleProvider);
+    // Keep the client stream live so the booking sheet and the chat
+    // shortcut have data even when this tab is the first one opened.
+    ref.watch(clientsProvider);
 
     return Scaffold(
       backgroundColor: AppColors.background,
       body: SafeArea(
-        child: ContentFrame(
-          child: schedule.when(
-            loading: () => const Center(child: CircularProgressIndicator()),
-            error: (e, _) => const Center(
-              child: Text(
-                '스케줄을 불러오지 못했어요',
-                style: TextStyle(color: AppColors.mutedForeground),
-              ),
+        child: schedule.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => const Center(
+            child: Text(
+              '스케줄을 불러오지 못했어요',
+              style: TextStyle(color: AppColors.mutedForeground),
             ),
-            data: (sessions) => ListView(
+          ),
+          data: (sessions) => LayoutBuilder(
+            builder: (context, constraints) {
+              final wide = constraints.maxWidth >= AppLayout.splitBreakpoint;
+              return wide
+                  ? _buildWide(sessions)
+                  : ContentFrame(child: _buildTimeline(sessions, true));
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Wide viewports: the date/week overview docks left and the timeline
+  /// gets its own scrollable column.
+  Widget _buildWide(List<ScheduleSession> sessions) {
+    return ContentFrame(
+      maxWidth: AppLayout.wideMaxWidth,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          SizedBox(
+            width: AppLayout.splitListWidth,
+            child: Padding(
               padding: const EdgeInsets.fromLTRB(
                 AppSpacing.xl,
                 AppSpacing.lg,
                 AppSpacing.xl,
-                AppSpacing.xxl,
+                AppSpacing.lg,
               ),
-              children: <Widget>[
-                const _Header(),
-                const SizedBox(height: AppSpacing.lg),
-                _WeekStrip(hasScheduleToday: sessions.isNotEmpty),
-                const SizedBox(height: AppSpacing.lg),
-                for (final s in sessions) ...<Widget>[
-                  _TimelineRow(
-                    session: s,
-                    expanded: _expanded.contains(s.id),
-                    sent: _sent.contains(s.id),
-                    flashing: _flash == s.id,
-                    onToggle: () => _toggle(s),
-                    onSend: () => _send(s),
-                  ),
-                  const SizedBox(height: AppSpacing.sm),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  const _Header(),
+                  const SizedBox(height: AppSpacing.lg),
+                  _WeekStrip(hasScheduleToday: sessions.isNotEmpty),
+                  const SizedBox(height: AppSpacing.lg),
+                  _AddSessionButton(onTap: () => _openSessionSheet()),
                 ],
-              ],
+              ),
+            ),
+          ),
+          const VerticalDivider(width: 1, color: AppColors.borderStrong),
+          Expanded(child: _buildTimeline(sessions, false)),
+        ],
+      ),
+    );
+  }
+
+  /// The scrollable timeline; [withOverview] prepends the header, week
+  /// strip, and add button (single-column layout).
+  Widget _buildTimeline(List<ScheduleSession> sessions, bool withOverview) {
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.xl,
+        AppSpacing.lg,
+        AppSpacing.xl,
+        AppSpacing.xxl,
+      ),
+      children: <Widget>[
+        if (withOverview) ...<Widget>[
+          const _Header(),
+          const SizedBox(height: AppSpacing.lg),
+          _WeekStrip(hasScheduleToday: sessions.isNotEmpty),
+          const SizedBox(height: AppSpacing.lg),
+          _AddSessionButton(onTap: () => _openSessionSheet()),
+          const SizedBox(height: AppSpacing.lg),
+        ],
+        for (final s in sessions) ...<Widget>[
+          _TimelineRow(
+            session: s,
+            expanded: _expanded.contains(s.id),
+            sent: _sent.contains(s.id),
+            flashing: _flash == s.id,
+            onToggle: () => _toggle(s),
+            onSend: () => _send(s),
+            onEdit: () => _openSessionSheet(existing: s),
+            onDelete: () => _confirmDelete(s),
+            onChat: () => _openChat(s),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+        ],
+      ],
+    );
+  }
+}
+
+/// "＋ 새 일정 추가" — opens the booking sheet.
+class _AddSessionButton extends StatelessWidget {
+  const _AddSessionButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: const BorderRadius.all(AppRadius.card),
+        child: Container(
+          height: 42,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            borderRadius: const BorderRadius.all(AppRadius.card),
+            border: Border.all(color: AppColors.accent.withValues(alpha: 0.4)),
+          ),
+          child: const Text(
+            '＋ 새 일정 추가',
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              color: AppColors.accent,
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// Bottom sheet for booking or editing a session: client, type, time
+/// (15-minute steps), and duration.
+class _SessionSheet extends ConsumerStatefulWidget {
+  const _SessionSheet({required this.clientNames, required this.existing});
+
+  final List<String> clientNames;
+  final ScheduleSession? existing;
+
+  @override
+  ConsumerState<_SessionSheet> createState() => _SessionSheetState();
+}
+
+class _SessionSheetState extends ConsumerState<_SessionSheet> {
+  static const List<String> _types = <String>['1:1 PT', '상담'];
+  static const List<int> _durations = <int>[30, 45, 60, 90];
+
+  late String _client;
+  late String _type;
+  late int _hour;
+  late int _minute;
+  late int _duration;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final e = widget.existing;
+    _client = e != null && widget.clientNames.contains(e.clientName)
+        ? e.clientName
+        : widget.clientNames.first;
+    _type = e != null && _types.contains(e.type) ? e.type : _types.first;
+    final parts = e?.time.split(':');
+    _hour = parts != null ? int.tryParse(parts[0]) ?? 10 : 10;
+    _minute = parts != null && parts.length > 1
+        ? int.tryParse(parts[1]) ?? 0
+        : 0;
+    // Snap legacy values onto the 15-minute grid the picker offers.
+    _minute = (_minute ~/ 15) * 15;
+    _duration = e != null && _durations.contains(e.durationMinutes)
+        ? e.durationMinutes
+        : 60;
+  }
+
+  String get _time =>
+      '${_hour.toString().padLeft(2, '0')}:'
+      '${_minute.toString().padLeft(2, '0')}';
+
+  Future<void> _save() async {
+    if (_saving) return;
+    setState(() => _saving = true);
+    final repo = ref.read(scheduleRepositoryProvider);
+    final navigator = Navigator.of(context);
+    try {
+      final e = widget.existing;
+      if (e == null) {
+        await repo.addSession(
+          clientName: _client,
+          time: _time,
+          type: _type,
+          durationMinutes: _duration,
+        );
+      } else {
+        await repo.updateSession(
+          e.id,
+          clientName: _client,
+          time: _time,
+          type: _type,
+          durationMinutes: _duration,
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+    if (!mounted) return;
+    navigator.pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      // Keep the sheet above the keyboard/safe area.
+      padding: EdgeInsets.fromLTRB(
+        AppSpacing.xl,
+        AppSpacing.lg,
+        AppSpacing.xl,
+        AppSpacing.xl + MediaQuery.viewInsetsOf(context).bottom,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Text(
+            widget.existing == null ? '새 일정 추가' : '일정 수정',
+            style: const TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w800,
+              color: AppColors.foreground,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          _sheetField(
+            label: '고객',
+            child: DropdownButton<String>(
+              value: _client,
+              isExpanded: true,
+              underline: const SizedBox.shrink(),
+              items: <DropdownMenuItem<String>>[
+                for (final name in widget.clientNames)
+                  DropdownMenuItem<String>(value: name, child: Text(name)),
+              ],
+              onChanged: (v) => setState(() => _client = v ?? _client),
+            ),
+          ),
+          _sheetField(
+            label: '유형',
+            child: DropdownButton<String>(
+              value: _type,
+              isExpanded: true,
+              underline: const SizedBox.shrink(),
+              items: <DropdownMenuItem<String>>[
+                for (final t in _types)
+                  DropdownMenuItem<String>(value: t, child: Text(t)),
+              ],
+              onChanged: (v) => setState(() => _type = v ?? _type),
+            ),
+          ),
+          _sheetField(
+            label: '시간',
+            child: Row(
+              children: <Widget>[
+                Expanded(
+                  child: DropdownButton<int>(
+                    value: _hour,
+                    isExpanded: true,
+                    underline: const SizedBox.shrink(),
+                    items: <DropdownMenuItem<int>>[
+                      for (var h = 6; h <= 22; h++)
+                        DropdownMenuItem<int>(
+                          value: h,
+                          child: Text('${h.toString().padLeft(2, '0')}시'),
+                        ),
+                    ],
+                    onChanged: (v) => setState(() => _hour = v ?? _hour),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.md),
+                Expanded(
+                  child: DropdownButton<int>(
+                    value: _minute,
+                    isExpanded: true,
+                    underline: const SizedBox.shrink(),
+                    items: const <DropdownMenuItem<int>>[
+                      DropdownMenuItem<int>(value: 0, child: Text('00분')),
+                      DropdownMenuItem<int>(value: 15, child: Text('15분')),
+                      DropdownMenuItem<int>(value: 30, child: Text('30분')),
+                      DropdownMenuItem<int>(value: 45, child: Text('45분')),
+                    ],
+                    onChanged: (v) => setState(() => _minute = v ?? _minute),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          _sheetField(
+            label: '소요 시간',
+            child: DropdownButton<int>(
+              value: _duration,
+              isExpanded: true,
+              underline: const SizedBox.shrink(),
+              items: <DropdownMenuItem<int>>[
+                for (final d in _durations)
+                  DropdownMenuItem<int>(value: d, child: Text('$d분')),
+              ],
+              onChanged: (v) => setState(() => _duration = v ?? _duration),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          Material(
+            color: AppColors.primary,
+            borderRadius: const BorderRadius.all(AppRadius.lg),
+            child: InkWell(
+              onTap: _saving ? null : _save,
+              borderRadius: const BorderRadius.all(AppRadius.lg),
+              child: Container(
+                height: 44,
+                alignment: Alignment.center,
+                child: Text(
+                  widget.existing == null ? '추가하기' : '저장하기',
+                  style: const TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.primaryForeground,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _sheetField({required String label, required Widget child}) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+      child: Row(
+        children: <Widget>[
+          SizedBox(
+            width: 72,
+            child: Text(
+              label,
+              style: const TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: AppColors.subtleForeground,
+              ),
+            ),
+          ),
+          Expanded(child: child),
+        ],
       ),
     );
   }
@@ -147,8 +536,9 @@ class _Header extends StatelessWidget {
   }
 }
 
-/// Mon–Sun strip for the current week with today highlighted; a dot
-/// marks days that have schedule entries (seed data covers today only).
+/// 7-day strip **centered on today** (D-3 … D+3) with today highlighted
+/// in the middle; a dot marks days that have schedule entries (seed
+/// data covers today only).
 class _WeekStrip extends StatelessWidget {
   const _WeekStrip({required this.hasScheduleToday});
 
@@ -159,17 +549,22 @@ class _WeekStrip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final now = DateTime.now();
-    final monday = DateTime(now.year, now.month, now.day - (now.weekday - 1));
+    final today = DateTime(now.year, now.month, now.day);
 
     return Row(
       children: <Widget>[
-        for (var i = 0; i < 7; i++)
+        for (var i = -3; i <= 3; i++)
           Expanded(
-            child: _DayCell(
-              label: _days[i],
-              date: monday.add(Duration(days: i)),
-              isToday: i == now.weekday - 1,
-              hasDot: i == now.weekday - 1 && hasScheduleToday,
+            child: Builder(
+              builder: (context) {
+                final date = today.add(Duration(days: i));
+                return _DayCell(
+                  label: _days[date.weekday - 1],
+                  date: date,
+                  isToday: i == 0,
+                  hasDot: i == 0 && hasScheduleToday,
+                );
+              },
             ),
           ),
       ],
@@ -245,6 +640,9 @@ class _TimelineRow extends StatelessWidget {
     required this.flashing,
     required this.onToggle,
     required this.onSend,
+    required this.onEdit,
+    required this.onDelete,
+    required this.onChat,
   });
 
   final ScheduleSession session;
@@ -253,6 +651,9 @@ class _TimelineRow extends StatelessWidget {
   final bool flashing;
   final VoidCallback onToggle;
   final VoidCallback onSend;
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+  final VoidCallback onChat;
 
   @override
   Widget build(BuildContext context) {
@@ -286,6 +687,9 @@ class _TimelineRow extends StatelessWidget {
                   flashing: flashing,
                   onToggle: onToggle,
                   onSend: onSend,
+                  onEdit: onEdit,
+                  onDelete: onDelete,
+                  onChat: onChat,
                 ),
         ),
       ],
@@ -325,6 +729,9 @@ class _SessionCard extends StatelessWidget {
     required this.flashing,
     required this.onToggle,
     required this.onSend,
+    required this.onEdit,
+    required this.onDelete,
+    required this.onChat,
   });
 
   final ScheduleSession session;
@@ -333,6 +740,9 @@ class _SessionCard extends StatelessWidget {
   final bool flashing;
   final VoidCallback onToggle;
   final VoidCallback onSend;
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+  final VoidCallback onChat;
 
   @override
   Widget build(BuildContext context) {
@@ -420,7 +830,7 @@ class _SessionCard extends StatelessWidget {
               ),
             ),
           ),
-          if (expanded && s.program.isNotEmpty)
+          if (expanded)
             Padding(
               padding: const EdgeInsets.fromLTRB(
                 AppSpacing.lg,
@@ -433,21 +843,35 @@ class _SessionCard extends StatelessWidget {
                 children: <Widget>[
                   const Divider(height: 1, color: AppColors.borderStrong),
                   const SizedBox(height: AppSpacing.md),
-                  for (var i = 0; i < s.program.length; i++) ...<Widget>[
-                    _ProgramRow(index: i + 1, item: s.program[i]),
-                    const SizedBox(height: AppSpacing.sm),
+                  if (s.program.isNotEmpty)
+                    for (var i = 0; i < s.program.length; i++) ...<Widget>[
+                      _ProgramRow(index: i + 1, item: s.program[i]),
+                      const SizedBox(height: AppSpacing.sm),
+                    ]
+                  else if (s.isUpcoming) ...<Widget>[
+                    // 예정 session without a plan yet.
+                    const _NoPlanBox(),
+                    const SizedBox(height: AppSpacing.md),
                   ],
                   if (s.note.isNotEmpty) ...<Widget>[
                     const SizedBox(height: AppSpacing.xs),
                     _NoteBox(note: s.note),
                     const SizedBox(height: AppSpacing.md),
                   ],
-                  _SendButton(
-                    clientName: s.clientName,
-                    sent: sent,
-                    flashing: flashing,
-                    onSend: onSend,
+                  _ManageRow(
+                    onEdit: onEdit,
+                    onDelete: onDelete,
+                    onChat: onChat,
                   ),
+                  if (s.isDone && s.program.isNotEmpty) ...<Widget>[
+                    const SizedBox(height: AppSpacing.md),
+                    _SendButton(
+                      clientName: s.clientName,
+                      sent: sent,
+                      flashing: flashing,
+                      onSend: onSend,
+                    ),
+                  ],
                 ],
               ),
             ),
@@ -554,6 +978,112 @@ class _ProgramRow extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// Shown inside an expanded 예정 session that has no program yet.
+class _NoPlanBox extends StatelessWidget {
+  const _NoPlanBox();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.md,
+        vertical: AppSpacing.md,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.background,
+        borderRadius: const BorderRadius.all(AppRadius.md),
+        border: Border.all(color: AppColors.borderStrong),
+      ),
+      child: const Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            '아직 계획된 프로그램이 없어요',
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              color: AppColors.mutedForeground,
+            ),
+          ),
+          SizedBox(height: 2),
+          Text(
+            'AI 루틴 탭에서 프로그램을 만들어 보내거나, 채팅으로 미리 조율해 보세요.',
+            style: TextStyle(
+              fontSize: 10.5,
+              fontWeight: FontWeight.w500,
+              color: AppColors.subtleForeground,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 수정 · 삭제 · 채팅 바로가기 actions for a booked session.
+class _ManageRow extends StatelessWidget {
+  const _ManageRow({
+    required this.onEdit,
+    required this.onDelete,
+    required this.onChat,
+  });
+
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+  final VoidCallback onChat;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: <Widget>[
+        _ActionChip(label: '✎ 수정', color: AppColors.accent, onTap: onEdit),
+        const SizedBox(width: AppSpacing.xs),
+        _ActionChip(label: '삭제', color: AppColors.destructive, onTap: onDelete),
+        const Spacer(),
+        _ActionChip(label: '💬 채팅', color: AppColors.accent, onTap: onChat),
+      ],
+    );
+  }
+}
+
+class _ActionChip extends StatelessWidget {
+  const _ActionChip({
+    required this.label,
+    required this.color,
+    required this.onTap,
+  });
+
+  final String label;
+  final Color color;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: color.withValues(alpha: 0.08),
+      borderRadius: const BorderRadius.all(AppRadius.pill),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: const BorderRadius.all(AppRadius.pill),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.md,
+            vertical: AppSpacing.xs,
+          ),
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: 10.5,
+              fontWeight: FontWeight.w700,
+              color: color,
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -290,6 +290,54 @@ void main() {
       expect(find.textContaining('AI가 박성호님의'), findsOneWidget);
     });
 
+    testWidgets('editing a session whose client is not in the roster keeps '
+        'its own values on a no-op save', (tester) async {
+      final container = await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+      );
+      await tester.tap(find.text('스케줄'));
+      await settle(tester);
+
+      // 신규 회원 (상담, 30분) is booked but is NOT a registered client.
+      await tester.scrollUntilVisible(find.text('신규 회원'), 120);
+      await tester.ensureVisible(find.text('신규 회원'));
+      await tester.pump();
+      await tester.tap(find.text('신규 회원'));
+      await tester.pump();
+
+      await tester.scrollUntilVisible(find.text('✎ 수정'), 120);
+      await tester.ensureVisible(find.text('✎ 수정'));
+      await tester.pump();
+      await tester.tap(find.text('✎ 수정'));
+      await settle(tester);
+
+      // Save without changing anything — the sheet must have prefilled
+      // the session's own values, not snapped to defaults.
+      await tester.tap(find.text('저장하기'));
+      await settle(tester);
+
+      // Read the row outside fake-async — a drift stream's .first would
+      // otherwise deadlock inside testWidgets.
+      String? clientName;
+      String? type;
+      int? duration;
+      await tester.runAsync(() async {
+        final slots = await container
+            .read(scheduleRepositoryProvider)
+            .watchToday()
+            .first;
+        final consult = slots.firstWhere((s) => s.time == '17:00');
+        clientName = consult.clientName;
+        type = consult.type;
+        duration = consult.durationMinutes;
+      });
+
+      expect(clientName, '신규 회원'); // not reassigned to 김민수
+      expect(type, '상담');
+      expect(duration, 30);
+    });
+
     testWidgets('a failed save shows a snackbar and keeps the sheet open', (
       tester,
     ) async {

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -1,4 +1,5 @@
 import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oncare_trainer/core/storage/app_database.dart';
@@ -6,6 +7,22 @@ import 'package:oncare_trainer/core/storage/seed_data.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
 
 import '../../helpers/pump_app.dart';
+
+/// A repository whose writes always fail — to exercise error handling.
+class _ThrowingScheduleRepository extends ScheduleRepository {
+  const _ThrowingScheduleRepository(super.db);
+
+  @override
+  Future<void> addSession({
+    required String clientName,
+    required String time,
+    required String type,
+    required int durationMinutes,
+  }) async => throw Exception('add failed');
+
+  @override
+  Future<void> deleteSession(String id) async => throw Exception('del failed');
+}
 
 void main() {
   group('ScheduleRepository.watchToday', () {
@@ -271,6 +288,63 @@ void main() {
       expect(find.text('채팅'), findsOneWidget);
       expect(find.text('운동기록'), findsOneWidget);
       expect(find.textContaining('AI가 박성호님의'), findsOneWidget);
+    });
+
+    testWidgets('a failed save shows a snackbar and keeps the sheet open', (
+      tester,
+    ) async {
+      await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        extraOverrides: <Override>[
+          scheduleRepositoryProvider.overrideWith(
+            (ref) =>
+                _ThrowingScheduleRepository(ref.watch(appDatabaseProvider)),
+          ),
+        ],
+      );
+      await tester.tap(find.text('스케줄'));
+      await settle(tester);
+
+      await tester.tap(find.text('＋ 새 일정 추가'));
+      await settle(tester);
+      await tester.tap(find.text('추가하기'));
+      await settle(tester);
+
+      expect(find.text('일정 저장에 실패했어요. 다시 시도해 주세요'), findsOneWidget);
+      // Sheet stays open (its title is still present) so input isn't lost.
+      expect(find.text('새 일정 추가'), findsOneWidget);
+    });
+
+    testWidgets('a failed delete shows a snackbar', (tester) async {
+      await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        extraOverrides: <Override>[
+          scheduleRepositoryProvider.overrideWith(
+            (ref) =>
+                _ThrowingScheduleRepository(ref.watch(appDatabaseProvider)),
+          ),
+        ],
+      );
+      await tester.tap(find.text('스케줄'));
+      await settle(tester);
+
+      await tester.scrollUntilVisible(find.text('박성호'), 120);
+      await tester.ensureVisible(find.text('박성호'));
+      await tester.pump();
+      await tester.tap(find.text('박성호'));
+      await tester.pump();
+
+      await tester.scrollUntilVisible(find.text('삭제'), 120);
+      await tester.ensureVisible(find.text('삭제'));
+      await tester.pump();
+      await tester.tap(find.text('삭제'));
+      await settle(tester);
+      await tester.tap(find.text('삭제').last); // confirm in dialog
+      await settle(tester);
+
+      expect(find.text('일정 삭제에 실패했어요. 다시 시도해 주세요'), findsOneWidget);
     });
   });
 }

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -41,9 +41,55 @@ void main() {
       expect(minsu.program.first.weight, '80kg');
 
       final seongho = slots.firstWhere((s) => s.clientName == '박성호');
-      expect(seongho.expandable, isFalse); // 예정 — not expandable
+      expect(seongho.expandable, isTrue); // 예정 now opens (plan preview)
+      expect(seongho.isUpcoming, isTrue);
       final consult = slots.firstWhere((s) => s.clientName == '신규 회원');
       expect(consult.program, isEmpty);
+      expect(consult.expandable, isTrue); // opens with the no-plan hint
+    });
+
+    test('addSession inserts an 예정 slot sorted into the timeline', () async {
+      final repo = ScheduleRepository(db);
+      await repo.addSession(
+        clientName: '이지수',
+        time: '10:15',
+        type: '1:1 PT',
+        durationMinutes: 45,
+      );
+      final slots = await repo.watchToday().first;
+      expect(slots.length, 7);
+      // Lands right after the 10:00 session (time-ordered).
+      expect(slots[1].time, '10:15');
+      expect(slots[1].clientName, '이지수');
+      expect(slots[1].isUpcoming, isTrue);
+      expect(slots[1].id.startsWith('seed-'), isFalse);
+    });
+
+    test('updateSession moves a slot to a 15-minute step', () async {
+      final repo = ScheduleRepository(db);
+      final before = await repo.watchToday().first;
+      final target = before.firstWhere((s) => s.clientName == '박성호');
+      await repo.updateSession(
+        target.id,
+        clientName: target.clientName,
+        time: '19:30',
+        type: target.type,
+        durationMinutes: 90,
+      );
+      final after = await repo.watchToday().first;
+      final moved = after.firstWhere((s) => s.clientName == '박성호');
+      expect(moved.time, '19:30');
+      expect(moved.durationMinutes, 90);
+    });
+
+    test('deleteSession removes the slot', () async {
+      final repo = ScheduleRepository(db);
+      final before = await repo.watchToday().first;
+      final target = before.firstWhere((s) => s.clientName == '신규 회원');
+      await repo.deleteSession(target.id);
+      final after = await repo.watchToday().first;
+      expect(after.length, before.length - 1);
+      expect(after.where((s) => s.clientName == '신규 회원'), isEmpty);
     });
   });
 
@@ -65,8 +111,10 @@ void main() {
       await tester.scrollUntilVisible(find.text('신규 회원'), 120);
       expect(find.text('박성호'), findsOneWidget);
       expect(find.text('상담 · 30분'), findsOneWidget);
-      expect(find.text('빈 시간'), findsNWidgets(2));
-      expect(find.text('예정'), findsNWidgets(2));
+      // Lazy list: off-screen rows are disposed, so assert presence
+      // rather than an exact count.
+      expect(find.text('빈 시간'), findsWidgets);
+      expect(find.text('예정'), findsWidgets);
     });
 
     testWidgets('completed session expands to program, note, and send flow', (
@@ -105,13 +153,124 @@ void main() {
       expect(find.text('✓ 김민수님에게 전송됨'), findsOneWidget);
     });
 
-    testWidgets('예정 sessions do not expand', (tester) async {
+    testWidgets('예정 session expands to the plan preview with manage '
+        'actions', (tester) async {
       await openSchedule(tester);
 
       await tester.scrollUntilVisible(find.text('박성호'), 120);
+      await tester.ensureVisible(find.text('박성호'));
+      await tester.pump();
       await tester.tap(find.text('박성호'));
       await tester.pump();
-      expect(find.text('벤치프레스'), findsNothing);
+
+      await tester.scrollUntilVisible(find.text('✎ 수정'), 120);
+      expect(find.text('벤치프레스'), findsOneWidget); // planned program
+      expect(find.text('삭제'), findsOneWidget);
+      expect(find.text('💬 채팅'), findsOneWidget);
+    });
+
+    testWidgets('예정 session without a plan shows the no-plan hint', (
+      tester,
+    ) async {
+      await openSchedule(tester);
+
+      await tester.scrollUntilVisible(find.text('신규 회원'), 120);
+      await tester.ensureVisible(find.text('신규 회원'));
+      await tester.pump();
+      await tester.tap(find.text('신규 회원'));
+      await tester.pump();
+
+      await tester.scrollUntilVisible(find.text('아직 계획된 프로그램이 없어요'), 120);
+      expect(find.text('아직 계획된 프로그램이 없어요'), findsOneWidget);
+    });
+
+    testWidgets('새 일정 추가 books a session at a 15-minute step', (tester) async {
+      await openSchedule(tester);
+
+      await tester.tap(find.text('＋ 새 일정 추가'));
+      await settle(tester);
+
+      // Change 00분 → 15분 in the time picker.
+      await tester.tap(find.text('00분'));
+      await settle(tester);
+      await tester.tap(find.text('15분').last);
+      await settle(tester);
+
+      await tester.tap(find.text('추가하기'));
+      await settle(tester);
+
+      expect(find.text('10:15'), findsOneWidget);
+    });
+
+    testWidgets('수정 moves 박성호 to a 15-minute step (15:00 → 15:30)', (
+      tester,
+    ) async {
+      await openSchedule(tester);
+
+      await tester.scrollUntilVisible(find.text('박성호'), 120);
+      await tester.ensureVisible(find.text('박성호'));
+      await tester.pump();
+      await tester.tap(find.text('박성호'));
+      await tester.pump();
+
+      await tester.scrollUntilVisible(find.text('✎ 수정'), 120);
+      await tester.ensureVisible(find.text('✎ 수정'));
+      await tester.pump();
+      await tester.tap(find.text('✎ 수정'));
+      await settle(tester);
+
+      // Change 00분 → 30분 in the time picker and save.
+      await tester.tap(find.text('00분'));
+      await settle(tester);
+      await tester.tap(find.text('30분').last);
+      await settle(tester);
+      await tester.tap(find.text('저장하기'));
+      await settle(tester);
+
+      expect(find.text('15:30'), findsOneWidget);
+      expect(find.text('15:00'), findsNothing);
+    });
+
+    testWidgets('삭제 removes the session after confirmation', (tester) async {
+      await openSchedule(tester);
+
+      await tester.scrollUntilVisible(find.text('신규 회원'), 120);
+      await tester.ensureVisible(find.text('신규 회원'));
+      await tester.pump();
+      await tester.tap(find.text('신규 회원'));
+      await tester.pump();
+
+      await tester.scrollUntilVisible(find.text('삭제'), 120);
+      await tester.ensureVisible(find.text('삭제'));
+      await tester.pump();
+      await tester.tap(find.text('삭제'));
+      await settle(tester);
+      // Confirm in the dialog (its action is the last 삭제 on screen).
+      await tester.tap(find.text('삭제').last);
+      await settle(tester);
+
+      expect(find.text('신규 회원'), findsNothing);
+    });
+
+    testWidgets('💬 채팅 jumps to the client detail chat', (tester) async {
+      await openSchedule(tester);
+
+      await tester.scrollUntilVisible(find.text('박성호'), 120);
+      await tester.ensureVisible(find.text('박성호'));
+      await tester.pump();
+      await tester.tap(find.text('박성호'));
+      await tester.pump();
+
+      await tester.scrollUntilVisible(find.text('💬 채팅'), 120);
+      await tester.ensureVisible(find.text('💬 채팅'));
+      await tester.pump();
+      await tester.tap(find.text('💬 채팅'));
+      await settle(tester);
+
+      // Full-screen client detail with the chat sub-tab.
+      expect(find.text('채팅'), findsOneWidget);
+      expect(find.text('운동기록'), findsOneWidget);
+      expect(find.textContaining('AI가 박성호님의'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary
* 일정 추가/수정/삭제(15분 단위 시간), 예정 세션 확장(계획 미리보기·계획 없음 안내·💬 채팅 바로가기), 오늘 중심 주간 스트립, 와이드 2컬럼.

## Changes
### ✨ Features
* `ScheduleRepository.addSession/updateSession/deleteSession` + 시간순 정렬, 예약/수정 바텀시트, 세션 관리 액션
### 🐛 Fixes
* 저장·삭제 실패 시 Snackbar 표시(저장 실패 시 시트 유지) — 조용히 전파되던 예외 처리
* 편집 시트가 세션 자신의 값을 항상 옵션에 포함 — 목록 밖 고객/비표준 소요시간/범위 밖 시각이 조용히 재배정·스냅되던 문제 해결 (리뷰 Major 반영)
### 🎨 UI/UX
* 오늘 중심 주간 스트립, 와이드 2컬럼(`splitListWidth` 좌측 개요)

## Commits
1. `ee4e00b` feat: schedule management — add/edit/delete, 15-minute steps, plan preview
2. `53f0264` fix: surface schedule save/delete failures with a snackbar
3. `24a25cf` fix: stop the edit sheet silently rewriting a session's own values
4. `0a7bc09` fix(a11y): merge sub-tab semantics… *(#216 )*
5. `3782750` fix: build the ?c= panel location through Uri *(#212 )*

## Notes
* 리뷰의 clientName→clientId 지적은 백엔드 연동 단계로 이월(현재 mock은 이름 고유·변경 없음, 서버 clientId로 대체 예정).
* 테스트: throwing repository로 저장·삭제 실패 안내 검증.

## Test Plan
* [ ] 기능 정상 동작 확인
* [ ] 예외 케이스 확인
* [ ] UI 확인
* [ ] 빌드 성공
* [ ] 관련 테스트 통과
### Manual Test Steps
1. 스케줄 탭 → ＋ 새 일정 추가 → 10:15 예약 → 타임라인 10:00 다음에 삽입 확인
4. 박성호 카드 확장 → 계획 미리보기 + ✎ 수정으로 15:30 변경 / 신규 회원 확장 → 무계획 안내 → 삭제
5. 💬 채팅 → 해당 고객 채팅으로 이동(와이드에선 스플릿 패널) 확인

## Related Issues
Closes #217 

## Checklist
* [ ] 코드 리뷰 준비 완료
* [ ] 불필요한 코드 제거
* [ ] 하드코딩 값 점검
* [ ] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인