### PR TITLE
feat(trainer): AI 루틴 스케줄 등록과 추천 항목 삭제

### DIFF
--- a/frontend/flutter_trainer/lib/app/router/routes.dart
+++ b/frontend/flutter_trainer/lib/app/router/routes.dart
@@ -26,4 +26,10 @@ class AppRoutes {
 
   /// Builds the client detail path for [id].
   static String clientDetail(String id) => '/client/$id';
+
+  /// Builds the 고객 tab location with [id] preselected (wide split
+  /// panel). Routed through [Uri] so the id is percent-encoded — string
+  /// concatenation would break on a `?`/`&`/non-ASCII id.
+  static String clientsWithSelection(String id) =>
+      Uri(path: clients, queryParameters: <String, String>{'c': id}).toString();
 }

--- a/frontend/flutter_trainer/lib/features/ai_routine/data/repositories/ai_routine_repository.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/data/repositories/ai_routine_repository.dart
@@ -74,10 +74,12 @@ class AiRoutineRepository {
     }
 
     final now = DateTime.now();
-    // Next full hour, capped at 23 so an evening registration lands on a
-    // FUTURE slot (22:xx → 23:00) instead of clamping down to a past
-    // 22:00 (review PR 220). Late-night bookings should use the date
-    // picker to target the next day.
+    // Next full hour, capped at the 23:00 slot. This keeps an evening
+    // registration in the future (22:xx → 23:00) where the previous cap
+    // of 22 produced a past 22:00. It does NOT cover 23:00–23:59: there
+    // is no later slot today, so that books at an already-past 23:00 —
+    // register after 23:00 against the next day via the date picker.
+    // A complete fix needs a server clock (review PR 220).
     final hour = (now.hour + 1).clamp(6, 23);
     await _db
         .into(table)

--- a/frontend/flutter_trainer/lib/features/ai_routine/data/repositories/ai_routine_repository.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/data/repositories/ai_routine_repository.dart
@@ -1,7 +1,10 @@
+import 'dart:convert';
+
 import 'package:drift/drift.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare_trainer/core/storage/app_database.dart';
+import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/features/ai_routine/domain/entities/ai_routine_item.dart';
 
 /// Reads a client's AI-suggested routine from the local drift DB.
@@ -31,6 +34,62 @@ class AiRoutineRepository {
           )
           .toList(),
     );
+  }
+
+  /// Registers the composed routine as [clientName]'s PT program on
+  /// today's schedule (스케줄 탭 watches the same table, so it updates
+  /// live). Attaches to the client's earliest 예정 session when one
+  /// exists; otherwise books a new one-hour 예정 slot at the next full
+  /// hour. Returns `true` when attached to an existing session.
+  ///
+  /// [program] entries follow the schedule programJson shape
+  /// (`{name, sets, reps, weight}`).
+  Future<bool> registerToTodaySchedule({
+    required String clientName,
+    required List<Map<String, Object?>> program,
+  }) async {
+    final table = _db.trainerScheduleEntries;
+    final today = ymd(DateTime.now());
+    final existing =
+        await (_db.select(table)
+              ..where(
+                (t) =>
+                    t.date.equals(today) &
+                    t.clientName.equals(clientName) &
+                    t.status.equals('예정'),
+              )
+              ..orderBy(<OrderingTerm Function($TrainerScheduleEntriesTable)>[
+                (t) => OrderingTerm(expression: t.time),
+              ])
+              ..limit(1))
+            .getSingleOrNull();
+
+    if (existing != null) {
+      await (_db.update(table)..where((t) => t.id.equals(existing.id))).write(
+        TrainerScheduleEntriesCompanion(
+          programJson: Value(jsonEncode(program)),
+        ),
+      );
+      return true;
+    }
+
+    final now = DateTime.now();
+    final hour = (now.hour + 1).clamp(6, 22);
+    await _db
+        .into(table)
+        .insert(
+          TrainerScheduleEntriesCompanion.insert(
+            id: 'sched-${now.microsecondsSinceEpoch}',
+            date: today,
+            time: '${hour.toString().padLeft(2, '0')}:00',
+            clientName: Value(clientName),
+            type: const Value('1:1 PT'),
+            durationMinutes: const Value(60),
+            status: '예정',
+            programJson: Value(jsonEncode(program)),
+          ),
+        );
+    return false;
   }
 }
 

--- a/frontend/flutter_trainer/lib/features/ai_routine/data/repositories/ai_routine_repository.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/data/repositories/ai_routine_repository.dart
@@ -74,7 +74,11 @@ class AiRoutineRepository {
     }
 
     final now = DateTime.now();
