### PR TITLE
docs(trainer): 와이드 레이아웃·스케줄 관리·루틴 등록 반영 README 갱신

### DIFF
--- a/frontend/flutter_trainer/README.md
+++ b/frontend/flutter_trainer/README.md
@@ -109,5 +109,5 @@ lib/
   `dart format --set-exit-if-changed` 포함)
 - 실 백엔드(FastAPI) 연동 — `TrainerAuthRepository`/`SessionTokenStore` 교체 지점 주석 참조
 - 자정 넘김 시 '오늘' 스케줄/예약 수 자동 갱신, DB JSON 역직렬화 방어
-  (codex 리뷰 3·5 — 백엔드 연동과 함께 처리)
+  ( 백엔드 연동과 함께 처리)
 - AI 루틴 날짜 선택(미래 스케줄 등록·과거 조회)

--- a/frontend/flutter_trainer/README.md
+++ b/frontend/flutter_trainer/README.md
@@ -109,5 +109,5 @@ lib/
   `dart format --set-exit-if-changed` 포함)
 - 실 백엔드(FastAPI) 연동 — `TrainerAuthRepository`/`SessionTokenStore` 교체 지점 주석 참조
 - 자정 넘김 시 '오늘' 스케줄/예약 수 자동 갱신, DB JSON 역직렬화 방어
-  ( 백엔드 연동과 함께 처리)
+  (백엔드 연동과 함께 처리)
 - AI 루틴 날짜 선택(미래 스케줄 등록·과거 조회)

