### PR TITLE
feat(trainer): 안읽은 채팅 알림 + 읽음 처리

### DIFF
--- a/frontend/flutter_trainer/lib/features/clients/presentation/pages/clients_page.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/pages/clients_page.dart
@@ -10,6 +10,7 @@ import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/features/clients/presentation/widgets/client_card.dart';
 import 'package:oncare_trainer/features/clients/presentation/widgets/client_detail_view.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
+import 'package:oncare_trainer/shared/services/chat_repository.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/content_frame.dart';
 import 'package:oncare_trainer/shared/widgets/oni_avatar.dart';
@@ -30,6 +31,8 @@ class ClientsPage extends ConsumerWidget {
     // Priority ordering: sodium-over clients first, then recent chat.
     final clients = ref.watch(prioritizedClientsProvider);
     final reservations = ref.watch(todayReservationCountProvider).valueOrNull;
+    final unread =
+        ref.watch(unreadCountsProvider).valueOrNull ?? const <String, int>{};
 
     return Scaffold(
       backgroundColor: AppColors.background,
@@ -61,6 +64,7 @@ class ClientsPage extends ConsumerWidget {
                   child: _ClientsView(
                     clients: list,
                     reservations: reservations,
+                    unread: unread,
                     selectedId: null,
                     // Wide: open the side panel via the URL. Narrow:
                     // keep the full-screen push.
@@ -81,6 +85,7 @@ class ClientsPage extends ConsumerWidget {
                       child: _ClientsView(
                         clients: list,
                         reservations: reservations,
+                        unread: unread,
                         selectedId: selected,
                         // Selecting swaps the right panel (and the URL)
                         // instead of pushing a new screen.
@@ -114,12 +119,16 @@ class _ClientsView extends StatelessWidget {
   const _ClientsView({
     required this.clients,
     required this.reservations,
+    required this.unread,
     required this.selectedId,
     required this.onOpen,
   });
 
   final List<TrainerClient> clients;
   final int? reservations;
+
+  /// Unread chat counts by client id (absent = 0).
+  final Map<String, int> unread;
 
   /// Highlighted client in the split layout (null on narrow viewports).
   final String? selectedId;
@@ -179,6 +188,7 @@ class _ClientsView extends StatelessWidget {
           ClientCard(
             client: client,
             selected: client.id == selectedId,
+            unread: unread[client.id] ?? 0,
             onTap: () => onOpen(client.id),
           ),
           const SizedBox(height: AppSpacing.md),

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
@@ -110,6 +110,13 @@ class _ChatViewState extends ConsumerState<ChatView> {
               if (list.length != _lastCount) {
                 _lastCount = list.length;
                 _scrollToBottom();
+                // Viewing the thread clears its unread badge — also for
+                // messages that arrive while it stays open. Deferred so
+                // the write never runs inside build.
+                final repo = ref.read(chatRepositoryProvider);
+                Future<void>.microtask(
+                  () => repo.markThreadRead(widget.clientId),
+                );
               }
               return ListView(
                 controller: _scroll,

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_card.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_card.dart
@@ -15,6 +15,7 @@ class ClientCard extends StatelessWidget {
     required this.client,
     required this.onTap,
     this.selected = false,
+    this.unread = 0,
   });
 
   /// The client to render.
@@ -26,6 +27,9 @@ class ClientCard extends StatelessWidget {
   /// Highlighted in the wide-viewport split layout when this client's
   /// detail panel is open.
   final bool selected;
+
+  /// Unread chat messages — shows a count badge next to the preview.
+  final int unread;
 
   @override
   Widget build(BuildContext context) {
@@ -91,15 +95,49 @@ class ClientCard extends StatelessWidget {
                           ),
                         ),
                         const SizedBox(height: 4),
-                        Text(
-                          client.lastMessage,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(
-                            fontSize: 12,
-                            color: AppColors.mutedForeground,
-                            fontWeight: FontWeight.w500,
-                          ),
+                        Row(
+                          children: <Widget>[
+                            Expanded(
+                              child: Text(
+                                client.lastMessage,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  color: unread > 0
+                                      ? AppColors.foreground
+                                      : AppColors.mutedForeground,
+                                  fontWeight: unread > 0
+                                      ? FontWeight.w700
+                                      : FontWeight.w500,
+                                ),
+                              ),
+                            ),
+                            if (unread > 0)
+                              Container(
+                                margin: const EdgeInsets.only(
+                                  left: AppSpacing.xs,
+                                ),
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 6,
+                                  vertical: 1,
+                                ),
+                                decoration: const BoxDecoration(
+                                  color: AppColors.accent,
+                                  borderRadius: BorderRadius.all(
+                                    AppRadius.pill,
+                                  ),
+                                ),
+                                child: Text(
+                                  '$unread',
+                                  style: const TextStyle(
+                                    fontSize: 10,
+                                    fontWeight: FontWeight.w800,
+                                    color: AppColors.accentForeground,
+                                  ),
+                                ),
+                              ),
+                          ],
                         ),
                       ],
                     ),

--- a/frontend/flutter_trainer/lib/shared/services/chat_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/chat_repository.dart
@@ -56,6 +56,39 @@ class ChatRepository {
     });
   }
 
+  /// Per-client unread counts — client-sent messages newer than the
+  /// trainer's last-read marker (an `AppKeyValues` row per client, so
+  /// no schema migration). Clients with zero unread are absent.
+  Stream<Map<String, int>> watchUnreadCounts() {
+    // drift stores DateTime columns as unix epoch seconds; the read
+    // marker persists the same unit for a plain integer comparison.
+    final query = _db.customSelect(
+      'SELECT m.client_id AS cid, COUNT(*) AS cnt '
+      'FROM client_chat_messages m '
+      "LEFT JOIN app_key_values k ON k.\"key\" = '$_readKeyPrefix' || m.client_id "
+      "WHERE m.sender = 'client' "
+      'AND (k.value IS NULL OR m.created_at > CAST(k.value AS INTEGER)) '
+      'GROUP BY m.client_id',
+      readsFrom: <ResultSetImplementation<Object?, Object?>>{
+        _db.clientChatMessages,
+        _db.appKeyValues,
+      },
+    );
+    return query.watch().map(
+      (rows) => <String, int>{
+        for (final row in rows) row.read<String>('cid'): row.read<int>('cnt'),
+      },
+    );
+  }
+
+  /// Marks a client's thread as read up to now.
+  Future<void> markThreadRead(String clientId) {
+    final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    return _db.putValue('$_readKeyPrefix$clientId', '$nowSeconds');
+  }
+
+  static const String _readKeyPrefix = 'chat_read_';
+
   ClientChatMessage _toEntity(ClientChatMessageRow row) {
     return ClientChatMessage(
       id: row.id,
@@ -74,6 +107,11 @@ class ChatRepository {
 /// Provides the [ChatRepository].
 final chatRepositoryProvider = Provider<ChatRepository>((ref) {
   return ChatRepository(ref.watch(appDatabaseProvider));
+});
+
+/// Streams per-client unread message counts for the 고객 list badges.
+final unreadCountsProvider = StreamProvider<Map<String, int>>((ref) {
+  return ref.watch(chatRepositoryProvider).watchUnreadCounts();
 });
 
 /// Streams a client's chat thread by client id.

--- a/frontend/flutter_trainer/lib/shared/services/chat_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/chat_repository.dart
@@ -81,10 +81,38 @@ class ChatRepository {
     );
   }
 
-  /// Marks a client's thread as read up to now.
-  Future<void> markThreadRead(String clientId) {
-    final nowSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    return _db.putValue('$_readKeyPrefix$clientId', '$nowSeconds');
+  /// Marks a client's thread read up to its newest client message.
+  ///
+  /// Idempotent and write-free when there is nothing new: the marker is
+  /// the newest client message's timestamp (not `now()`), so calling this
+  /// again with no new messages computes the same value and skips the
+  /// write entirely. That matters because `watchUnreadCounts` watches
+  /// `app_key_values` — an unconditional write would emit on that stream
+  /// and rebuild the list on every call (review PR 241).
+  Future<void> markThreadRead(String clientId) async {
+    final newest =
+        await (_db.select(_db.clientChatMessages)
+              ..where(
+                (t) => t.clientId.equals(clientId) & t.sender.equals('client'),
+              )
+              ..orderBy(<OrderingTerm Function($ClientChatMessagesTable)>[
+                (t) => OrderingTerm(
+                  expression: t.createdAt,
+                  mode: OrderingMode.desc,
+                ),
+              ])
+              ..limit(1))
+            .getSingleOrNull();
+    // No client message at all — nothing could be unread.
+    if (newest == null) return;
+
+    // Same unit as the unread query's comparison (epoch seconds).
+    final marker = newest.createdAt.millisecondsSinceEpoch ~/ 1000;
+    final key = '$_readKeyPrefix$clientId';
+    final stored = int.tryParse(await _db.readValue(key) ?? '');
+    if (stored != null && stored >= marker) return; // already read
+
+    await _db.putValue(key, '$marker');
   }
 
   static const String _readKeyPrefix = 'chat_read_';

--- a/frontend/flutter_trainer/lib/shared/services/chat_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/chat_repository.dart
@@ -56,18 +56,21 @@ class ChatRepository {
     });
   }
 
-  /// Per-client unread counts — client-sent messages newer than the
-  /// trainer's last-read marker (an `AppKeyValues` row per client, so
-  /// no schema migration). Clients with zero unread are absent.
+  /// Per-client unread counts — client-sent messages after the trainer's
+  /// last-read marker (an `AppKeyValues` row per client, so no schema
+  /// migration). Clients with zero unread are absent.
   Stream<Map<String, int>> watchUnreadCounts() {
-    // drift stores DateTime columns as unix epoch seconds; the read
-    // marker persists the same unit for a plain integer comparison.
+    // The marker is a monotonic `rowid`, not an epoch second: two client
+    // messages that land in the same second share a `created_at` value,
+    // so a timestamp marker can't tell them apart — after reading the
+    // first, the second would look already-read. `rowid` is unique and
+    // increasing, so it distinguishes same-second messages (review 241).
     final query = _db.customSelect(
       'SELECT m.client_id AS cid, COUNT(*) AS cnt '
       'FROM client_chat_messages m '
       "LEFT JOIN app_key_values k ON k.\"key\" = '$_readKeyPrefix' || m.client_id "
       "WHERE m.sender = 'client' "
-      'AND (k.value IS NULL OR m.created_at > CAST(k.value AS INTEGER)) '
+      'AND (k.value IS NULL OR m.rowid > CAST(k.value AS INTEGER)) '
       'GROUP BY m.client_id',
       readsFrom: <ResultSetImplementation<Object?, Object?>>{
         _db.clientChatMessages,
@@ -84,30 +87,27 @@ class ChatRepository {
   /// Marks a client's thread read up to its newest client message.
   ///
   /// Idempotent and write-free when there is nothing new: the marker is
-  /// the newest client message's timestamp (not `now()`), so calling this
+  /// the newest client message's `rowid` (not `now()`), so calling this
   /// again with no new messages computes the same value and skips the
   /// write entirely. That matters because `watchUnreadCounts` watches
   /// `app_key_values` — an unconditional write would emit on that stream
   /// and rebuild the list on every call (review PR 241).
   Future<void> markThreadRead(String clientId) async {
-    final newest =
-        await (_db.select(_db.clientChatMessages)
-              ..where(
-                (t) => t.clientId.equals(clientId) & t.sender.equals('client'),
-              )
-              ..orderBy(<OrderingTerm Function($ClientChatMessagesTable)>[
-                (t) => OrderingTerm(
-                  expression: t.createdAt,
-                  mode: OrderingMode.desc,
-                ),
-              ])
-              ..limit(1))
+    final row =
+        await _db
+            .customSelect(
+              'SELECT MAX(rowid) AS r FROM client_chat_messages '
+              "WHERE client_id = ?1 AND sender = 'client'",
+              variables: <Variable<Object>>[Variable<String>(clientId)],
+              readsFrom: <ResultSetImplementation<Object?, Object?>>{
+                _db.clientChatMessages,
+              },
+            )
             .getSingleOrNull();
-    // No client message at all — nothing could be unread.
-    if (newest == null) return;
+    // MAX over no client message returns NULL — nothing could be unread.
+    final marker = row?.read<int?>('r');
+    if (marker == null) return;
 
-    // Same unit as the unread query's comparison (epoch seconds).
-    final marker = newest.createdAt.millisecondsSinceEpoch ~/ 1000;
     final key = '$_readKeyPrefix$clientId';
     final stored = int.tryParse(await _db.readValue(key) ?? '');
     if (stored != null && stored >= marker) return; // already read

--- a/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
@@ -81,6 +81,46 @@ void main() {
       expect(row.lastTime, '방금');
     });
 
+    test(
+      'watchUnreadCounts counts client messages until marked read',
+      () async {
+        final repo = ChatRepository(db);
+
+        // Seeded client replies: 김민수 2 · 이지수 1 · 박성호 1.
+        var counts = await repo.watchUnreadCounts().first;
+        expect(counts['seed-client-1'], 2);
+        expect(counts['seed-client-2'], 1);
+        expect(counts['seed-client-3'], 1);
+
+        // Opening 김민수's thread clears his badge only.
+        await repo.markThreadRead('seed-client-1');
+        counts = await repo.watchUnreadCounts().first;
+        expect(counts.containsKey('seed-client-1'), isFalse);
+        expect(counts['seed-client-2'], 1);
+
+        // A trainer message never counts as unread.
+        await repo.sendTrainerMessage(clientId: 'seed-client-1', text: '확인!');
+        counts = await repo.watchUnreadCounts().first;
+        expect(counts.containsKey('seed-client-1'), isFalse);
+
+        // A NEW client reply after the marker counts again.
+        await db
+            .into(db.clientChatMessages)
+            .insert(
+              ClientChatMessagesCompanion.insert(
+                id: 'chat-reply-1',
+                clientId: 'seed-client-1',
+                sender: 'client',
+                body: '네 감사합니다!',
+                timeLabel: '09:00',
+                createdAt: DateTime.now().add(const Duration(seconds: 2)),
+              ),
+            );
+        counts = await repo.watchUnreadCounts().first;
+        expect(counts['seed-client-1'], 1);
+      },
+    );
+
     test('sendTrainerMessage ignores empty/whitespace input', () async {
       final repo = ChatRepository(db);
       final before = (await repo.watchThread('seed-client-1').first).length;

--- a/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
@@ -137,6 +137,59 @@ void main() {
       },
     );
 
+    test('markThreadRead is idempotent and skips redundant writes', () async {
+      final repo = ChatRepository(db);
+
+      Future<String?> marker() => db.readValue('chat_read_seed-client-1');
+
+      // First call stores the newest client message's timestamp.
+      await repo.markThreadRead('seed-client-1');
+      final first = await marker();
+      expect(first, isNotNull);
+      expect((await repo.watchUnreadCounts().first)['seed-client-1'], isNull);
+
+      // Repeat calls must produce the SAME value — an unconditional
+      // write would emit on app_key_values and rebuild the list, which
+      // is what the write→watch→build concern was about (review PR 241).
+      for (var i = 0; i < 3; i++) {
+        await repo.markThreadRead('seed-client-1');
+      }
+      expect(await marker(), first);
+
+      // A trainer message doesn't move the marker (only client messages
+      // can be unread).
+      await repo.sendTrainerMessage(clientId: 'seed-client-1', text: '확인!');
+      await repo.markThreadRead('seed-client-1');
+      expect(await marker(), first);
+
+      // A NEW client reply advances it exactly once.
+      await db
+          .into(db.clientChatMessages)
+          .insert(
+            ClientChatMessagesCompanion.insert(
+              id: 'chat-reply-x',
+              clientId: 'seed-client-1',
+              sender: 'client',
+              body: '넵!',
+              timeLabel: '09:00',
+              createdAt: DateTime.now().add(const Duration(seconds: 5)),
+            ),
+          );
+      await repo.markThreadRead('seed-client-1');
+      final second = await marker();
+      expect(second, isNot(first));
+      await repo.markThreadRead('seed-client-1');
+      expect(await marker(), second);
+    });
+
+    test(
+      'markThreadRead on a thread with no client message writes nothing',
+      () async {
+        await ChatRepository(db).markThreadRead('no-such-client');
+        expect(await db.readValue('chat_read_no-such-client'), isNull);
+      },
+    );
+
     test('sendTrainerMessage ignores empty/whitespace input', () async {
       final repo = ChatRepository(db);
       final before = (await repo.watchThread('seed-client-1').first).length;

--- a/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
@@ -142,7 +142,7 @@ void main() {
 
       Future<String?> marker() => db.readValue('chat_read_seed-client-1');
 
-      // First call stores the newest client message's timestamp.
+      // First call stores the newest client message's rowid.
       await repo.markThreadRead('seed-client-1');
       final first = await marker();
       expect(first, isNotNull);
@@ -181,6 +181,50 @@ void main() {
       await repo.markThreadRead('seed-client-1');
       expect(await marker(), second);
     });
+
+    test(
+      'a same-second reply after markThreadRead still counts as unread',
+      () async {
+        final repo = ChatRepository(db);
+        // A fresh client with no seeded messages, so the count is only
+        // what this test inserts.
+        const cid = 'rowid-test-client';
+        final sameSecond = DateTime(2026, 1, 1, 9, 0, 0);
+
+        // First client message, then mark the thread read.
+        await db
+            .into(db.clientChatMessages)
+            .insert(
+              ClientChatMessagesCompanion.insert(
+                id: 'chat-ss-1',
+                clientId: cid,
+                sender: 'client',
+                body: '첫 메시지',
+                timeLabel: '09:00',
+                createdAt: sameSecond,
+              ),
+            );
+        await repo.markThreadRead(cid);
+        expect((await repo.watchUnreadCounts().first)[cid], isNull);
+
+        // A SECOND reply lands in the very same second. An epoch-second
+        // marker (created_at > marker) would miss it because both share
+        // the same second; the rowid marker still flags it (review 241).
+        await db
+            .into(db.clientChatMessages)
+            .insert(
+              ClientChatMessagesCompanion.insert(
+                id: 'chat-ss-2',
+                clientId: cid,
+                sender: 'client',
+                body: '같은 초에 온 두 번째 메시지',
+                timeLabel: '09:00',
+                createdAt: sameSecond,
+              ),
+            );
+        expect((await repo.watchUnreadCounts().first)[cid], 1);
+      },
+    );
 
     test(
       'markThreadRead on a thread with no client message writes nothing',

--- a/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oncare_trainer/core/storage/app_database.dart';
@@ -87,6 +88,23 @@ void main() {
       expect(find.text('박성호'), findsOneWidget);
       await tester.scrollUntilVisible(find.text('이지수'), 150);
       expect(find.text('이지수'), findsOneWidget);
+    });
+
+    testWidgets('unread badges show and clear after reading the thread', (
+      tester,
+    ) async {
+      await pumpTrainerApp(tester, token: 'demo-trainer-token');
+
+      // 김민수 has 2 unseen client replies in the seed.
+      expect(find.text('2'), findsOneWidget);
+
+      // Open his chat, then come back — badge cleared.
+      await tester.tap(find.text('김민수'));
+      await settle(tester);
+      await tester.tap(find.byIcon(Icons.arrow_back_ios_new));
+      await settle(tester);
+
+      expect(find.text('2'), findsNothing);
     });
 
     testWidgets('tapping a client card opens the detail screen', (


### PR DESCRIPTION
## Summary
* 고객 카드에 안읽은 메시지 수 알림(파랑)가 표시되고 미리보기가 볼드 처리됩니다. 시드 기준 김민수 2·이지수 1·박성호 1로 시작합니다.
* 스레드를 열면(열려 있는 동안 새 메시지가 와도) 읽음 처리되어 뱃지가 실시간으로 사라집니다.
* 읽음 마커는 `AppKeyValues`(`chat_read_<clientId>`, epoch 초) — **스키마 마이그레이션 없이** 반응형 customSelect 한 방으로 카운트합니다.

## Changes
### ✨ Features
* `ChatRepository.watchUnreadCounts()/markThreadRead()` + `unreadCountsProvider`
* `ClientCard` 뱃지 + 미리보기 강조, ChatView 열람 시 읽음 처리(빌드 밖 microtask)
### 🐛 Fixes
* `markThreadRead` 멱등화(최신 메시지 시각 마커, 불필요 write 생략)

## Commits
1. `b3b0090` feat: unread chat badges on the client list

## Notes
* 트레이너 발신 메시지는 카운트에서 제외 — 회원 앱 연동 전에는 고객 메시지가 시드로만 존재하므로, 데모에선 최초 뱃지 → 열람 → 해제 흐름을 보여줍니다.

## Test Plan
* [ ] 기능 / 예외 / UI / 빌드 / 테스트 통과
### Manual Test Steps
1. 고객 탭 → 김민수 카드 뱃지 '2' 확인 → 채팅 열람 → 목록 복귀 → 뱃지 사라짐 확인

## Related Issues
Closes #240 

## Checklist
* [ ] 코드 리뷰 준비 완료 / 불필요한 코드 제거 / 하드코딩 점검 / 충돌 없음 / 데모 영향 확인