-    final hour = (now.hour + 1).clamp(6, 22);
+    // Next full hour, capped at 23 so an evening registration lands on a
+    // FUTURE slot (22:xx → 23:00) instead of clamping down to a past
+    // 22:00 (review PR 220). Late-night bookings should use the date
+    // picker to target the next day.
+    final hour = (now.hour + 1).clamp(6, 23);
     await _db
         .into(table)
         .insert(

--- a/frontend/flutter_trainer/lib/features/ai_routine/presentation/pages/ai_routine_page.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/presentation/pages/ai_routine_page.dart
@@ -58,6 +58,9 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
 
   /// A schedule registration just succeeded (drives the 3s flash).
   bool _registered = false;
+  // In-flight guard: set before the await so a second tap can't create a
+  // duplicate session while the first is still saving (review PR 220).
+  bool _registering = false;
   Timer? _registerTimer;
 
   @override
@@ -134,22 +137,34 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
     TrainerClient client,
     List<AiRoutineItem> items,
   ) async {
-    if (_registered) return;
-    final program = _composeProgram(items);
-    if (program.isEmpty) return;
+    if (_registered || _registering) return;
     final messenger = ScaffoldMessenger.of(context);
+    final program = _composeProgram(items);
+    if (program.isEmpty) {
+      // Every exercise was removed — tell the trainer instead of a
+      // silent no-op (review PR 220).
+      messenger.showSnackBar(
+        const SnackBar(content: Text('운동을 하나 이상 추가해 주세요')),
+      );
+      return;
+    }
+    setState(() => _registering = true);
     try {
       await ref
           .read(aiRoutineRepositoryProvider)
           .registerToTodaySchedule(clientName: client.name, program: program);
     } catch (_) {
+      if (mounted) setState(() => _registering = false);
       messenger.showSnackBar(
         const SnackBar(content: Text('스케줄 등록에 실패했어요. 다시 시도해 주세요')),
       );
       return;
     }
     if (!mounted) return;
-    setState(() => _registered = true);
+    setState(() {
+      _registering = false;
+      _registered = true;
+    });
     _registerTimer?.cancel();
     _registerTimer = Timer(const Duration(seconds: 3), () {
       if (mounted) setState(() => _registered = false);
@@ -416,7 +431,9 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
               ),
             const SizedBox(height: AppSpacing.sm),
             _RegisterButton(
-              registered: _registered,
+              // Disabled while registering (or after) so a second tap
+              // can't queue a duplicate session.
+              registered: _registered || _registering,
               onTap: () => _registerToSchedule(client, items),
             ),
             if (_registered)

--- a/frontend/flutter_trainer/lib/features/ai_routine/presentation/pages/ai_routine_page.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/presentation/pages/ai_routine_page.dart
@@ -4,9 +4,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/layout.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/features/ai_routine/data/repositories/ai_routine_repository.dart';
+import 'package:oncare_trainer/features/ai_routine/domain/entities/ai_routine_item.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
@@ -44,15 +46,24 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
   String? _clientId; // null until clients load (defaults to the first)
   final Map<String, int> _minuteEdits = <String, int>{};
   final Map<String, String> _nameEdits = <String, String>{};
+
+  /// AI suggestions the trainer removed for this round (in-memory,
+  /// like the other edits).
+  final Set<String> _removed = <String>{};
   String? _editingNameId;
   final List<_CustomExercise> _custom = <_CustomExercise>[];
   bool _showAddForm = false;
   bool _sent = false;
   Timer? _sentTimer;
 
+  /// A schedule registration just succeeded (drives the 3s flash).
+  bool _registered = false;
+  Timer? _registerTimer;
+
   @override
   void dispose() {
     _sentTimer?.cancel();
+    _registerTimer?.cancel();
     super.dispose();
   }
 
@@ -63,12 +74,15 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
       // A different client gets a clean slate, like the mock.
       _minuteEdits.clear();
       _nameEdits.clear();
+      _removed.clear();
       _editingNameId = null;
       _custom.clear();
       _showAddForm = false;
       _sent = false;
+      _registered = false;
     });
     _sentTimer?.cancel();
+    _registerTimer?.cancel();
   }
 
   void _send() {
@@ -83,11 +97,62 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
         _custom.clear();
         _minuteEdits.clear();
         _nameEdits.clear();
+        _removed.clear();
         // Close any editing UI too — otherwise an open name editor or
         // add-form would survive the "next round" reset (PR review).
         _editingNameId = null;
         _showAddForm = false;
       });
+    });
+  }
+
+  /// The composed routine (edited AI items minus removed, plus custom)
+  /// in the schedule programJson shape.
+  List<Map<String, Object?>> _composeProgram(List<AiRoutineItem> items) {
+    return <Map<String, Object?>>[
+      for (final item in items)
+        if (!_removed.contains(item.id))
+          <String, Object?>{
+            'name': _nameEdits[item.id] ?? item.name,
+            'sets': 1,
+            'reps': '${_minuteEdits[item.id] ?? item.minutes}분',
+            'weight': '-',
+          },
+      for (final c in _custom)
+        <String, Object?>{
+          'name': c.name,
+          'sets': 1,
+          'reps': '${c.minutes}분',
+          'weight': '-',
+        },
+    ];
+  }
+
+  /// Writes the routine onto today's schedule (attach to the client's
+  /// 예정 session, or book a new slot) and flashes a confirmation.
+  Future<void> _registerToSchedule(
+    TrainerClient client,
+    List<AiRoutineItem> items,
+  ) async {
+    if (_registered) return;
+    final program = _composeProgram(items);
+    if (program.isEmpty) return;
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref
+          .read(aiRoutineRepositoryProvider)
+          .registerToTodaySchedule(clientName: client.name, program: program);
+    } catch (_) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('스케줄 등록에 실패했어요. 다시 시도해 주세요')),
+      );
+      return;
+    }
+    if (!mounted) return;
+    setState(() => _registered = true);
+    _registerTimer?.cancel();
+    _registerTimer = Timer(const Duration(seconds: 3), () {
+      if (mounted) setState(() => _registered = false);
     });
   }
 