--- a/frontend/flutter_trainer/README.md
+++ b/frontend/flutter_trainer/README.md
@@ -4,8 +4,9 @@ On-Care **트레이너 전용 앱**입니다. [On-Care Figma 트레이너 목업
 사용자 앱([frontend/flutter](../flutter))과 **완전히 분리된 코드베이스**로 구현했습니다
 (아키텍처 패턴만 미러링, `package:oncare` import 0건 — 계정도 별도).
 
-> 현재 상태: **트레이너 MVP 완성** — 인증 + 4탭(고객/스케줄/AI루틴/MY) 전부 실제 화면,
-> 백엔드 미연결(drift 로컬 DB mock), 웹 1차 타깃
+> 현재 상태: **트레이너 MVP + 웹 와이드 레이아웃/스케줄·프로그램 관리** —
+> 인증 + 4탭(고객/스케줄/AI루틴/MY) 전부 실제 화면, 와이드 뷰포트 마스터-디테일,
+> 스케줄 CRUD·AI 루틴의 스케줄 등록까지. 백엔드 미연결(drift 로컬 DB mock), 웹 1차 타깃
 
 ## 아키텍처 방향 (하이브리드)
 
@@ -16,6 +17,15 @@ On-Care **트레이너 전용 앱**입니다. [On-Care Figma 트레이너 목업
 
 이에 따라 콘텐츠 폭 제한(`AppLayout.contentMaxWidth`), drift 웹 런타임
 (`tool/fetch_drift_wasm.sh`)이 포함되어 있습니다.
+
+### 와이드 뷰포트 (≥ `AppLayout.splitBreakpoint` = 1024px)
+
+- **고객 탭**: 마스터-디테일 스플릿 — 고객을 누르면 우측 패널에서
+  채팅/식단/운동기록이 열리고(닫기 버튼으로 리스트만 보기 복귀), 선택은
+  URL(`/clients?c=<id>`)에 동기화되어 새로고침에도 복원됩니다.
+- **스케줄 탭**: 날짜/주간 개요가 좌측에 도킹, 타임라인이 우측 컬럼.
+- **AI 루틴 탭**: 고객 선택·식단 요약(좌) + 루틴 편집기(우) 분할.
+- 좁은 화면은 기존 단일 컬럼 + 전체 화면 push 그대로입니다.
 
 ## 빌드 / 실행
 
@@ -69,17 +79,35 @@ lib/
 | 11 | AI 루틴 탭 (고객 선택·수정·전송) | `TrainerClient`/`ClientRepository` → shared 승격, Oni 마스코트 채택 |
 | 12 | MY 탭 (프로필·자격증·통계·헬스장) | **역할 전환 미구현**(계정 분리 정책) → 로그아웃만, `TabPlaceholder` 삭제 |
 
+### 이후 확장 (웹 와이드 + 관리 기능)
+
+| 브랜치 | 내용 |
+| --- | --- |
+| `feature/trainer-split-view` | 고객 탭 마스터-디테일 스플릿(URL 동기화·닫기 버튼), 나트륨 초과 우선 정렬(동순위 → 최근 채팅순), 채팅 초안 고객 간 누수 수정, 포맷/LF 정규화 |
+| `fix/trainer-chat-send-guard` | 채팅 중복 전송 가드(`_sending`)·dispose 후 접근 방지·메시지 도착 시에만 자동 스크롤 (codex 리뷰 1) |
+| `fix/trainer-client-detail-states` | 고객 상세 로딩/오류/미존재 상태 분리 + 다시 시도 (codex 리뷰 2) |
+| `feature/trainer-schedule-manage` | 스케줄 추가/수정/삭제(15분 단위 시간), 예정 세션 확장(계획 미리보기·계획 없음 안내·💬 채팅 바로가기), 오늘 중심 주간 스트립, 와이드 2컬럼 |
+| `feature/trainer-routine-programs` | AI 루틴 → 오늘 PT 스케줄 등록(예정 세션에 부착 or 신규 슬롯), AI 추천 항목 삭제, 고객 피커 가로 스크롤 (codex 리뷰 4), 와이드 분할 |
+
 ## 주요 결정
 
 - **색상**: 서비스 메인 = 파랑(#3EAFDF). 오렌지는 "트레이너" 브랜드 워드·경고·수동 추가
   구분·MY 아이덴티티 블록에만 (`brandOrange`/`warning`)
 - **역할 전환 없음**: Figma의 "역할 전환" UI는 구현하지 않음 — 트레이너/회원은 계정으로 분리
-- **mock-first**: 전송·수정 등 상호작용은 Figma와 동일한 in-memory mock,
-  채팅만 drift에 영속(재시딩에도 `seed-` 아닌 행은 보존)
+- **mock-first**: 전송 등 상호작용은 Figma와 동일한 in-memory mock.
+  채팅과 스케줄(추가/수정/삭제·AI 루틴 등록)은 drift에 영속
+  (재시딩에도 `seed-` 아닌 행은 보존)
+- **프로그램 이원화**: AI 루틴은 "고객 숙제 전송(mock)"과
+  "오늘 PT 스케줄 등록(drift 영속)" 두 액션으로 분리 — 스케줄 탭의 예정
+  세션에서 계획 미리보기로 이어짐. 날짜 선택(미래 스케줄)은 백엔드/캘린더
+  확장 시 도입
 - **디자인 일관성**: 사용자 앱 리디자인(figma kit)의 Oni 마스코트·AI 필 패턴 채택
 
 ## 로드맵
 
-- 와이드 화면 마스터-디테일(고객 리스트 + 우측 상세 패널)
-- 트레이너 CI/배포 파이프라인 (analyze·test·web build + wasm fetch)
+- 트레이너 CI/배포 파이프라인 (analyze·test·web build + wasm fetch,
+  `dart format --set-exit-if-changed` 포함)
 - 실 백엔드(FastAPI) 연동 — `TrainerAuthRepository`/`SessionTokenStore` 교체 지점 주석 참조
+- 자정 넘김 시 '오늘' 스케줄/예약 수 자동 갱신, DB JSON 역직렬화 방어
+  (codex 리뷰 3·5 — 백엔드 연동과 함께 처리)
+- AI 루틴 날짜 선택(미래 스케줄 등록·과거 조회)

--- a/frontend/flutter_trainer/README.md
+++ b/frontend/flutter_trainer/README.md
@@ -84,10 +84,10 @@ lib/
 | 브랜치 | 내용 |
 | --- | --- |
 | `feature/trainer-split-view` | 고객 탭 마스터-디테일 스플릿(URL 동기화·닫기 버튼), 나트륨 초과 우선 정렬(동순위 → 최근 채팅순), 채팅 초안 고객 간 누수 수정, 포맷/LF 정규화 |
-| `fix/trainer-chat-send-guard` | 채팅 중복 전송 가드(`_sending`)·dispose 후 접근 방지·메시지 도착 시에만 자동 스크롤 (codex 리뷰 1) |
-| `fix/trainer-client-detail-states` | 고객 상세 로딩/오류/미존재 상태 분리 + 다시 시도 (codex 리뷰 2) |
+| `fix/trainer-chat-send-guard` | 채팅 중복 전송 가드(`_sending`)·dispose 후 접근 방지·메시지 도착 시에만 자동 스크롤 |
+| `fix/trainer-client-detail-states` | 고객 상세 로딩/오류/미존재 상태 분리 + 다시 시도 |
 | `feature/trainer-schedule-manage` | 스케줄 추가/수정/삭제(15분 단위 시간), 예정 세션 확장(계획 미리보기·계획 없음 안내·💬 채팅 바로가기), 오늘 중심 주간 스트립, 와이드 2컬럼 |
-| `feature/trainer-routine-programs` | AI 루틴 → 오늘 PT 스케줄 등록(예정 세션에 부착 or 신규 슬롯), AI 추천 항목 삭제, 고객 피커 가로 스크롤 (codex 리뷰 4), 와이드 분할 |
+| `feature/trainer-routine-programs` | AI 루틴 → 오늘 PT 스케줄 등록(예정 세션에 부착 or 신규 슬롯), AI 추천 항목 삭제, 고객 피커 가로 스크롤, 와이드 분할 |
 
 ## 주요 결정
 


### PR DESCRIPTION
## 배경
- 와이드 레이아웃·스케줄 관리·루틴 등록 기능이 추가됐지만 README에 반영되지 않았습니다.

## 작업 내용
- 탭별 와이드 뷰포트 동작, 확장 브랜치 표, 프로그램 이원화(숙제 vs PT 스케줄) 결정, 로드맵 갱신.

## Summary
* 확장 브랜치 표·프로그램 이원화·로드맵 갱신. 로드맵의 괄호 앞 공백 오탈자 수정.
---
## Changes
### 📝 Docs
* 트레이너 MVP의 인증, 4탭, 스플릿 뷰, CRUD 범위와 Drift 웹 타깃을 명시하고, 고객·스케줄·AI 루틴 탭의 와이드 화면 동작 및 좁은 화면 동작을 설명합니다.
* 관련 브랜치별 변경 범위, 색상 규칙, mock-first 조건, 프로그램 액션 분리 등의 주요 결정과 CI·배포, 백엔드 연동, 날짜 갱신 및 AI 루틴 조회 계획을 추가합니다.
---
## Commits
1. `c5cd697` docs: reflect wide layouts, schedule management, and routine registration
2. `c1f6f9e` fix: formatting in README.md for branch descriptions
3. `5b76497` Update README.md to clarify backend integration notes
4. `76cfa1c` docs: drop the stray space before '백엔드' in the roadmap (review PR 221)

## Test Plan
* [ ] 문서 렌더링 확인

## Checklist
* [ ] 코드 리뷰 준비 완료
* [ ] Merge 충돌 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 트레이너 앱의 현재 상태와 MVP 범위를 보다 구체적으로 안내합니다.
  * 1024px 이상 와이드 화면에서 고객, 스케줄, AI 루틴 탭의 화면 구성을 설명합니다.
  * 향후 확장 계획, 주요 결정 사항, 로드맵을 최신 내용으로 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->