### PR TITLE
chore(ci): 트레이너 웹 앱 GitHub Pages 배포(/trainer/) 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,11 +45,25 @@ jobs:
         working-directory: frontend/flutter
         run: flutter build web --release --base-href "/frontend/"
 
+      - name: Install Flutter dependencies (trainer)
+        working-directory: frontend/flutter_trainer
+        run: flutter pub get
+
+      - name: Download drift WASM (trainer)
+        working-directory: frontend/flutter_trainer
+        run: bash tool/fetch_drift_wasm.sh
+
+      - name: Build Flutter web (trainer)
+        working-directory: frontend/flutter_trainer
+        run: flutter build web --release --base-href "/trainer/"
+
       - name: Prepare GitHub Pages files
         run: |
           mkdir -p public/frontend
           cp index.html public/index.html
           cp -R frontend/flutter/build/web/* public/frontend/
+          mkdir -p public/trainer
+          cp -R frontend/flutter_trainer/build/web/* public/trainer/
           touch public/.nojekyll
 
       - name: Configure GitHub Pages


### PR DESCRIPTION
## Summary

트레이너 앱(`frontend/flutter_trainer`)을 기존 GitHub Pages 배포 파이프라인에 추가해 **`ewhasudo.zapto.org/trainer/`** 로 접속되게 합니다. 호스팅은 사용자 앱과 **동일한 GitHub Pages**(같은 사이트의 하위 경로) — 별도 서비스(Vercel 등) 없음.

Closes #232

## Changes

`deploy.yml`의 `build` 잡에 사용자 앱 빌드와 동일 패턴으로 트레이너 단계 추가:
- `(trainer) flutter pub get`
- `(trainer) bash tool/fetch_drift_wasm.sh` — 웹 drift(로컬 DB)용 sqlite3.wasm/drift_worker.js
- `(trainer) flutter build web --release --base-href "/trainer/"`
- Prepare 단계에서 `public/trainer/` 로 복사

결과 사이트 구성:
```
ewhasudo.zapto.org/            소개 페이지(index.html)
ewhasudo.zapto.org/frontend/   사용자 앱 (기존)
ewhasudo.zapto.org/trainer/    트레이너 앱 (이 PR)
```

## Verification

- `deploy.yml` YAML 파싱 OK, `build` 잡에 trainer 3단계 + copy 확인
- 로컬에서 `flutter build web --release --base-href "/trainer/"` (트레이너) **빌드 성공**(`✓ Built build/web`)
- 빌드 산출물(`build/`)은 gitignore라 커밋에 미포함

## Notes

- **트레이너 기능 스택(#212~#221)은 이 PR에서 병합하지 않습니다.** 이 PR 병합 시점엔 `main`의 현재 트레이너가 배포되고, 이후 스택이 병합되면 자동으로 최신본이 배포됩니다.
- 웹 배포(호스팅)만 추가하는 것이며 네이티브 앱 스토어 배포와 무관합니다.
- 배포는 `main` push 시 자동(Actions). 이 PR이 `main`에 병합되면 첫 트레이너 배포가 실행됩니다.
