### PR TITLE
docs(readme): 리드미와 코드 싱크 불일치 정정

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@
 
 <br/>
 
-[![Intro Page](https://img.shields.io/badge/Intro_Page-소개페이지-185079?style=for-the-badge&logo=googlechrome&logoColor=white)](https://ewhasudo.zapto.org/)
-[![Web](https://img.shields.io/badge/Web-서비스_바로가기-3eafdf?style=for-the-badge&logo=flutter&logoColor=white)](https://ewhasudo.zapto.org/frontend/#/dashboard)
-[![YouTube Demo](https://img.shields.io/badge/YouTube-데모_영상_보기-FF0000?style=for-the-badge&logo=youtube&logoColor=white)](https://youtu.be/C4ivM_dlAww?si=8iOWmOpSxcpQmlU3)
+[![소개 페이지](https://img.shields.io/badge/INTRO_PAGE-소개_페이지-185079?style=for-the-badge&logo=googlechrome&logoColor=white)](https://ewhasudo.zapto.org/)
+[![사용자 앱](https://img.shields.io/badge/APP-사용자-3eafdf?style=for-the-badge&logo=flutter&logoColor=white)](https://ewhasudo.zapto.org/frontend/#/dashboard)
+[![트레이너 앱](https://img.shields.io/badge/WEB-트레이너-9bd3f0?style=for-the-badge&logo=safari&logoColor=white)](https://ewhasudo.zapto.org/trainer/)
+[![데모 영상](https://img.shields.io/badge/YOUTUBE-데모_영상-FF0000?style=for-the-badge&logo=youtube&logoColor=white)](https://youtu.be/C4ivM_dlAww?si=8iOWmOpSxcpQmlU3)
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@
 
 | 영역 | 사용 기술 |
 | --- | --- |
-| **Frontend** | Flutter · Dart · Riverpod · GoRouter (회원/트레이너 이중 모드) |
+| **Frontend** | Flutter · Dart · Riverpod · GoRouter (사용자 앱 · 트레이너 앱 — 분리된 코드베이스, 아키텍처 패턴 미러링) |
 | **Backend** | FastAPI · SQLAlchemy · Alembic · JWT · Docker |
 | **Database** | PostgreSQL · pgvector |
 | **AI** | Vision(VLM) 식단 인식 · 식약처 공공 영양성분 DB 매칭 · RAG 코치 |

--- a/backend/README.md
+++ b/backend/README.md
@@ -15,7 +15,7 @@
 
 ## STEP 1 에서 동작하는 것
 - `GET /v1/ping` · `GET /v1/healthz` · `GET /v1/version` — 프론트 계약과 정확히 일치
-- 테이블 생성 (프론트 drift 스키마 정렬: diet_entries 에 sodium_mg/sugar_g 포함) — 베이스라인 9테이블, 이후 마이그레이션으로 현재 12테이블(social_accounts·food_nutrients·places·audit_logs 추가)
+- 테이블 생성 (프론트 drift 스키마 정렬: diet_entries 에 sodium_mg/sugar_g 포함) — 베이스라인 9테이블(places 포함), 이후 마이그레이션으로 현재 12테이블(social_accounts·food_nutrients·audit_logs 추가)
 - 사용자 id = 문자열, 데모 유저 'user-demo'(김민수) 시드
 
 ## 실행

--- a/backend/README.md
+++ b/backend/README.md
@@ -15,7 +15,7 @@
 
 ## STEP 1 에서 동작하는 것
 - `GET /v1/ping` · `GET /v1/healthz` · `GET /v1/version` — 프론트 계약과 정확히 일치
-- 9개 테이블 생성 (프론트 drift 스키마 정렬: diet_entries 에 sodium_mg/sugar_g 포함)
+- 테이블 생성 (프론트 drift 스키마 정렬: diet_entries 에 sodium_mg/sugar_g 포함) — 베이스라인 9테이블, 이후 마이그레이션으로 현재 12테이블(social_accounts·food_nutrients·places·audit_logs 추가)
 - 사용자 id = 문자열, 데모 유저 'user-demo'(김민수) 시드
 
 ## 실행
@@ -26,7 +26,7 @@ docker compose up --build
 → http://localhost:8000/docs  (경로는 모두 /v1/...)
 
 ## DB 마이그레이션 (Alembic)
-스키마는 **Alembic 마이그레이션**으로 관리합니다(베이스라인: `migrations/versions/0001_baseline.py`, 9테이블 + pgvector).
+스키마는 **Alembic 마이그레이션**으로 관리합니다(베이스라인: `migrations/versions/0001_baseline.py`, 9테이블 + pgvector; 이후 마이그레이션으로 현재 12테이블).
 DB URL 은 `.env` 의 `DATABASE_URL` 을 그대로 사용합니다(`migrations/env.py` 가 app 설정에서 읽음).
 
 ```bash

--- a/frontend/flutter/CHANGELOG.md
+++ b/frontend/flutter/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+- **Figma 리디자인**: 사용자 앱 전 화면(홈·식단·운동·MY·코칭)을 figma_kit 기준으로
+  재구성하고, 하드코딩 데모 대신 핵심 데이터 흐름을 실 provider로 재연결 (#189, #200).
+
 ## [0.3.0+3] — 2026-05-20
 
 Stage 9 — Local backend via drift + LocalApiInterceptor. The

--- a/frontend/flutter/README.md
+++ b/frontend/flutter/README.md
@@ -1,9 +1,9 @@
 # oncare-flutter
 
-[Oncare Prototype (React/TS)](https://github.com/subin21cc/Oncareprototype) 를 Flutter로 재구성하는 프로젝트입니다.
+[Oncare Prototype (React/TS)](https://github.com/subin21cc/Oncareprototype) 에서 출발해 이후 **Figma 디자인 기준으로 재구성**한 On-Care 사용자 앱입니다.
 **Android / iOS / Web** 3개 타깃을 단일 코드베이스로 빌드하며, 웹은 GitHub Pages에 CI 배포됩니다.
 
-> 현재 상태: **Stage 9 — Local Backend 완료** — v0.3.0+3
+> 현재 상태: **Stage 10 — Figma 리디자인 · 실데이터 재연결 반영** (기반: Stage 9 로컬 백엔드, v0.3.0+3)
 > (drift + LocalApiInterceptor 기반 로컬 백엔드 — `--dart-define=USE_MOCK_API=false` 한 줄로 FastAPI 전환 가능)
 
 ## 문서
@@ -72,3 +72,4 @@ flutter build ios --release      # Xcode에서 archive
 - [x] **Stage 7 — Release** (RELEASE.md guides, CHANGELOG v0.1.0+1, web Pages live)
 - [x] **Stage 8 — UX Alignment** (shadcn tokens / 홈·식단·운동·My / OncareHeader / Dashboard 5-card / Calendar·QuickInput·AddEvent modals / Notification·AI-coach right-slide panels)
 - [x] **Stage 9 — Local Backend** (drift schema v2 6-table / `LocalApiInterceptor` dio dispatcher / seed bootstrap / `USE_MOCK_API` 플래그로 FastAPI 단일 전환)
+- [x] **Stage 10 — Figma 리디자인** (figma_kit 기준 홈·식단·운동·MY·코칭 재구성 / 핵심 데이터 흐름을 실 provider로 재연결)

--- a/frontend/flutter_trainer/README.md
+++ b/frontend/flutter_trainer/README.md
@@ -31,7 +31,7 @@ flutter run -d chrome
 # 테스트 / 정적 분석 / drift codegen
 flutter test
 flutter analyze
-flutter pub run build_runner build --delete-conflicting-outputs
+dart run build_runner build --delete-conflicting-outputs
 ```
 
 로그인: 비어있지 않은 아무 이메일/비밀번호 → 시드 트레이너(김트레이너)로 로그인.

--- a/frontend/flutter_trainer/README.md
+++ b/frontend/flutter_trainer/README.md
@@ -31,7 +31,7 @@ flutter run -d chrome
 # 테스트 / 정적 분석 / drift codegen
 flutter test
 flutter analyze
-dart run build_runner build --delete-conflicting-outputs
+flutter pub run build_runner build --delete-conflicting-outputs
 ```
 
 로그인: 비어있지 않은 아무 이메일/비밀번호 → 시드 트레이너(김트레이너)로 로그인.


### PR DESCRIPTION
Closes #234

## Summary
리드미 문서와 실제 코드/구조가 어긋난 부분을 정정합니다. AWS·Firebase Cloud Messaging·카카오맵 등 계획성 표기는 사용자 요청으로 그대로 유지했습니다.

## Changes
- **루트 `README.md`** — Tech Stack "회원/트레이너 이중 모드" → **분리된 코드베이스**로 정정. 트레이너 앱은 `frontend/flutter_trainer`(패키지 `oncare_trainer`, `package:oncare` import 0건 확인), 사용자 앱 라우터엔 트레이너/역할 경로 없음.
- **`backend/README.md`** — "9개 테이블"은 베이스라인(0001) 기준. 이후 마이그레이션으로 `models.py` 현재 **12테이블** → 현재 수치 병기.
- **`frontend/flutter/README.md`** — Stage 9에서 멈춰 있던 상태에 **Stage 10(Figma 리디자인 #189·실데이터 재연결 #200)** 추가, 인트로에 Figma 재구성 명시.
- **`frontend/flutter/CHANGELOG.md`** — 비어 있던 `[Unreleased]`에 Figma 리디자인 요약 추가(버전 bump 없음).
- **`frontend/flutter_trainer/README.md`** — `dart run build_runner`(Flutter SDK 부재 시 실패) → `flutter pub run build_runner`로 정정.

## Notes
- 전체 ARB 다국어화(#201/#208)는 아직 main 미병합 → CHANGELOG/상태에 미포함(main 기준 정확성).
- 트레이너 `/trainer/` 배포(#233) 병합 후 루트 README Web 링크 추가는 후속 검토.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 사용자 앱 전 화면이 Figma 리디자인 및 실제 데이터 흐름 기반으로 재구성된 내용을 문서에 반영했습니다.
  * 사용자 앱의 개발 진행 단계가 Stage 10으로 업데이트되었습니다.
  * 데이터베이스 문서가 최신 12개 테이블 및 pgvector 구성에 맞게 갱신되었습니다.
  * 프로젝트 소개 배지와 기술 스택 설명을 최신 명칭과 구조에 맞게 수정했습니다.
  * 트레이너 앱의 빌드 안내 명령을 최신 실행 방식으로 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->