### PR TITLE
feat(ui): 하단 바텀시트 폭을 본 화면과 동일한 반응형(≤720)으로 통일

### DIFF
--- a/frontend/flutter/lib/app/router/main_shell.dart
+++ b/frontend/flutter/lib/app/router/main_shell.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/design_system/tokens/breakpoints.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/features/diet/presentation/widgets/diet_flows.dart';
 import 'package:oncare/features/exercise/presentation/widgets/exercise_flows.dart';
@@ -207,9 +208,10 @@ class _RecordAddSheet extends StatelessWidget {
     return SafeArea(
       top: false,
       child: ConstrainedBox(
-        // Match the main content width (720) so the sheet scales with the
-        // viewport like the tab pages instead of a narrow fixed cap.
-        constraints: const BoxConstraints(maxWidth: 720),
+        // Match the main content width so the sheet scales with the viewport
+        // like the tab pages. The theme lifts the modal route cap to this
+        // width too (see AppTheme._bottomSheetTheme); this centres the child.
+        constraints: const BoxConstraints(maxWidth: AppBreakpoints.contentMaxWidth),
         child: Container(
           decoration: const BoxDecoration(
             color: Colors.white,

--- a/frontend/flutter/lib/app/router/main_shell.dart
+++ b/frontend/flutter/lib/app/router/main_shell.dart
@@ -207,7 +207,9 @@ class _RecordAddSheet extends StatelessWidget {
     return SafeArea(
       top: false,
       child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 480),
+        // Match the main content width (720) so the sheet scales with the
+        // viewport like the tab pages instead of a narrow fixed cap.
+        constraints: const BoxConstraints(maxWidth: 720),
         child: Container(
           decoration: const BoxDecoration(
             color: Colors.white,

--- a/frontend/flutter/lib/design_system/theme/app_theme.dart
+++ b/frontend/flutter/lib/design_system/theme/app_theme.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:oncare/design_system/tokens/breakpoints.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/design_system/tokens/typography.dart';
 
@@ -9,6 +10,15 @@ import 'package:oncare/design_system/tokens/typography.dart';
 /// be tightened in a later phase.
 class AppTheme {
   AppTheme._();
+
+  /// Material 3 caps modal bottom sheets at 640dp by default, so an inner
+  /// `ConstrainedBox` alone can never widen them. Lifting the route-level
+  /// cap to [AppBreakpoints.contentMaxWidth] lets sheets reach the same
+  /// width as the tab pages on wide viewports; their own inner constraints
+  /// then centre the content.
+  static const BottomSheetThemeData _bottomSheetTheme = BottomSheetThemeData(
+    constraints: BoxConstraints(maxWidth: AppBreakpoints.contentMaxWidth),
+  );
 
   static ThemeData light() {
     const ColorScheme scheme = ColorScheme(
@@ -56,6 +66,7 @@ class AppTheme {
       progressIndicatorTheme: const ProgressIndicatorThemeData(
         color: AppColors.primary,
       ),
+      bottomSheetTheme: _bottomSheetTheme,
     );
   }
 
@@ -72,6 +83,7 @@ class AppTheme {
     );
     return base.copyWith(
       textTheme: AppTypography.buildTextTheme(base.textTheme),
+      bottomSheetTheme: _bottomSheetTheme,
     );
   }
 }

--- a/frontend/flutter/lib/design_system/tokens/breakpoints.dart
+++ b/frontend/flutter/lib/design_system/tokens/breakpoints.dart
@@ -5,6 +5,11 @@ class AppBreakpoints {
   AppBreakpoints._();
   static const double tablet = 600;
   static const double desktop = 1024;
+
+  /// Max width of primary page/sheet content. The tab pages and every
+  /// bottom-sheet cap their content at this so they scale with the
+  /// viewport identically instead of drifting apart.
+  static const double contentMaxWidth = 720;
 }
 
 /// Coarse device form factor inferred from a width. Pages and shells

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
@@ -74,7 +74,9 @@ Widget _sheetShell(BuildContext context, Widget child) {
     child: ConstrainedBox(
       constraints: BoxConstraints(
         maxHeight: MediaQuery.of(context).size.height * 0.9,
-        maxWidth: 480,
+        // Match the main content width (720) so the sheet scales with the
+        // viewport like the tab pages instead of a narrow fixed cap.
+        maxWidth: 720,
       ),
       child: Container(
         decoration: const BoxDecoration(

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
 
 import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/design_system/tokens/breakpoints.dart';
 import 'package:oncare/features/diet/domain/entities/diet_analysis.dart';
 import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
@@ -74,9 +75,10 @@ Widget _sheetShell(BuildContext context, Widget child) {
     child: ConstrainedBox(
       constraints: BoxConstraints(
         maxHeight: MediaQuery.of(context).size.height * 0.9,
-        // Match the main content width (720) so the sheet scales with the
-        // viewport like the tab pages instead of a narrow fixed cap.
-        maxWidth: 720,
+        // Match the main content width so the sheet scales with the viewport
+        // like the tab pages. The theme lifts the modal route cap to this
+        // width too (see AppTheme._bottomSheetTheme); this centres the child.
+        maxWidth: AppBreakpoints.contentMaxWidth,
       ),
       child: Container(
         decoration: const BoxDecoration(

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/design_system/tokens/breakpoints.dart';
 import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
@@ -64,9 +65,10 @@ Widget _shell(BuildContext context, Widget child) => SafeArea(
   child: ConstrainedBox(
     constraints: BoxConstraints(
       maxHeight: MediaQuery.of(context).size.height * 0.9,
-      // Match the main content width (720) so the sheet scales with the
-      // viewport like the tab pages instead of a narrow fixed cap.
-      maxWidth: 720,
+      // Match the main content width so the sheet scales with the viewport
+      // like the tab pages. The theme lifts the modal route cap to this
+      // width too (see AppTheme._bottomSheetTheme); this centres the child.
+      maxWidth: AppBreakpoints.contentMaxWidth,
     ),
     child: Container(
       decoration: const BoxDecoration(

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
@@ -64,7 +64,9 @@ Widget _shell(BuildContext context, Widget child) => SafeArea(
   child: ConstrainedBox(
     constraints: BoxConstraints(
       maxHeight: MediaQuery.of(context).size.height * 0.9,
-      maxWidth: 480,
+      // Match the main content width (720) so the sheet scales with the
+      // viewport like the tab pages instead of a narrow fixed cap.
+      maxWidth: 720,
     ),
     child: Container(
       decoration: const BoxDecoration(

--- a/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
@@ -18,7 +18,9 @@ Widget _shell(
     child: ConstrainedBox(
       constraints: BoxConstraints(
         maxHeight: MediaQuery.of(context).size.height * 0.9,
-        maxWidth: 560,
+        // Match the main content width (720) so the sheet scales with the
+        // viewport like the tab pages instead of a narrow fixed cap.
+        maxWidth: 720,
       ),
       child: Container(
         decoration: const BoxDecoration(

--- a/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:oncare/core/storage/prefs_store.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/design_system/tokens/breakpoints.dart';
 import 'package:oncare/features/account/domain/entities/user_profile.dart';
 import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -18,9 +19,10 @@ Widget _shell(
     child: ConstrainedBox(
       constraints: BoxConstraints(
         maxHeight: MediaQuery.of(context).size.height * 0.9,
-        // Match the main content width (720) so the sheet scales with the
-        // viewport like the tab pages instead of a narrow fixed cap.
-        maxWidth: 720,
+        // Match the main content width so the sheet scales with the viewport
+        // like the tab pages. The theme lifts the modal route cap to this
+        // width too (see AppTheme._bottomSheetTheme); this centres the child.
+        maxWidth: AppBreakpoints.contentMaxWidth,
       ),
       child: Container(
         decoration: const BoxDecoration(

--- a/frontend/flutter/lib/shared/widgets/modals/schedule_calendar_sheet.dart
+++ b/frontend/flutter/lib/shared/widgets/modals/schedule_calendar_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:oncare/design_system/tokens/breakpoints.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/design_system/tokens/radius.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
@@ -28,9 +29,10 @@ Future<void> showScheduleCalendarSheet(
       borderRadius: BorderRadius.vertical(top: AppRadius.card),
     ),
     builder: (BuildContext ctx) => ConstrainedBox(
-      // Match the main content width (720) so the sheet scales with the
-      // viewport like the tab pages instead of spanning full width.
-      constraints: const BoxConstraints(maxWidth: 720),
+      // Match the main content width so the sheet scales with the viewport
+      // like the tab pages. The theme lifts the modal route cap to this
+      // width too (see AppTheme._bottomSheetTheme); this centres the child.
+      constraints: const BoxConstraints(maxWidth: AppBreakpoints.contentMaxWidth),
       child: _CalendarBody(initialDate: initialDate ?? DateTime.now()),
     ),
   );

--- a/frontend/flutter/lib/shared/widgets/modals/schedule_calendar_sheet.dart
+++ b/frontend/flutter/lib/shared/widgets/modals/schedule_calendar_sheet.dart
@@ -27,8 +27,12 @@ Future<void> showScheduleCalendarSheet(
     shape: const RoundedRectangleBorder(
       borderRadius: BorderRadius.vertical(top: AppRadius.card),
     ),
-    builder: (BuildContext ctx) =>
-        _CalendarBody(initialDate: initialDate ?? DateTime.now()),
+    builder: (BuildContext ctx) => ConstrainedBox(
+      // Match the main content width (720) so the sheet scales with the
+      // viewport like the tab pages instead of spanning full width.
+      constraints: const BoxConstraints(maxWidth: 720),
+      child: _CalendarBody(initialDate: initialDate ?? DateTime.now()),
+    ),
   );
 }
 

--- a/frontend/flutter/test/design_system/bottom_sheet_width_test.dart
+++ b/frontend/flutter/test/design_system/bottom_sheet_width_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/design_system/theme/app_theme.dart';
+import 'package:oncare/design_system/tokens/breakpoints.dart';
+
+void main() {
+  testWidgets(
+    'modal bottom sheet is capped at contentMaxWidth on a desktop viewport',
+    (WidgetTester tester) async {
+      // Wide desktop surface — far wider than contentMaxWidth (720).
+      tester.view.physicalSize = const Size(1400, 1000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppTheme.light(),
+          home: const Scaffold(body: SizedBox.expand()),
+        ),
+      );
+
+      showModalBottomSheet<void>(
+        context: tester.element(find.byType(Scaffold)),
+        // A full-width child collapses to whatever the route allows, so its
+        // measured width is exactly the effective route-level cap.
+        builder: (_) => const SizedBox(
+          key: Key('sheetContent'),
+          width: double.infinity,
+          height: 200,
+          child: Text('sheet'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('sheet'), findsOneWidget);
+
+      // Material 3 caps modal sheets at 640dp by default; the theme lifts that
+      // route-level cap to contentMaxWidth (720). Asserting the exact width
+      // proves the sheet neither spans the 1400 viewport nor stays at 640.
+      final double sheetWidth =
+          tester.getSize(find.byKey(const Key('sheetContent'))).width;
+      expect(sheetWidth, AppBreakpoints.contentMaxWidth);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

하단 바텀시트가 화면 크기와 무관하게 좁은 고정 폭으로 뜨던 것을, 본 화면(탭 페이지, `ConstrainedBox(maxWidth: 720)`)과 **동일하게 화면 크기에 따라 폭이 달라지도록** 통일합니다. 넓은 화면에선 720 캡·가운데 정렬, 좁은 화면(<720)에선 전체 폭.

Closes #228

## Changes

- `diet_flows` `_sheetShell` 480 → 720 (식단 추가·분석 결과·식사 수정)
- `exercise_flows` `_shell` 480 → 720 (운동 추가·헬스장 찾기/정보/상담)
- `my_flows` `_shell` 560 → 720 (내 프로필·건강 목표·알림 설정·고객 지원·약관)
- `main_shell` 새 기록 추가 시트 480 → 720
- `schedule_calendar_sheet`(일정 관리): 폭 제한이 없어 전체폭이던 것을 `ConstrainedBox(maxWidth: 720)`로 래핑
- 가운데 정렬은 `showModalBottomSheet`의 `_ModalBottomSheetLayout`이 자식 폭 기준으로 이미 처리하므로 캡만 조정(기존 동작 유지)

## Verification

- `flutter analyze` (변경 5개 영역): No issues found
- **프리뷰 실환경(넓은 뷰포트)**: 「새 기록 추가」·「식단 추가」 시트가 720 폭·중앙 정렬로 렌더돼 본 화면 콘텐츠와 폭이 일치함을 확인(이전엔 480으로 눈에 띄게 좁았음)

## Notes

- **범위 = 활성 바텀시트**. 화면에 뜨지 않는 legacy 시트(edit_meal_sheet·gym_finder_sheet·add_session_sheet)와 하단 팝업이 아닌 다이얼로그(showDialog: settings_modals·indicator_trend_modal)는 제외.
- base `main`. 사용자 앱(`frontend/flutter`). C(제목 통일)와 파일이 겹치지만(diet_flows/my_flows) 서로 다른 라인이라 자동 병합 가능.