@@ -98,68 +163,124 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
     return Scaffold(
       backgroundColor: AppColors.background,
       body: SafeArea(
-        child: ContentFrame(
-          child: clientsAsync.when(
-            loading: () => const Center(child: CircularProgressIndicator()),
-            error: (e, _) => const Center(
-              child: Text(
-                '고객 정보를 불러오지 못했어요',
-                style: TextStyle(color: AppColors.mutedForeground),
-              ),
+        child: clientsAsync.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => const Center(
+            child: Text(
+              '고객 정보를 불러오지 못했어요',
+              style: TextStyle(color: AppColors.mutedForeground),
             ),
-            data: (clients) {
-              if (clients.isEmpty) {
-                return const Center(
-                  child: Text(
-                    '등록된 고객이 없어요',
-                    style: TextStyle(color: AppColors.mutedForeground),
+          ),
+          data: (clients) {
+            if (clients.isEmpty) {
+              return const Center(
+                child: Text(
+                  '등록된 고객이 없어요',
+                  style: TextStyle(color: AppColors.mutedForeground),
+                ),
+              );
+            }
+            final selected = clients.firstWhere(
+              (c) => c.id == _clientId,
+              orElse: () => clients.first,
+            );
+            return LayoutBuilder(
+              builder: (context, constraints) {
+                final wide = constraints.maxWidth >= AppLayout.splitBreakpoint;
+                if (!wide) {
+                  return ContentFrame(
+                    child: ListView(
+                      padding: const EdgeInsets.fromLTRB(
+                        AppSpacing.xl,
+                        AppSpacing.lg,
+                        AppSpacing.xl,
+                        AppSpacing.xxl,
+                      ),
+                      children: <Widget>[
+                        ..._overviewChildren(clients, selected),
+                        const SizedBox(height: AppSpacing.lg),
+                        ..._editorChildren(selected),
+                      ],
+                    ),
+                  );
+                }
+                // Wide: client/diet overview docks left, the routine
+                // editor gets its own column.
+                return ContentFrame(
+                  maxWidth: AppLayout.wideMaxWidth,
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: <Widget>[
+                      SizedBox(
+                        width: AppLayout.splitListWidth,
+                        child: ListView(
+                          padding: const EdgeInsets.fromLTRB(
+                            AppSpacing.xl,
+                            AppSpacing.lg,
+                            AppSpacing.xl,
+                            AppSpacing.xxl,
+                          ),
+                          children: _overviewChildren(clients, selected),
+                        ),
+                      ),
+                      const VerticalDivider(
+                        width: 1,
+                        color: AppColors.borderStrong,
+                      ),
+                      Expanded(
+                        child: ListView(
+                          padding: const EdgeInsets.fromLTRB(
+                            AppSpacing.xl,
+                            AppSpacing.lg,
+                            AppSpacing.xl,
+                            AppSpacing.xxl,
+                          ),
+                          children: _editorChildren(selected),
+                        ),
+                      ),
+                    ],
                   ),
                 );
-              }
-              final selected = clients.firstWhere(
-                (c) => c.id == _clientId,
-                orElse: () => clients.first,
-              );
-              return _buildBody(clients, selected);
-            },
-          ),
+              },
+            );
+          },
         ),
       ),
     );
   }
 
-  Widget _buildBody(List<TrainerClient> clients, TrainerClient client) {
-    final routineAsync = ref.watch(aiRoutineProvider(client.id));
-
-    return ListView(
-      padding: const EdgeInsets.fromLTRB(
-        AppSpacing.xl,
-        AppSpacing.lg,
-        AppSpacing.xl,
-        AppSpacing.xxl,
+  /// Title, client picker, and diet summary (left column on wide).
+  List<Widget> _overviewChildren(
+    List<TrainerClient> clients,
+    TrainerClient client,
+  ) {
+    return <Widget>[
+      Text(
+        'AI 루틴 생성',
+        style: Theme.of(
+          context,
+        ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w800),
       ),
-      children: <Widget>[
-        Text(
-          'AI 루틴 생성',
-          style: Theme.of(
-            context,
-          ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w800),
+      const Text(
+        '고객 식단 · 건강 데이터 기반',
+        style: TextStyle(
+          fontSize: 11.5,
+          fontWeight: FontWeight.w500,
+          color: AppColors.subtleForeground,
         ),
-        const Text(
-          '고객 식단 · 건강 데이터 기반',
-          style: TextStyle(
-            fontSize: 11.5,
-            fontWeight: FontWeight.w500,
-            color: AppColors.subtleForeground,
-          ),
-        ),
-        const SizedBox(height: AppSpacing.lg),
-        _sectionLabel('고객 선택'),
-        const SizedBox(height: AppSpacing.sm),
-        Row(
+      ),
+      const SizedBox(height: AppSpacing.lg),
+      _sectionLabel('고객 선택'),
+      const SizedBox(height: AppSpacing.sm),
+      // Horizontal scroll instead of one cramped Row — stays usable as
+      // the roster grows past the seeded three (codex review).
+      SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
           children: <Widget>[
             for (final c in clients) ...<Widget>[
-              Expanded(
+              SizedBox(
+                width: 104,
                 child: _ClientChip(
                   client: c,
                   selected: c.id == client.id,
@@ -170,57 +291,63 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
             ],
           ],
         ),
-        const SizedBox(height: AppSpacing.lg),
-        _sectionLabel('오늘 식단 요약'),
-        const SizedBox(height: AppSpacing.sm),
-        _DietSummaryCard(client: client),
-        const SizedBox(height: AppSpacing.lg),
-        Row(
-          children: <Widget>[
-            _sectionLabel('AI 추천 루틴'),
-            const SizedBox(width: AppSpacing.xs),
-            const Text(
-              '· 수정 가능',
+      ),
+      const SizedBox(height: AppSpacing.lg),
+      _sectionLabel('오늘 식단 요약'),
+      const SizedBox(height: AppSpacing.sm),
+      _DietSummaryCard(client: client),
+    ];
+  }
+
+  /// The routine editor column (right column on wide).
+  List<Widget> _editorChildren(TrainerClient client) {
+    final routineAsync = ref.watch(aiRoutineProvider(client.id));
+
+    return <Widget>[
+      Row(
+        children: <Widget>[
+          _sectionLabel('AI 추천 루틴'),
+          const SizedBox(width: AppSpacing.xs),
+          const Text(
+            '· 수정 가능',
+            style: TextStyle(fontSize: 11, color: AppColors.disabledForeground),
+          ),
+          const Spacer(),
+          Container(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.sm,
+              vertical: 2,
+            ),
+            decoration: const BoxDecoration(
+              color: AppColors.accentSurface,
+              borderRadius: BorderRadius.all(AppRadius.pill),
+            ),
+            child: const Text(
+              '✦ 자동 생성',
               style: TextStyle(
-                fontSize: 11,
-                color: AppColors.disabledForeground,
+                fontSize: 9,
+                fontWeight: FontWeight.w700,
+                color: AppColors.accent,
               ),
             ),
-            const Spacer(),
-            Container(
-              padding: const EdgeInsets.symmetric(
-                horizontal: AppSpacing.sm,
-                vertical: 2,
-              ),
-              decoration: const BoxDecoration(
-                color: AppColors.accentSurface,
-                borderRadius: BorderRadius.all(AppRadius.pill),
-              ),
-              child: const Text(
-                '✦ 자동 생성',
-                style: TextStyle(
-                  fontSize: 9,
-                  fontWeight: FontWeight.w700,
-                  color: AppColors.accent,
-                ),
-              ),
-            ),
-          ],
+          ),
+        ],
+      ),
+      const SizedBox(height: AppSpacing.sm),
+      routineAsync.when(
+        loading: () => const Padding(
+          padding: EdgeInsets.all(AppSpacing.xl),
+          child: Center(child: CircularProgressIndicator()),
         ),
-        const SizedBox(height: AppSpacing.sm),
-        routineAsync.when(
-          loading: () => const Padding(
-            padding: EdgeInsets.all(AppSpacing.xl),
-            child: Center(child: CircularProgressIndicator()),
-          ),
-          error: (e, _) => const Text(
-            '루틴을 불러오지 못했어요',
-            style: TextStyle(color: AppColors.mutedForeground),
-          ),
-          data: (items) => Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              for (final item in items) ...<Widget>[
+        error: (e, _) => const Text(
+          '루틴을 불러오지 못했어요',
+          style: TextStyle(color: AppColors.mutedForeground),
+        ),
+        data: (items) => Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            for (final item in items)
+              if (!_removed.contains(item.id)) ...<Widget>[
                 _RoutineCard(
                   name: _nameEdits[item.id] ?? item.name,
                   minutes: _minuteEdits[item.id] ?? item.minutes,
@@ -232,58 +359,83 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
                   onNameChanged: (v) => _nameEdits[item.id] = v,
                   onNameDone: () => setState(() => _editingNameId = null),
                   onMinutes: (m) => setState(() => _minuteEdits[item.id] = m),
+                  // AI suggestions can be dropped from this round too.
+                  onDelete: () => setState(() {
+                    _removed.add(item.id);
+                    if (_editingNameId == item.id) _editingNameId = null;
+                  }),
                 ),
                 const SizedBox(height: AppSpacing.sm),
               ],
-              for (var i = 0; i < _custom.length; i++) ...<Widget>[
-                _RoutineCard(
-                  name: _custom[i].name,
-                  minutes: _custom[i].minutes,
-                  type: _custom[i].type,
-                  reason: '트레이너 추가',
-                  isCustom: true,
-                  onDelete: () => setState(() => _custom.removeAt(i)),
-                ),
-                const SizedBox(height: AppSpacing.sm),
-              ],
-              const SizedBox(height: AppSpacing.xs),
-              _showAddForm
-                  ? _AddExerciseForm(
-                      onCancel: () => setState(() => _showAddForm = false),
-                      onAdd: (name, minutes, type) => setState(() {
-                        _custom.add(
-                          _CustomExercise(
-                            name: name,
-                            minutes: minutes,
-                            type: type,
-                          ),
-                        );
-                        _showAddForm = false;
-                      }),
-                    )
-                  : _AddExerciseButton(
-                      onTap: () => setState(() => _showAddForm = true),
-                    ),
-              const SizedBox(height: AppSpacing.lg),
-              _SendButton(clientName: client.name, sent: _sent, onSend: _send),
-              if (_sent)
-                const Padding(
-                  padding: EdgeInsets.only(top: AppSpacing.sm),
-                  child: Text(
-                    '고객 앱에 알림이 전송됐어요',
-                    textAlign: TextAlign.center,
-                    style: TextStyle(
-                      fontSize: 10.5,
-                      fontWeight: FontWeight.w600,
-                      color: AppColors.success,
-                    ),
+            for (var i = 0; i < _custom.length; i++) ...<Widget>[
+              _RoutineCard(
+                name: _custom[i].name,
+                minutes: _custom[i].minutes,
+                type: _custom[i].type,
+                reason: '트레이너 추가',
+                isCustom: true,
+                onDelete: () => setState(() => _custom.removeAt(i)),
+              ),
+              const SizedBox(height: AppSpacing.sm),
+            ],
+            const SizedBox(height: AppSpacing.xs),
+            _showAddForm
+                ? _AddExerciseForm(
+                    onCancel: () => setState(() => _showAddForm = false),
+                    onAdd: (name, minutes, type) => setState(() {
+                      _custom.add(
+                        _CustomExercise(
+                          name: name,
+                          minutes: minutes,
+                          type: type,
+                        ),
+                      );
+                      _showAddForm = false;
+                    }),
+                  )
+                : _AddExerciseButton(
+                    onTap: () => setState(() => _showAddForm = true),
+                  ),
+            const SizedBox(height: AppSpacing.lg),
+            // Two destinations: homework to the client's app (mock),
+            // or today's PT session program (real drift write that the
+            // 스케줄 탭 picks up live).
+            _SendButton(clientName: client.name, sent: _sent, onSend: _send),
+            if (_sent)
+              const Padding(
+                padding: EdgeInsets.only(top: AppSpacing.sm),
+                child: Text(
+                  '고객 앱에 알림이 전송됐어요',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 10.5,
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.success,
                   ),
                 ),
-            ],
-          ),
+              ),
+            const SizedBox(height: AppSpacing.sm),
+            _RegisterButton(
+              registered: _registered,
+              onTap: () => _registerToSchedule(client, items),
+            ),
+            if (_registered)
+              const Padding(
+                padding: EdgeInsets.only(top: AppSpacing.sm),
+                child: Text(
+                  '스케줄 탭에서 오늘 세션의 프로그램으로 확인할 수 있어요',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 10.5,
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.success,
+                  ),
+                ),
+              ),
+          ],
         ),
-      ],
-    );
+      ),
+    ];
   }
 
   Widget _sectionLabel(String text) {
@@ -537,7 +689,7 @@ class _RoutineCard extends StatelessWidget {
                         ),
                       ),
               ),
-              if (isCustom)
+              if (onDelete != null)
                 GestureDetector(
                   onTap: onDelete,
                   child: const Padding(
@@ -914,6 +1066,44 @@ class _FormButton extends StatelessWidget {
               fontSize: 12,
               fontWeight: FontWeight.w700,
               color: foreground,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Secondary action — registers the routine as today's PT session
+/// program on the 스케줄 tab.
+class _RegisterButton extends StatelessWidget {
+  const _RegisterButton({required this.registered, required this.onTap});
+
+  final bool registered;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = registered ? AppColors.success : AppColors.accent;
+    return Material(
+      color: Colors.transparent,
+      borderRadius: const BorderRadius.all(AppRadius.card),
+      child: InkWell(
+        onTap: registered ? null : onTap,
+        borderRadius: const BorderRadius.all(AppRadius.card),
+        child: Container(
+          height: 44,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            borderRadius: const BorderRadius.all(AppRadius.card),
+            border: Border.all(color: color.withValues(alpha: 0.5)),
+          ),
+          child: Text(
+            registered ? '✓ 오늘 스케줄에 등록됨' : '📅 오늘 PT 스케줄에 등록',
+            style: TextStyle(
+              fontSize: 12.5,
+              fontWeight: FontWeight.w700,
+              color: color,
             ),
           ),
         ),

--- a/frontend/flutter_trainer/lib/features/ai_routine/presentation/pages/ai_routine_page.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/presentation/pages/ai_routine_page.dart
@@ -83,6 +83,10 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
       _showAddForm = false;
       _sent = false;
       _registered = false;
+      // Also drop the in-flight guard: a registration still saving for
+      // the PREVIOUS client must not leave this one stuck disabled — its
+      // late result is ignored in _registerToSchedule (review PR 220).
+      _registering = false;
     });
     _sentTimer?.cancel();
     _registerTimer?.cancel();
@@ -133,6 +137,12 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
 
   /// Writes the routine onto today's schedule (attach to the client's
   /// 예정 session, or book a new slot) and flashes a confirmation.
+  /// Whether [clientId] is still the client on screen. `_clientId` is
+  /// null until the trainer picks someone (the first client is shown by
+  /// default), so null means "still the initial selection".
+  bool _isStillSelected(String clientId) =>
+      _clientId == null || _clientId == clientId;
+
   Future<void> _registerToSchedule(
     TrainerClient client,
     List<AiRoutineItem> items,
@@ -148,19 +158,24 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
       );
       return;
     }
+    // Remember who this write is for — the trainer can switch clients
+    // while it saves, and the result must not be attributed to the new
+    // one (review PR 220).
+    final registeredFor = client.id;
     setState(() => _registering = true);
     try {
       await ref
           .read(aiRoutineRepositoryProvider)
           .registerToTodaySchedule(clientName: client.name, program: program);
     } catch (_) {
-      if (mounted) setState(() => _registering = false);
+      if (!mounted || !_isStillSelected(registeredFor)) return;
+      setState(() => _registering = false);
       messenger.showSnackBar(
         const SnackBar(content: Text('스케줄 등록에 실패했어요. 다시 시도해 주세요')),
       );
       return;
     }
-    if (!mounted) return;
+    if (!mounted || !_isStillSelected(registeredFor)) return;
     setState(() {
       _registering = false;
       _registered = true;

--- a/frontend/flutter_trainer/lib/features/ai_routine/presentation/pages/ai_routine_page.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/presentation/pages/ai_routine_page.dart
@@ -58,9 +58,11 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
 
   /// A schedule registration just succeeded (drives the 3s flash).
   bool _registered = false;
-  // In-flight guard: set before the await so a second tap can't create a
-  // duplicate session while the first is still saving (review PR 220).
-  bool _registering = false;
+  // The client whose registration is in flight (null when none). Tracked
+  // per-client — not a plain bool — so switching away and back can't let
+  // the SAME client's registration be triggered twice while the first is
+  // still saving (review PR 220).
+  String? _registeringClientId;
   Timer? _registerTimer;
 
   @override
@@ -83,10 +85,9 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
       _showAddForm = false;
       _sent = false;
       _registered = false;
-      // Also drop the in-flight guard: a registration still saving for
-      // the PREVIOUS client must not leave this one stuck disabled — its
-      // late result is ignored in _registerToSchedule (review PR 220).
-      _registering = false;
+      // NOTE: _registeringClientId is intentionally NOT cleared — a
+      // registration in flight for another client keeps being tracked,
+      // so returning to it still blocks a duplicate (review PR 220).
     });
     _sentTimer?.cancel();
     _registerTimer?.cancel();
@@ -147,7 +148,9 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
     TrainerClient client,
     List<AiRoutineItem> items,
   ) async {
-    if (_registered || _registering) return;
+    // Block a duplicate for THIS client — either just registered, or one
+    // is already in flight for them.
+    if (_registered || _registeringClientId == client.id) return;
     final messenger = ScaffoldMessenger.of(context);
     final program = _composeProgram(items);
     if (program.isEmpty) {
@@ -158,28 +161,33 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
       );
       return;
     }
-    // Remember who this write is for — the trainer can switch clients
-    // while it saves, and the result must not be attributed to the new
-    // one (review PR 220).
     final registeredFor = client.id;
-    setState(() => _registering = true);
+    setState(() => _registeringClientId = registeredFor);
     try {
       await ref
           .read(aiRoutineRepositoryProvider)
           .registerToTodaySchedule(clientName: client.name, program: program);
     } catch (_) {
-      if (!mounted || !_isStillSelected(registeredFor)) return;
-      setState(() => _registering = false);
-      messenger.showSnackBar(
-        const SnackBar(content: Text('스케줄 등록에 실패했어요. 다시 시도해 주세요')),
-      );
+      if (!mounted) return;
+      // Clear the guard for this client so it can be retried.
+      if (_registeringClientId == registeredFor) {
+        setState(() => _registeringClientId = null);
+      }
+      // Only surface the error if that client is still on screen.
+      if (_isStillSelected(registeredFor)) {
+        messenger.showSnackBar(
+          const SnackBar(content: Text('스케줄 등록에 실패했어요. 다시 시도해 주세요')),
+        );
+      }
       return;
     }
-    if (!mounted || !_isStillSelected(registeredFor)) return;
-    setState(() {
-      _registering = false;
-      _registered = true;
-    });
+    if (!mounted) return;
+    if (_registeringClientId == registeredFor) {
+      setState(() => _registeringClientId = null);
+    }
+    // Attribute the success flash only to the client it was started for.
+    if (!_isStillSelected(registeredFor)) return;
+    setState(() => _registered = true);
     _registerTimer?.cancel();
     _registerTimer = Timer(const Duration(seconds: 3), () {
       if (mounted) setState(() => _registered = false);
@@ -446,9 +454,10 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
               ),
             const SizedBox(height: AppSpacing.sm),
             _RegisterButton(
-              // Disabled while registering (or after) so a second tap
-              // can't queue a duplicate session.
-              registered: _registered || _registering,
+              // Disabled just after registering, or while THIS client's
+              // registration is in flight, so a second tap can't queue a
+              // duplicate session.
+              registered: _registered || _registeringClientId == client.id,
               onTap: () => _registerToSchedule(client, items),
             ),
             if (_registered)

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -130,7 +130,7 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
     final id = match.first.id;
     final wide = MediaQuery.sizeOf(context).width >= AppLayout.splitBreakpoint;
     if (wide) {
-      context.go('${AppRoutes.clients}?c=$id');
+      context.go(AppRoutes.clientsWithSelection(id));
     } else {
       context.go(AppRoutes.clients);
       context.push(AppRoutes.clientDetail(id));

--- a/frontend/flutter_trainer/test/features/ai_routine/ai_routine_page_test.dart
+++ b/frontend/flutter_trainer/test/features/ai_routine/ai_routine_page_test.dart
@@ -29,6 +29,58 @@ void main() {
       final jisu = await repo.watchRoutine('seed-client-2').first;
       expect(jisu.first.name, '인터벌 런닝');
     });
+
+    test(
+      'registerToTodaySchedule attaches to an existing 예정 session',
+      () async {
+        final repo = AiRoutineRepository(db);
+        // 박성호 has a seeded 15:00 예정 session.
+        final attached = await repo.registerToTodaySchedule(
+          clientName: '박성호',
+          program: <Map<String, Object?>>[
+            <String, Object?>{
+              'name': '저강도 유산소',
+              'sets': 1,
+              'reps': '30분',
+              'weight': '-',
+            },
+          ],
+        );
+        expect(attached, isTrue);
+
+        final rows = await db.select(db.trainerScheduleEntries).get();
+        final his = rows.where((r) => r.clientName == '박성호').toList();
+        expect(his.length, 1); // no extra slot booked
+        expect(his.single.programJson, contains('저강도 유산소'));
+      },
+    );
+
+    test(
+      'registerToTodaySchedule books a new slot when no 예정 exists',
+      () async {
+        final repo = AiRoutineRepository(db);
+        // 김민수's only session today is 완료 — a new slot gets booked.
+        final attached = await repo.registerToTodaySchedule(
+          clientName: '김민수',
+          program: <Map<String, Object?>>[
+            <String, Object?>{
+              'name': '코어 강화',
+              'sets': 1,
+              'reps': '10분',
+              'weight': '-',
+            },
+          ],
+        );
+        expect(attached, isFalse);
+
+        final rows = await db.select(db.trainerScheduleEntries).get();
+        final his = rows.where((r) => r.clientName == '김민수').toList();
+        expect(his.length, 2);
+        final booked = his.firstWhere((r) => r.status == '예정');
+        expect(booked.programJson, contains('코어 강화'));
+        expect(booked.id.startsWith('seed-'), isFalse);
+      },
+    );
   });
 
   group('AiRoutinePage', () {
@@ -67,7 +119,11 @@ void main() {
     testWidgets('adding and deleting a custom exercise', (tester) async {
       await openTab(tester);
 
-      await tester.scrollUntilVisible(find.text('＋ 운동 직접 추가'), 150);
+      await tester.scrollUntilVisible(
+        find.text('＋ 운동 직접 추가'),
+        150,
+        scrollable: find.byType(Scrollable).first,
+      );
       await tester.ensureVisible(find.text('＋ 운동 직접 추가'));
       await tester.pump();
       await tester.tap(find.text('＋ 운동 직접 추가'));
@@ -79,13 +135,17 @@ void main() {
       await tester.tap(find.text('추가하기'));
       await tester.pump();
       // The new custom card may land below the fold.
-      await tester.scrollUntilVisible(find.text('레그프레스 5세트'), 150);
+      await tester.scrollUntilVisible(
+        find.text('레그프레스 5세트'),
+        150,
+        scrollable: find.byType(Scrollable).first,
+      );
 
       expect(find.text('레그프레스 5세트'), findsOneWidget);
       expect(find.text('💡 트레이너 추가'), findsOneWidget);
 
       // Delete it again.
-      await tester.tap(find.byIcon(Icons.close));
+      await tester.tap(find.byIcon(Icons.close).last);
       await tester.pump();
       expect(find.text('레그프레스 5세트'), findsNothing);
     });
@@ -94,7 +154,11 @@ void main() {
       await openTab(tester);
 
       // Open the add form, then send with it still open.
-      await tester.scrollUntilVisible(find.text('＋ 운동 직접 추가'), 150);
+      await tester.scrollUntilVisible(
+        find.text('＋ 운동 직접 추가'),
+        150,
+        scrollable: find.byType(Scrollable).first,
+      );
       await tester.ensureVisible(find.text('＋ 운동 직접 추가'));
       await tester.pump();
       await tester.tap(find.text('＋ 운동 직접 추가'));
@@ -116,14 +180,76 @@ void main() {
       await tester.pump(const Duration(seconds: 4)); // reset window
       // The add form must be closed again after the reset.
       expect(find.text('운동 추가'), findsNothing);
-      await tester.scrollUntilVisible(find.text('＋ 운동 직접 추가'), 150);
+      await tester.scrollUntilVisible(
+        find.text('＋ 운동 직접 추가'),
+        150,
+        scrollable: find.byType(Scrollable).first,
+      );
       expect(find.text('＋ 운동 직접 추가'), findsOneWidget);
+    });
+
+    testWidgets('an AI suggestion can be removed for this round', (
+      tester,
+    ) async {
+      await openTab(tester);
+
+      expect(find.text('저강도 유산소 (걷기)'), findsOneWidget);
+      // Every card carries an X now — the first belongs to the first
+      // AI suggestion.
+      await tester.tap(find.byIcon(Icons.close).first);
+      await tester.pump();
+      expect(find.text('저강도 유산소 (걷기)'), findsNothing);
+
+      // Switching clients and back restores the full suggestion list.
+      await tester.tap(find.text('이지수'));
+      await settle(tester);
+      await tester.tap(find.text('김민수'));
+      await settle(tester);
+      expect(find.text('저강도 유산소 (걷기)'), findsOneWidget);
+    });
+
+    testWidgets('오늘 스케줄에 등록 writes the routine onto the schedule tab', (
+      tester,
+    ) async {
+      await openTab(tester);
+
+      // 박성호 → his 15:00 예정 session receives the program.
+      await tester.tap(find.text('박성호'));
+      await settle(tester);
+
+      await tester.scrollUntilVisible(
+        find.text('📅 오늘 PT 스케줄에 등록'),
+        150,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.ensureVisible(find.text('📅 오늘 PT 스케줄에 등록'));
+      await tester.pump();
+      await tester.tap(find.text('📅 오늘 PT 스케줄에 등록'));
+      await settle(tester);
+
+      expect(find.text('✓ 오늘 스케줄에 등록됨'), findsOneWidget);
+      expect(find.text('스케줄 탭에서 오늘 세션의 프로그램으로 확인할 수 있어요'), findsOneWidget);
+
+      // The 스케줄 tab shows the registered plan on his 예정 session.
+      await tester.tap(find.text('스케줄'));
+      await settle(tester);
+      await tester.scrollUntilVisible(find.text('박성호'), 120);
+      await tester.ensureVisible(find.text('박성호'));
+      await tester.pump();
+      await tester.tap(find.text('박성호'));
+      await tester.pump();
+      await tester.scrollUntilVisible(find.text('벤치프레스 4세트'), 120);
+      expect(find.text('벤치프레스 4세트'), findsOneWidget); // AI routine item
     });
 
     testWidgets('send shows confirmation then resets edits', (tester) async {
       await openTab(tester);
 
-      await tester.scrollUntilVisible(find.textContaining('님에게 전송'), 150);
+      await tester.scrollUntilVisible(
+        find.textContaining('님에게 전송'),
+        150,
+        scrollable: find.byType(Scrollable).first,
+      );
       await tester.ensureVisible(find.textContaining('님에게 전송'));
       await tester.pump();
       await tester.tap(find.textContaining('님에게 전송'));

--- a/frontend/flutter_trainer/test/features/ai_routine/ai_routine_page_test.dart
+++ b/frontend/flutter_trainer/test/features/ai_routine/ai_routine_page_test.dart
@@ -322,6 +322,49 @@ void main() {
       expect(repo.registerCalls, 1);
     });
 
+    testWidgets('switching clients mid-registration does not flash success '
+        'on the new client', (tester) async {
+      await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        extraOverrides: <Override>[
+          aiRoutineRepositoryProvider.overrideWith(
+            (ref) =>
+                _SlowCountingRoutineRepository(ref.watch(appDatabaseProvider)),
+          ),
+        ],
+      );
+      await tester.tap(find.text('AI루틴'));
+      await settle(tester);
+
+      await tester.scrollUntilVisible(
+        find.text('📅 오늘 PT 스케줄에 등록'),
+        150,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.ensureVisible(find.text('📅 오늘 PT 스케줄에 등록'));
+      await tester.pump();
+      await tester.tap(find.text('📅 오늘 PT 스케줄에 등록'));
+      await tester.pump(const Duration(milliseconds: 50));
+
+      // Switch client while the write for 김민수 is still in flight —
+      // the picker is above the button, so scroll back up to it.
+      await tester.scrollUntilVisible(
+        find.text('이지수'),
+        -150,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.ensureVisible(find.text('이지수'));
+      await tester.pump();
+      await tester.tap(find.text('이지수'));
+      await settle(tester);
+
+      // 이지수's card must not claim the registration, and her button
+      // must not be left disabled by the previous client's guard.
+      expect(find.text('✓ 오늘 스케줄에 등록됨'), findsNothing);
+      expect(find.text('📅 오늘 PT 스케줄에 등록'), findsOneWidget);
+    });
+
     testWidgets('registering with every exercise removed shows a hint', (
       tester,
     ) async {

--- a/frontend/flutter_trainer/test/features/ai_routine/ai_routine_page_test.dart
+++ b/frontend/flutter_trainer/test/features/ai_routine/ai_routine_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oncare_trainer/core/storage/app_database.dart';
@@ -7,6 +8,27 @@ import 'package:oncare_trainer/core/storage/seed_data.dart';
 import 'package:oncare_trainer/features/ai_routine/data/repositories/ai_routine_repository.dart';
 
 import '../../helpers/pump_app.dart';
+
+/// Counts registration calls and delays them, to test the in-flight
+/// double-tap guard.
+class _SlowCountingRoutineRepository extends AiRoutineRepository {
+  _SlowCountingRoutineRepository(super.db);
+
+  int registerCalls = 0;
+
+  @override
+  Future<bool> registerToTodaySchedule({
+    required String clientName,
+    required List<Map<String, Object?>> program,
+  }) async {
+    registerCalls++;
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    return super.registerToTodaySchedule(
+      clientName: clientName,
+      program: program,
+    );
+  }
+}
 
 void main() {
   group('AiRoutineRepository.watchRoutine', () {
@@ -260,6 +282,68 @@ void main() {
 
       await tester.pump(const Duration(seconds: 4)); // reset window
       expect(find.textContaining('검토 완료'), findsOneWidget);
+    });
+
+    testWidgets('mashing 스케줄 등록 registers only once', (tester) async {
+      final container = await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        extraOverrides: <Override>[
+          // Shares the app's seeded DB so the AI suggestions load.
+          aiRoutineRepositoryProvider.overrideWith(
+            (ref) =>
+                _SlowCountingRoutineRepository(ref.watch(appDatabaseProvider)),
+          ),
+        ],
+      );
+      await tester.tap(find.text('AI루틴'));
+      await settle(tester);
+
+      await tester.scrollUntilVisible(
+        find.text('📅 오늘 PT 스케줄에 등록'),
+        150,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.ensureVisible(find.text('📅 오늘 PT 스케줄에 등록'));
+      await tester.pump();
+      await tester.tap(find.text('📅 오늘 PT 스케줄에 등록'));
+      await tester.pump(const Duration(milliseconds: 50));
+      // Second tap lands mid-flight — the button is now disabled and its
+      // label has flipped, so this must NOT trigger a second register.
+      await tester.tap(
+        find.textContaining('스케줄에 등록').first,
+        warnIfMissed: false,
+      );
+      await settle(tester);
+
+      final repo =
+          container.read(aiRoutineRepositoryProvider)
+              as _SlowCountingRoutineRepository;
+      expect(repo.registerCalls, 1);
+    });
+
+    testWidgets('registering with every exercise removed shows a hint', (
+      tester,
+    ) async {
+      await openTab(tester);
+
+      // Remove all three seeded AI suggestions for 김민수.
+      for (var i = 0; i < 3; i++) {
+        await tester.tap(find.byIcon(Icons.close).first);
+        await tester.pump();
+      }
+
+      await tester.scrollUntilVisible(
+        find.text('📅 오늘 PT 스케줄에 등록'),
+        150,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.ensureVisible(find.text('📅 오늘 PT 스케줄에 등록'));
+      await tester.pump();
+      await tester.tap(find.text('📅 오늘 PT 스케줄에 등록'));
+      await tester.pump();
+
+      expect(find.text('운동을 하나 이상 추가해 주세요'), findsOneWidget);
     });
   });
 }

--- a/frontend/flutter_trainer/test/features/ai_routine/ai_routine_page_test.dart
+++ b/frontend/flutter_trainer/test/features/ai_routine/ai_routine_page_test.dart
@@ -365,6 +365,64 @@ void main() {
       expect(find.text('📅 오늘 PT 스케줄에 등록'), findsOneWidget);
     });
 
+    testWidgets('A → B → A cannot double-register while A is still saving', (
+      tester,
+    ) async {
+      final container = await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        extraOverrides: <Override>[
+          aiRoutineRepositoryProvider.overrideWith(
+            (ref) =>
+                _SlowCountingRoutineRepository(ref.watch(appDatabaseProvider)),
+          ),
+        ],
+      );
+      await tester.tap(find.text('AI루틴'));
+      await settle(tester);
+
+      // Matches both the idle '📅 …등록' and the in-flight/disabled
+      // '✓ …등록됨' label so it works before and during a save.
+      Future<void> tapRegister() async {
+        final f = find.textContaining('스케줄에 등록');
+        await tester.scrollUntilVisible(
+          f,
+          150,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.ensureVisible(f);
+        await tester.pump();
+        await tester.tap(f, warnIfMissed: false);
+        await tester.pump(const Duration(milliseconds: 30));
+      }
+
+      Future<void> selectClient(String name) async {
+        await tester.scrollUntilVisible(
+          find.text(name),
+          -150,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.ensureVisible(find.text(name));
+        await tester.pump();
+        await tester.tap(find.text(name));
+        await tester.pump(const Duration(milliseconds: 30));
+      }
+
+      // Start 김민수's (slow) registration, hop to 이지수 and back.
+      await tapRegister();
+      await selectClient('이지수');
+      await selectClient('김민수');
+      // Back on 김민수 while the first write is still in flight — the
+      // button stays disabled, so this tap must NOT start a second one.
+      await tapRegister();
+      await settle(tester);
+
+      final repo =
+          container.read(aiRoutineRepositoryProvider)
+              as _SlowCountingRoutineRepository;
+      expect(repo.registerCalls, 1);
+    });
+
     testWidgets('registering with every exercise removed shows a hint', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary
* 편집된 루틴을 오늘 PT 스케줄 프로그램으로 등록(예정 세션 부착 or 신규 슬롯), AI 추천 항목 삭제, 고객 피커 가로 스크롤, 와이드 분할.

## Changes
### ✨ Features
* `registerToSchedule` — 예정 세션 부착/신규 슬롯, AI 항목 삭제, 피커 가로 스크롤
### 🐛 Fixes
* 연속 탭 중복 등록 방지 — `_registering` 가드를 await 전 설정 + 버튼 비활성화
* 22시 이후 과거 슬롯 생성 방지 — 다음 정시 캡을 23시로(22:xx → 23:00)
* 모든 항목 삭제 시 조용한 무반응 → "운동을 하나 이상 추가해 주세요" 안내
* 고객 전환 시 `_registering` 리셋 + in-flight 결과를 시작 시점 고객에만 귀속 (리뷰 반영)
* 23:00 캡의 한계를 주석에 정확히 명시 (23:00–23:59는 미해결 → 날짜 선택 사용)
### 🎨 UI/UX
* 고객 피커 가로 스크롤(칩 104px), 와이드 2컬럼 분할

## Commits
1. `a750860` feat: AI routine — schedule registration, suggestion removal, wide split
2. `8da5149` fix: guard routine registration (double-tap, empty program, late hour)
3. `e6c8513` fix: don't leak an in-flight registration across a client switch
4. `24a25cf` fix: stop the edit sheet silently rewriting… *(#218 )*
5. `0a7bc09` fix(a11y): merge sub-tab semantics… *(#216 )*
6. `3782750` fix: build the ?c= panel location through Uri *(#212 )*

## Notes
* 테스트: 느린 카운팅 repo로 연타 시 1회 등록, 빈 프로그램 안내.

## Test Plan
* [ ] 기능 정상 동작 확인
* [ ] 예외 케이스 확인
* [ ] UI 확인
* [ ] 빌드 성공
* [ ] 관련 테스트 통과
### Manual Test Steps
1. AI루틴 → 박성호 → 항목 하나 X 삭제 + 직접 추가 → 📅 등록 → 스케줄 탭 박성호 예정 세션에서 프로그램 확인
2. 김민수(예정 없음) → 등록 → 새 예정 슬롯 생성 확인

## Related Issues
Closes #219 

## Checklist
* [ ] 코드 리뷰 준비 완료
* [ ] 불필요한 코드 제거
* [ ] 하드코딩 값 점검
* [ ] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인