### PR TITLE
feat(trainer): 스케줄·AI 루틴 날짜 이동

### DIFF
--- a/frontend/flutter_trainer/lib/features/ai_routine/data/repositories/ai_routine_repository.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/data/repositories/ai_routine_repository.dart
@@ -37,24 +37,24 @@ class AiRoutineRepository {
   }
 
   /// Registers the composed routine as [clientName]'s PT program on
-  /// today's schedule (스케줄 탭 watches the same table, so it updates
-  /// live). Attaches to the client's earliest 예정 session when one
-  /// exists; otherwise books a new one-hour 예정 slot at the next full
-  /// hour. Returns `true` when attached to an existing session.
+  /// [date]'s schedule (스케줄 탭 watches the same table, so it updates
+  /// live). Attaches to the client's earliest 예정 session on that date
+  /// when one exists; otherwise books a new one-hour 예정 slot.
+  /// Returns `true` when attached to an existing session.
   ///
   /// [program] entries follow the schedule programJson shape
   /// (`{name, sets, reps, weight}`).
-  Future<bool> registerToTodaySchedule({
+  Future<bool> registerToSchedule({
+    required String date,
     required String clientName,
     required List<Map<String, Object?>> program,
   }) async {
     final table = _db.trainerScheduleEntries;
-    final today = ymd(DateTime.now());
     final existing =
         await (_db.select(table)
               ..where(
                 (t) =>
-                    t.date.equals(today) &
+                    t.date.equals(date) &
                     t.clientName.equals(clientName) &
                     t.status.equals('예정'),
               )
@@ -74,13 +74,14 @@ class AiRoutineRepository {
     }
 
     final now = DateTime.now();
-    final hour = (now.hour + 1).clamp(6, 22);
+    // 오늘이면 다음 정시, 다른 날짜면 오전 10시가 기본 슬롯.
+    final hour = date == ymd(now) ? (now.hour + 1).clamp(6, 22) : 10;
     await _db
         .into(table)
         .insert(
           TrainerScheduleEntriesCompanion.insert(
             id: 'sched-${now.microsecondsSinceEpoch}',
-            date: today,
+            date: date,
             time: '${hour.toString().padLeft(2, '0')}:00',
             clientName: Value(clientName),
             type: const Value('1:1 PT'),

--- a/frontend/flutter_trainer/lib/features/ai_routine/presentation/pages/ai_routine_page.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/presentation/pages/ai_routine_page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/layout.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
@@ -62,6 +63,9 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
   bool _registered = false;
   Timer? _registerTimer;
 
+  /// Day offset (0 = 오늘 … 6) the routine gets registered on.
+  int _registerOffset = 0;
+
   @override
   void dispose() {
     _sentTimer?.cancel();
@@ -82,6 +86,7 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
       _showAddForm = false;
       _sent = false;
       _registered = false;
+      _registerOffset = 0;
     });
     _sentTimer?.cancel();
     _registerTimer?.cancel();
@@ -159,10 +164,15 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
     final program = _composeProgram(items);
     if (program.isEmpty) return;
     final messenger = ScaffoldMessenger.of(context);
+    final date = ymd(DateTime.now().add(Duration(days: _registerOffset)));
     try {
       await ref
           .read(aiRoutineRepositoryProvider)
-          .registerToTodaySchedule(clientName: client.name, program: program);
+          .registerToSchedule(
+            date: date,
+            clientName: client.name,
+            program: program,
+          );
     } catch (_) {
       messenger.showSnackBar(
         const SnackBar(content: Text('스케줄 등록에 실패했어요. 다시 시도해 주세요')),
@@ -440,8 +450,30 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
                 ),
               ),
             const SizedBox(height: AppSpacing.sm),
+            // Which day the routine lands on (오늘 … +6일).
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children: <Widget>[
+                  for (var i = 0; i < 7; i++) ...<Widget>[
+                    _DateChip(
+                      offset: i,
+                      selected: _registerOffset == i,
+                      onTap: () => setState(() {
+                        _registerOffset = i;
+                        _registered = false;
+                      }),
+                    ),
+                    const SizedBox(width: AppSpacing.xs),
+                  ],
+                ],
+              ),
+            ),
+            const SizedBox(height: AppSpacing.sm),
             OutlinedActionButton(
-              label: _registered ? '✓ 오늘 스케줄에 등록됨' : '📅 오늘 PT 스케줄에 등록',
+              label: _registered
+                  ? '✓ ${_dateChipLabel(_registerOffset)} 스케줄에 등록됨'
+                  : '📅 ${_dateChipLabel(_registerOffset)} PT 스케줄에 등록',
               color: _registered ? AppColors.success : AppColors.accent,
               onTap: _registered
                   ? null
@@ -1095,6 +1127,54 @@ class _FormButton extends StatelessWidget {
               fontWeight: FontWeight.w700,
               color: foreground,
             ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Label for a register-day offset (오늘/내일/M/D).
+String _dateChipLabel(int offset) {
+  if (offset == 0) return '오늘';
+  if (offset == 1) return '내일';
+  final d = DateTime.now().add(Duration(days: offset));
+  return '${d.month}/${d.day}';
+}
+
+/// One selectable register-day chip.
+class _DateChip extends StatelessWidget {
+  const _DateChip({
+    required this.offset,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final int offset;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+          vertical: 4,
+        ),
+        decoration: BoxDecoration(
+          color: selected ? AppColors.primary : AppColors.inputBackground,
+          borderRadius: const BorderRadius.all(AppRadius.pill),
+        ),
+        child: Text(
+          _dateChipLabel(offset),
+          style: TextStyle(
+            fontSize: 10.5,
+            fontWeight: FontWeight.w700,
+            color: selected
+                ? AppColors.primaryForeground
+                : AppColors.subtleForeground,
           ),
         ),
       ),

--- a/frontend/flutter_trainer/lib/features/schedule/data/repositories/schedule_repository.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/data/repositories/schedule_repository.dart
@@ -19,9 +19,12 @@ class ScheduleRepository {
   /// NOTE: `ymd(DateTime.now())`는 스트림 구독 시점에 고정된다 — 앱을
   /// 자정 넘겨 켜두면 '오늘'이 갱신되지 않음(예약 카운트와 동일 패턴,
   /// 로컬 mock 데모 범위에선 허용). 실 백엔드 전환 시 서버가 판단한다.
-  Stream<List<ScheduleSession>> watchToday() {
+  Stream<List<ScheduleSession>> watchToday() => watchDate(ymd(DateTime.now()));
+
+  /// The timeline for one calendar [date] (`YYYY-MM-DD`).
+  Stream<List<ScheduleSession>> watchDate(String date) {
     final query = _db.select(_db.trainerScheduleEntries)
-      ..where((t) => t.date.equals(ymd(DateTime.now())))
+      ..where((t) => t.date.equals(date))
       // Time first (zero-padded HH:MM sorts lexicographically) so
       // trainer-added sessions land at the right timeline position;
       // sortOrder only breaks ties between seed rows.
@@ -32,9 +35,23 @@ class ScheduleRepository {
     return query.watch().map((rows) => rows.map(_toEntity).toList());
   }
 
-  /// Books a new session on today's timeline (status 예정). The
+  /// Dates (`YYYY-MM-DD`) that have at least one booked (non-공백)
+  /// session — drives the week strip's dot markers.
+  Stream<Set<String>> watchBookedDates() {
+    final t = _db.trainerScheduleEntries;
+    final query = _db.selectOnly(t, distinct: true)
+      ..addColumns(<Expression<Object>>[t.date])
+      ..where(t.status.equals('공백').not());
+    return query
+        .map((row) => row.read(t.date)!)
+        .watch()
+        .map((rows) => rows.toSet());
+  }
+
+  /// Books a new session on [date]'s timeline (status 예정). The
   /// non-`seed-` id survives the daily re-seed.
   Future<void> addSession({
+    required String date,
     required String clientName,
     required String time,
     required String type,
@@ -45,7 +62,7 @@ class ScheduleRepository {
         .insert(
           TrainerScheduleEntriesCompanion.insert(
             id: 'sched-${DateTime.now().microsecondsSinceEpoch}',
-            date: ymd(DateTime.now()),
+            date: date,
             time: time,
             clientName: Value(clientName),
             type: Value(type),
@@ -114,13 +131,17 @@ class ScheduleRepository {
           .map((e) => e! as Map<String, Object?>)
           .toList();
       final now = DateTime.now();
+      // Label with the SESSION's calendar day — completing a session
+      // browsed on another date must not claim '오늘'.
+      final day = DateTime.tryParse(session.date) ?? now;
+      final isToday = session.date == ymd(now);
       await _db
           .into(_db.clientRoutineHistory)
           .insert(
             ClientRoutineHistoryCompanion.insert(
               id: 'hist-${now.microsecondsSinceEpoch}',
               clientId: client.id,
-              dateLabel: '${now.month}/${now.day} (오늘)',
+              dateLabel: '${day.month}/${day.day}${isToday ? ' (오늘)' : ''}',
               label: 'PT 세션 · 트레이너 지도',
               completionRate: 100,
               exercisesJson: jsonEncode(<String>[
@@ -171,4 +192,15 @@ final scheduleRepositoryProvider = Provider<ScheduleRepository>((ref) {
 /// Streams today's timeline for the 스케줄 tab.
 final todayScheduleProvider = StreamProvider<List<ScheduleSession>>((ref) {
   return ref.watch(scheduleRepositoryProvider).watchToday();
+});
+
+/// Streams the timeline for one calendar date (`YYYY-MM-DD`).
+final scheduleForDateProvider =
+    StreamProvider.family<List<ScheduleSession>, String>((ref, date) {
+      return ref.watch(scheduleRepositoryProvider).watchDate(date);
+    });
+
+/// Streams the set of dates that have booked sessions (strip dots).
+final bookedDatesProvider = StreamProvider<Set<String>>((ref) {
+  return ref.watch(scheduleRepositoryProvider).watchBookedDates();
 });

--- a/frontend/flutter_trainer/lib/features/schedule/data/repositories/schedule_repository.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/data/repositories/schedule_repository.dart
@@ -109,14 +109,21 @@ class ScheduleRepository {
   /// when this call is the one that flipped 예정 → 완료. Two concurrent
   /// completions would otherwise both observe 예정 and insert duplicate
   /// history rows (review PR 237).
+  ///
+  /// A session dated in the FUTURE can't be completed — it hasn't
+  /// happened yet. The UI hides the 완료 action for future days, and this
+  /// guard rejects it even if reached another way (review PR 245).
   Future<void> completeSession(String id, {String note = ''}) async {
     final table = _db.trainerScheduleEntries;
+    final today = ymd(DateTime.now());
 
     await _db.transaction(() async {
       final session = await (_db.select(
         table,
       )..where((t) => t.id.equals(id))).getSingleOrNull();
       if (session == null || session.status != '예정') return;
+      // `YYYY-MM-DD` sorts lexicographically, so a plain compare works.
+      if (session.date.compareTo(today) > 0) return;
 
       // Conditional update: `changed` is 0 when a concurrent call already
       // completed this session, in which case we must not log again.

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -33,7 +33,15 @@ class SchedulePage extends ConsumerStatefulWidget {
 
 class _SchedulePageState extends ConsumerState<SchedulePage> {
   /// The calendar day being browsed (defaults to today).
-  DateTime _selectedDay = DateTime.now();
+  DateTime _selectedDay = _dateOnly(DateTime.now());
+
+  /// Leftmost day of the visible 7-day strip. Centred on today (D-3) so
+  /// today sits in the middle; chevrons shift it a week at a time.
+  DateTime _weekAnchor = _dateOnly(
+    DateTime.now(),
+  ).subtract(const Duration(days: 3));
+
+  static DateTime _dateOnly(DateTime d) => DateTime(d.year, d.month, d.day);
 
   final Set<String> _expanded = <String>{};
   final Set<String> _sent = <String>{};
@@ -216,28 +224,7 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
               ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: <Widget>[
-                  _Header(date: _selectedDay),
-                  const SizedBox(height: AppSpacing.lg),
-                  _ScheduleWeekStrip(
-                    selectedDay: _selectedDay,
-                    bookedDates:
-                        ref.watch(bookedDatesProvider).valueOrNull ??
-                        const <String>{},
-                    onSelect: (d) => setState(() => _selectedDay = d),
-                    onShiftWeek: (dir) => setState(
-                      () => _selectedDay = _selectedDay.add(
-                        Duration(days: 7 * dir),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: AppSpacing.lg),
-                  OutlinedActionButton(
-                    label: '＋ 새 일정 추가',
-                    color: AppColors.accent,
-                    onTap: () => _openSessionSheet(),
-                  ),
-                ],
+                children: _overviewChildren(),
               ),
             ),
           ),
@@ -246,6 +233,48 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
         ],
       ),
     );
+  }
+
+  /// Title + optional 오늘로 button, the week strip, and the add button.
+  /// Shared by the wide left column and the single-column timeline.
+  List<Widget> _overviewChildren() {
+    final today = _dateOnly(DateTime.now());
+    final defaultAnchor = today.subtract(const Duration(days: 3));
+    // Offer 오늘로 whenever the view has drifted from its default
+    // (either a non-today selection or a scrubbed window).
+    final showToday = _selectedDay != today || _weekAnchor != defaultAnchor;
+    return <Widget>[
+      Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Expanded(child: _Header(date: _selectedDay)),
+          if (showToday)
+            _TodayButton(
+              onTap: () => setState(() {
+                _selectedDay = today;
+                _weekAnchor = defaultAnchor;
+              }),
+            ),
+        ],
+      ),
+      const SizedBox(height: AppSpacing.lg),
+      _ScheduleWeekStrip(
+        weekAnchor: _weekAnchor,
+        selectedDay: _selectedDay,
+        bookedDates:
+            ref.watch(bookedDatesProvider).valueOrNull ?? const <String>{},
+        onSelect: (d) => setState(() => _selectedDay = d),
+        onShiftWeek: (dir) => setState(
+          () => _weekAnchor = _weekAnchor.add(Duration(days: 7 * dir)),
+        ),
+      ),
+      const SizedBox(height: AppSpacing.lg),
+      OutlinedActionButton(
+        label: '＋ 새 일정 추가',
+        color: AppColors.accent,
+        onTap: () => _openSessionSheet(),
+      ),
+    ];
   }
 
   /// The scrollable timeline; [withOverview] prepends the header, week
@@ -260,23 +289,7 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
       ),
       children: <Widget>[
         if (withOverview) ...<Widget>[
-          _Header(date: _selectedDay),
-          const SizedBox(height: AppSpacing.lg),
-          _ScheduleWeekStrip(
-            selectedDay: _selectedDay,
-            bookedDates:
-                ref.watch(bookedDatesProvider).valueOrNull ?? const <String>{},
-            onSelect: (d) => setState(() => _selectedDay = d),
-            onShiftWeek: (dir) => setState(
-              () => _selectedDay = _selectedDay.add(Duration(days: 7 * dir)),
-            ),
-          ),
-          const SizedBox(height: AppSpacing.lg),
-          OutlinedActionButton(
-            label: '＋ 새 일정 추가',
-            color: AppColors.accent,
-            onTap: () => _openSessionSheet(),
-          ),
+          ..._overviewChildren(),
           const SizedBox(height: AppSpacing.lg),
         ],
         if (sessions.isEmpty)
@@ -666,16 +679,52 @@ class _Header extends StatelessWidget {
   }
 }
 
-/// Sunday-to-Saturday week picker, mirroring the user app's Diet tab
-/// strip (chevrons scrub the week, the selected day fills primary,
-/// today reads primary). A dot marks days with booked sessions.
+/// "오늘로" pill — jumps the strip and selection back to today. Shown
+/// only when browsing another day (mirrors the user app's Diet tab).
+class _TodayButton extends StatelessWidget {
+  const _TodayButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.accentSurface,
+      borderRadius: const BorderRadius.all(AppRadius.pill),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: const BorderRadius.all(AppRadius.pill),
+        child: const Padding(
+          padding: EdgeInsets.symmetric(horizontal: AppSpacing.md, vertical: 6),
+          child: Text(
+            '오늘로',
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              color: AppColors.accent,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 7-day picker centred on today, mirroring the user app's Diet tab
+/// strip: chevrons shift the window a week at a time, the selected day
+/// fills primary, today reads primary. A dot marks days with booked
+/// sessions. Cells are flexible so the row never overflows.
 class _ScheduleWeekStrip extends StatelessWidget {
   const _ScheduleWeekStrip({
+    required this.weekAnchor,
     required this.selectedDay,
     required this.bookedDates,
     required this.onSelect,
     required this.onShiftWeek,
   });
+
+  /// Leftmost visible day (today − 3 by default).
+  final DateTime weekAnchor;
 
   /// The day currently highlighted and shown on the timeline.
   final DateTime selectedDay;
@@ -690,51 +739,41 @@ class _ScheduleWeekStrip extends StatelessWidget {
   final ValueChanged<int> onShiftWeek;
 
   static const List<String> _weekdayShort = <String>[
-    '일',
     '월',
     '화',
     '수',
     '목',
     '금',
     '토',
+    '일',
   ];
-
-  DateTime _sundayOf(DateTime d) {
-    final dayDate = DateTime(d.year, d.month, d.day);
-    // weekday: Mon=1..Sun=7; offset back to Sunday.
-    return dayDate.subtract(Duration(days: dayDate.weekday % 7));
-  }
 
   bool _isSameDay(DateTime a, DateTime b) =>
       a.year == b.year && a.month == b.month && a.day == b.day;
 
   @override
   Widget build(BuildContext context) {
-    final sunday = _sundayOf(selectedDay);
     final today = DateTime.now();
     final week = <DateTime>[
-      for (var i = 0; i < 7; i++) sunday.add(Duration(days: i)),
+      for (var i = 0; i < 7; i++) weekAnchor.add(Duration(days: i)),
     ];
 
     return Row(
       children: <Widget>[
         _ChevronButton(icon: Icons.chevron_left, onTap: () => onShiftWeek(-1)),
-        Expanded(
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: <Widget>[
-              for (final d in week)
-                _DayCell(
-                  date: d,
-                  label: _weekdayShort[d.weekday % 7],
-                  selected: _isSameDay(d, selectedDay),
-                  isToday: _isSameDay(d, today),
-                  hasDot: bookedDates.contains(ymd(d)),
-                  onTap: () => onSelect(d),
-                ),
-            ],
+        // Flexible cells share the middle space evenly — no fixed widths
+        // that could overflow a narrow column.
+        for (final d in week)
+          Expanded(
+            child: _DayCell(
+              date: d,
+              label: _weekdayShort[d.weekday - 1],
+              selected: _isSameDay(d, selectedDay),
+              isToday: _isSameDay(d, today),
+              hasDot: bookedDates.contains(ymd(d)),
+              onTap: () => onSelect(d),
+            ),
           ),
-        ),
         _ChevronButton(icon: Icons.chevron_right, onTap: () => onShiftWeek(1)),
       ],
     );
@@ -750,8 +789,8 @@ class _ChevronButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: 32,
-      height: 36,
+      width: 28,
+      height: 44,
       child: Material(
         color: Colors.transparent,
         shape: const CircleBorder(),
@@ -789,13 +828,12 @@ class _DayCell extends StatelessWidget {
         : (isToday ? AppColors.primary : AppColors.foreground);
     final labelColor = selected
         ? AppColors.primaryForeground.withValues(alpha: 0.85)
-        : AppColors.subtleForeground;
+        : (isToday ? AppColors.primary : AppColors.subtleForeground);
 
     return InkWell(
       onTap: onTap,
       borderRadius: const BorderRadius.all(AppRadius.lg),
       child: Container(
-        width: 36,
         padding: const EdgeInsets.symmetric(vertical: 6),
         decoration: BoxDecoration(
           color: selected ? AppColors.primary : Colors.transparent,

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/layout.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
@@ -31,6 +32,9 @@ class SchedulePage extends ConsumerStatefulWidget {
 }
 
 class _SchedulePageState extends ConsumerState<SchedulePage> {
+  /// The calendar day being browsed (defaults to today).
+  DateTime _selectedDay = DateTime.now();
+
   final Set<String> _expanded = <String>{};
   final Set<String> _sent = <String>{};
   // 단일 플래시: 연속 전송 시 직전 카드의 확인 플래시는 새 플래시로
@@ -91,6 +95,7 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
       ),
       builder: (context) => _SessionSheet(
         clientNames: clients.map((c) => c.name).toList(),
+        date: _selectedYmd,
         existing: existing,
       ),
     );
@@ -159,9 +164,11 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
     }
   }
 
+  String get _selectedYmd => ymd(_selectedDay);
+
   @override
   Widget build(BuildContext context) {
-    final schedule = ref.watch(todayScheduleProvider);
+    final schedule = ref.watch(scheduleForDateProvider(_selectedYmd));
     // Keep the client stream live so the booking sheet and the chat
     // shortcut have data even when this tab is the first one opened.
     ref.watch(clientsProvider);
@@ -210,9 +217,20 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: <Widget>[
-                  const _Header(),
+                  _Header(date: _selectedDay),
                   const SizedBox(height: AppSpacing.lg),
-                  _WeekStrip(hasScheduleToday: sessions.isNotEmpty),
+                  _ScheduleWeekStrip(
+                    selectedDay: _selectedDay,
+                    bookedDates:
+                        ref.watch(bookedDatesProvider).valueOrNull ??
+                        const <String>{},
+                    onSelect: (d) => setState(() => _selectedDay = d),
+                    onShiftWeek: (dir) => setState(
+                      () => _selectedDay = _selectedDay.add(
+                        Duration(days: 7 * dir),
+                      ),
+                    ),
+                  ),
                   const SizedBox(height: AppSpacing.lg),
                   OutlinedActionButton(
                     label: '＋ 새 일정 추가',
@@ -242,9 +260,17 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
       ),
       children: <Widget>[
         if (withOverview) ...<Widget>[
-          const _Header(),
+          _Header(date: _selectedDay),
           const SizedBox(height: AppSpacing.lg),
-          _WeekStrip(hasScheduleToday: sessions.isNotEmpty),
+          _ScheduleWeekStrip(
+            selectedDay: _selectedDay,
+            bookedDates:
+                ref.watch(bookedDatesProvider).valueOrNull ?? const <String>{},
+            onSelect: (d) => setState(() => _selectedDay = d),
+            onShiftWeek: (dir) => setState(
+              () => _selectedDay = _selectedDay.add(Duration(days: 7 * dir)),
+            ),
+          ),
           const SizedBox(height: AppSpacing.lg),
           OutlinedActionButton(
             label: '＋ 새 일정 추가',
@@ -253,6 +279,28 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
           ),
           const SizedBox(height: AppSpacing.lg),
         ],
+        if (sessions.isEmpty)
+          Container(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.lg,
+              vertical: AppSpacing.xl,
+            ),
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              borderRadius: const BorderRadius.all(AppRadius.card),
+              border: Border.all(color: AppColors.borderStrong),
+            ),
+            child: const Text(
+              '이 날짜에는 일정이 없어요.\n아래에서 새 일정을 추가해 보세요.',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+                color: AppColors.mutedForeground,
+                height: 1.5,
+              ),
+            ),
+          ),
         for (final s in sessions) ...<Widget>[
           _TimelineRow(
             session: s,
@@ -339,9 +387,17 @@ class _CompleteDialogState extends State<_CompleteDialog> {
 /// Bottom sheet for booking or editing a session: client, type, time
 /// (15-minute steps), and duration.
 class _SessionSheet extends ConsumerStatefulWidget {
-  const _SessionSheet({required this.clientNames, required this.existing});
+  const _SessionSheet({
+    required this.clientNames,
+    required this.date,
+    required this.existing,
+  });
 
   final List<String> clientNames;
+
+  /// The browsed calendar day new sessions are booked on (`YYYY-MM-DD`).
+  final String date;
+
   final ScheduleSession? existing;
 
   @override
@@ -392,6 +448,7 @@ class _SessionSheetState extends ConsumerState<_SessionSheet> {
       final e = widget.existing;
       if (e == null) {
         await repo.addSession(
+          date: widget.date,
           clientName: _client,
           time: _time,
           type: _type,
@@ -561,9 +618,12 @@ class _SessionSheetState extends ConsumerState<_SessionSheet> {
   }
 }
 
-/// "스케줄" title + "{오늘 날짜} · {헬스장}" subtitle.
+/// "스케줄" title + "{선택 날짜} · {헬스장}" subtitle.
 class _Header extends StatelessWidget {
-  const _Header();
+  const _Header({required this.date});
+
+  /// The calendar day being browsed.
+  final DateTime date;
 
   static const List<String> _weekdays = <String>[
     '월요일',
@@ -578,9 +638,11 @@ class _Header extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final now = DateTime.now();
+    final isToday =
+        date.year == now.year && date.month == now.month && date.day == now.day;
     final subtitle =
-        '${now.month}월 ${now.day}일 ${_weekdays[now.weekday - 1]}'
-        ' · ${seedTrainerProfile.gym.name}';
+        '${date.month}월 ${date.day}일 ${_weekdays[date.weekday - 1]}'
+        '${isToday ? ' (오늘)' : ''} · ${seedTrainerProfile.gym.name}';
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
@@ -604,97 +666,176 @@ class _Header extends StatelessWidget {
   }
 }
 
-/// 7-day strip **centered on today** (D-3 … D+3) with today highlighted
-/// in the middle; a dot marks days that have schedule entries (seed
-/// data covers today only).
-class _WeekStrip extends StatelessWidget {
-  const _WeekStrip({required this.hasScheduleToday});
+/// Sunday-to-Saturday week picker, mirroring the user app's Diet tab
+/// strip (chevrons scrub the week, the selected day fills primary,
+/// today reads primary). A dot marks days with booked sessions.
+class _ScheduleWeekStrip extends StatelessWidget {
+  const _ScheduleWeekStrip({
+    required this.selectedDay,
+    required this.bookedDates,
+    required this.onSelect,
+    required this.onShiftWeek,
+  });
 
-  final bool hasScheduleToday;
+  /// The day currently highlighted and shown on the timeline.
+  final DateTime selectedDay;
 
-  static const List<String> _days = <String>['월', '화', '수', '목', '금', '토', '일'];
+  /// `YYYY-MM-DD` dates that have at least one booked session.
+  final Set<String> bookedDates;
+
+  /// Called when the user taps a day cell.
+  final ValueChanged<DateTime> onSelect;
+
+  /// `-1` = previous week, `+1` = next week.
+  final ValueChanged<int> onShiftWeek;
+
+  static const List<String> _weekdayShort = <String>[
+    '일',
+    '월',
+    '화',
+    '수',
+    '목',
+    '금',
+    '토',
+  ];
+
+  DateTime _sundayOf(DateTime d) {
+    final dayDate = DateTime(d.year, d.month, d.day);
+    // weekday: Mon=1..Sun=7; offset back to Sunday.
+    return dayDate.subtract(Duration(days: dayDate.weekday % 7));
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
 
   @override
   Widget build(BuildContext context) {
-    final now = DateTime.now();
-    final today = DateTime(now.year, now.month, now.day);
+    final sunday = _sundayOf(selectedDay);
+    final today = DateTime.now();
+    final week = <DateTime>[
+      for (var i = 0; i < 7; i++) sunday.add(Duration(days: i)),
+    ];
 
     return Row(
       children: <Widget>[
-        for (var i = -3; i <= 3; i++)
-          Expanded(
-            child: Builder(
-              builder: (context) {
-                final date = today.add(Duration(days: i));
-                return _DayCell(
-                  label: _days[date.weekday - 1],
-                  date: date,
-                  isToday: i == 0,
-                  hasDot: i == 0 && hasScheduleToday,
-                );
-              },
-            ),
+        _ChevronButton(icon: Icons.chevron_left, onTap: () => onShiftWeek(-1)),
+        Expanded(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: <Widget>[
+              for (final d in week)
+                _DayCell(
+                  date: d,
+                  label: _weekdayShort[d.weekday % 7],
+                  selected: _isSameDay(d, selectedDay),
+                  isToday: _isSameDay(d, today),
+                  hasDot: bookedDates.contains(ymd(d)),
+                  onTap: () => onSelect(d),
+                ),
+            ],
           ),
+        ),
+        _ChevronButton(icon: Icons.chevron_right, onTap: () => onShiftWeek(1)),
       ],
+    );
+  }
+}
+
+class _ChevronButton extends StatelessWidget {
+  const _ChevronButton({required this.icon, required this.onTap});
+
+  final IconData icon;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 32,
+      height: 36,
+      child: Material(
+        color: Colors.transparent,
+        shape: const CircleBorder(),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onTap,
+          child: Icon(icon, size: 20, color: AppColors.mutedForeground),
+        ),
+      ),
     );
   }
 }
 
 class _DayCell extends StatelessWidget {
   const _DayCell({
-    required this.label,
     required this.date,
+    required this.label,
+    required this.selected,
     required this.isToday,
     required this.hasDot,
+    required this.onTap,
   });
 
-  final String label;
   final DateTime date;
+  final String label;
+  final bool selected;
   final bool isToday;
   final bool hasDot;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: <Widget>[
-        Text(
-          label,
-          style: TextStyle(
-            fontSize: 10,
-            fontWeight: FontWeight.w600,
-            color: isToday ? AppColors.primary : AppColors.subtleForeground,
-          ),
+    final dayColor = selected
+        ? AppColors.primaryForeground
+        : (isToday ? AppColors.primary : AppColors.foreground);
+    final labelColor = selected
+        ? AppColors.primaryForeground.withValues(alpha: 0.85)
+        : AppColors.subtleForeground;
+
+    return InkWell(
+      onTap: onTap,
+      borderRadius: const BorderRadius.all(AppRadius.lg),
+      child: Container(
+        width: 36,
+        padding: const EdgeInsets.symmetric(vertical: 6),
+        decoration: BoxDecoration(
+          color: selected ? AppColors.primary : Colors.transparent,
+          borderRadius: const BorderRadius.all(AppRadius.lg),
         ),
-        const SizedBox(height: AppSpacing.xs),
-        Container(
-          width: 32,
-          height: 32,
-          alignment: Alignment.center,
-          decoration: BoxDecoration(
-            color: isToday ? AppColors.primary : Colors.transparent,
-            borderRadius: const BorderRadius.all(AppRadius.md),
-          ),
-          child: Text(
-            '${date.day}',
-            style: TextStyle(
-              fontSize: 12.5,
-              fontWeight: FontWeight.w700,
-              color: isToday
-                  ? AppColors.primaryForeground
-                  : AppColors.mutedForeground,
+        child: Column(
+          children: <Widget>[
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 10,
+                fontWeight: FontWeight.w600,
+                color: labelColor,
+              ),
             ),
-          ),
+            const SizedBox(height: 3),
+            Text(
+              '${date.day}',
+              style: TextStyle(
+                fontSize: 12.5,
+                fontWeight: FontWeight.w700,
+                color: dayColor,
+              ),
+            ),
+            const SizedBox(height: 3),
+            Container(
+              width: 4,
+              height: 4,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: hasDot
+                    ? (selected
+                          ? AppColors.primaryForeground
+                          : AppColors.primary)
+                    : Colors.transparent,
+              ),
+            ),
+          ],
         ),
-        const SizedBox(height: 3),
-        Container(
-          width: 5,
-          height: 5,
-          decoration: BoxDecoration(
-            shape: BoxShape.circle,
-            color: hasDot ? AppColors.primary : Colors.transparent,
-          ),
-        ),
-      ],
+      ),
     );
   }
 }

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -217,22 +217,18 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
     return Scaffold(
       backgroundColor: AppColors.background,
       body: SafeArea(
-        child: schedule.when(
-          loading: () => const Center(child: CircularProgressIndicator()),
-          error: (e, _) => const Center(
-            child: Text(
-              '스케줄을 불러오지 못했어요',
-              style: TextStyle(color: AppColors.mutedForeground),
-            ),
-          ),
-          data: (sessions) => LayoutBuilder(
-            builder: (context, constraints) {
-              final wide = constraints.maxWidth >= AppLayout.splitBreakpoint;
-              return wide
-                  ? _buildWide(sessions)
-                  : ContentFrame(child: _buildTimeline(sessions, true));
-            },
-          ),
+        // The date header, week strip and add button live OUTSIDE the
+        // async `when()`: switching days spins up a new provider that
+        // starts in `loading`, and blanking the whole page to a spinner
+        // each tap made the strip flicker. Only the timeline reacts to
+        // the async state now (review PR 245).
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final wide = constraints.maxWidth >= AppLayout.splitBreakpoint;
+            return wide
+                ? _buildWide(schedule)
+                : ContentFrame(child: _buildTimeline(schedule, true));
+          },
         ),
       ),
     );
@@ -240,7 +236,7 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
 
   /// Wide viewports: the date/week overview docks left and the timeline
   /// gets its own scrollable column.
-  Widget _buildWide(List<ScheduleSession> sessions) {
+  Widget _buildWide(AsyncValue<List<ScheduleSession>> schedule) {
     return ContentFrame(
       maxWidth: AppLayout.wideMaxWidth,
       child: Row(
@@ -262,7 +258,7 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
             ),
           ),
           const VerticalDivider(width: 1, color: AppColors.borderStrong),
-          Expanded(child: _buildTimeline(sessions, false)),
+          Expanded(child: _buildTimeline(schedule, false)),
         ],
       ),
     );
@@ -311,8 +307,13 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
   }
 
   /// The scrollable timeline; [withOverview] prepends the header, week
-  /// strip, and add button (single-column layout).
-  Widget _buildTimeline(List<ScheduleSession> sessions, bool withOverview) {
+  /// strip, and add button (single-column layout). The overview is always
+  /// rendered — only the session list swaps on the async [schedule] state,
+  /// so switching days never blanks the strip (review PR 245).
+  Widget _buildTimeline(
+    AsyncValue<List<ScheduleSession>> schedule,
+    bool withOverview,
+  ) {
     return ListView(
       padding: const EdgeInsets.fromLTRB(
         AppSpacing.xl,
@@ -325,45 +326,77 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
           ..._overviewChildren(),
           const SizedBox(height: AppSpacing.lg),
         ],
-        if (sessions.isEmpty)
-          Container(
-            padding: const EdgeInsets.symmetric(
-              horizontal: AppSpacing.lg,
-              vertical: AppSpacing.xl,
+        ...schedule.when(
+          loading: () => const <Widget>[
+            Padding(
+              padding: EdgeInsets.symmetric(vertical: AppSpacing.xxl),
+              child: Center(child: CircularProgressIndicator()),
             ),
-            alignment: Alignment.center,
-            decoration: BoxDecoration(
-              borderRadius: const BorderRadius.all(AppRadius.card),
-              border: Border.all(color: AppColors.borderStrong),
-            ),
-            child: const Text(
-              '이 날짜에는 일정이 없어요.\n아래에서 새 일정을 추가해 보세요.',
-              textAlign: TextAlign.center,
-              style: TextStyle(
-                fontSize: 12,
-                fontWeight: FontWeight.w500,
-                color: AppColors.mutedForeground,
-                height: 1.5,
+          ],
+          error: (e, _) => const <Widget>[
+            Padding(
+              padding: EdgeInsets.symmetric(vertical: AppSpacing.xxl),
+              child: Center(
+                child: Text(
+                  '스케줄을 불러오지 못했어요',
+                  style: TextStyle(color: AppColors.mutedForeground),
+                ),
               ),
             ),
-          ),
-        for (final s in sessions) ...<Widget>[
-          _TimelineRow(
-            session: s,
-            expanded: _expanded.contains(s.id),
-            sent: _sent.contains(s.id),
-            flashing: _flash == s.id,
-            onToggle: () => _toggle(s),
-            onSend: () => _send(s),
-            onEdit: () => _openSessionSheet(existing: s),
-            onDelete: () => _confirmDelete(s),
-            onChat: () => _openChat(s),
-            onComplete: s.isUpcoming ? () => _confirmComplete(s) : null,
-          ),
-          const SizedBox(height: AppSpacing.sm),
-        ],
+          ],
+          data: _timelineChildren,
+        ),
       ],
     );
+  }
+
+  /// The empty-state box or the session rows for [sessions].
+  List<Widget> _timelineChildren(List<ScheduleSession> sessions) {
+    // 완료 is offered only for 예정 sessions that aren't dated in the
+    // future — you can't complete a class that hasn't happened yet. The
+    // repository enforces the same rule (review PR 245).
+    final isFuture = _selectedDay.isAfter(_dateOnly(DateTime.now()));
+    return <Widget>[
+      if (sessions.isEmpty)
+        Container(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.lg,
+            vertical: AppSpacing.xl,
+          ),
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            borderRadius: const BorderRadius.all(AppRadius.card),
+            border: Border.all(color: AppColors.borderStrong),
+          ),
+          child: const Text(
+            '이 날짜에는 일정이 없어요.\n아래에서 새 일정을 추가해 보세요.',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w500,
+              color: AppColors.mutedForeground,
+              height: 1.5,
+            ),
+          ),
+        ),
+      for (final s in sessions) ...<Widget>[
+        _TimelineRow(
+          session: s,
+          expanded: _expanded.contains(s.id),
+          sent: _sent.contains(s.id),
+          flashing: _flash == s.id,
+          onToggle: () => _toggle(s),
+          onSend: () => _send(s),
+          onEdit: () => _openSessionSheet(existing: s),
+          onDelete: () => _confirmDelete(s),
+          onChat: () => _openChat(s),
+          onComplete: (s.isUpcoming && !isFuture)
+              ? () => _confirmComplete(s)
+              : null,
+        ),
+        const SizedBox(height: AppSpacing.sm),
+      ],
+    ];
   }
 }
 

--- a/frontend/flutter_trainer/test/features/ai_routine/ai_routine_page_test.dart
+++ b/frontend/flutter_trainer/test/features/ai_routine/ai_routine_page_test.dart
@@ -4,7 +4,9 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/storage/seed_data.dart';
+import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/features/ai_routine/data/repositories/ai_routine_repository.dart';
+import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
 
 import '../../helpers/pump_app.dart';
 
@@ -35,7 +37,8 @@ void main() {
       () async {
         final repo = AiRoutineRepository(db);
         // 박성호 has a seeded 15:00 예정 session.
-        final attached = await repo.registerToTodaySchedule(
+        final attached = await repo.registerToSchedule(
+          date: ymd(DateTime.now()),
           clientName: '박성호',
           program: <Map<String, Object?>>[
             <String, Object?>{
@@ -60,7 +63,8 @@ void main() {
       () async {
         final repo = AiRoutineRepository(db);
         // 김민수's only session today is 완료 — a new slot gets booked.
-        final attached = await repo.registerToTodaySchedule(
+        final attached = await repo.registerToSchedule(
+          date: ymd(DateTime.now()),
           clientName: '김민수',
           program: <Map<String, Object?>>[
             <String, Object?>{
@@ -263,6 +267,47 @@ void main() {
       await tester.tap(find.text('김민수'));
       await settle(tester);
       expect(find.textContaining('📋 AI 루틴 숙제를 보냈어요'), findsOneWidget);
+    });
+
+    testWidgets('내일 chip registers the routine on the next day', (
+      tester,
+    ) async {
+      final container = await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+      );
+      await tester.tap(find.text('AI루틴'));
+      await settle(tester);
+
+      await tester.scrollUntilVisible(
+        find.text('내일'),
+        150,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.ensureVisible(find.text('내일'));
+      await tester.pump();
+      await tester.tap(find.text('내일'));
+      await tester.pump();
+
+      await tester.tap(find.textContaining('내일 PT 스케줄에 등록'));
+      await settle(tester);
+      expect(find.text('✓ 내일 스케줄에 등록됨'), findsOneWidget);
+
+      // Booked under tomorrow's date, not today's. Reading a drift stream
+      // must run outside the fake-async zone (`runAsync`), otherwise the
+      // subscription never flushes and the test hangs.
+      final tomorrow = ymd(DateTime.now().add(const Duration(days: 1)));
+      final rows = await tester.runAsync(
+        () => container
+            .read(scheduleRepositoryProvider)
+            .watchDate(tomorrow)
+            .first,
+      );
+      expect(rows!.single.clientName, '김민수');
+      expect(rows.single.program, isNotEmpty);
+
+      // Drain the 3s confirmation timer so it isn't left pending.
+      await tester.pump(const Duration(seconds: 3));
     });
 
     testWidgets('send shows confirmation then resets edits', (tester) async {

--- a/frontend/flutter_trainer/test/features/ai_routine/ai_routine_page_test.dart
+++ b/frontend/flutter_trainer/test/features/ai_routine/ai_routine_page_test.dart
@@ -19,13 +19,15 @@ class _SlowCountingRoutineRepository extends AiRoutineRepository {
   int registerCalls = 0;
 
   @override
-  Future<bool> registerToTodaySchedule({
+  Future<bool> registerToSchedule({
+    required String date,
     required String clientName,
     required List<Map<String, Object?>> program,
   }) async {
     registerCalls++;
     await Future<void>.delayed(const Duration(milliseconds: 300));
-    return super.registerToTodaySchedule(
+    return super.registerToSchedule(
+      date: date,
       clientName: clientName,
       program: program,
     );

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -17,6 +17,7 @@ class _ThrowingScheduleRepository extends ScheduleRepository {
 
   @override
   Future<void> addSession({
+    required String date,
     required String clientName,
     required String time,
     required String type,

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -54,6 +54,7 @@ void main() {
     test('addSession inserts an 예정 slot sorted into the timeline', () async {
       final repo = ScheduleRepository(db);
       await repo.addSession(
+        date: ymd(DateTime.now()),
         clientName: '이지수',
         time: '10:15',
         type: '1:1 PT',
@@ -157,6 +158,49 @@ void main() {
         expect(histAfter, histBefore); // no orphan history row
       },
     );
+
+    test('watchDate separates timelines per calendar day', () async {
+      final repo = ScheduleRepository(db);
+      final tomorrow = ymd(DateTime.now().add(const Duration(days: 1)));
+
+      expect(await repo.watchDate(tomorrow).first, isEmpty);
+
+      await repo.addSession(
+        date: tomorrow,
+        clientName: '이지수',
+        time: '11:00',
+        type: '1:1 PT',
+        durationMinutes: 60,
+      );
+
+      final tomorrowSlots = await repo.watchDate(tomorrow).first;
+      expect(tomorrowSlots.single.clientName, '이지수');
+      // Today's timeline is untouched.
+      expect((await repo.watchToday().first).length, 6);
+      // …and the booked-dates set now covers both days.
+      final booked = await repo.watchBookedDates().first;
+      expect(booked, containsAll(<String>[ymd(DateTime.now()), tomorrow]));
+    });
+
+    test('completing a non-today session labels its own date', () async {
+      final repo = ScheduleRepository(db);
+      final tomorrow = DateTime.now().add(const Duration(days: 1));
+      await repo.addSession(
+        date: ymd(tomorrow),
+        clientName: '이지수',
+        time: '11:00',
+        type: '1:1 PT',
+        durationMinutes: 60,
+      );
+      final slot = (await repo.watchDate(ymd(tomorrow)).first).single;
+
+      await repo.completeSession(slot.id, note: '내일 세션 선기록');
+
+      final history = await db.select(db.clientRoutineHistory).get();
+      final logged = history.firstWhere((h) => h.id.startsWith('hist-'));
+      expect(logged.dateLabel, '${tomorrow.month}/${tomorrow.day}');
+      expect(logged.dateLabel.contains('(오늘)'), isFalse);
+    });
 
     test('deleteSession removes the slot', () async {
       final repo = ScheduleRepository(db);
@@ -388,6 +432,32 @@ void main() {
       await settle(tester);
       expect(find.textContaining('(오늘)'), findsWidgets);
       expect(find.text('벤치 폼 안정적'), findsOneWidget);
+    });
+
+    testWidgets('the week strip browses other days and books on them', (
+      tester,
+    ) async {
+      await openSchedule(tester);
+      expect(find.text('김민수'), findsOneWidget);
+
+      // Next week (same weekday) — nothing seeded there.
+      await tester.tap(find.byIcon(Icons.chevron_right));
+      await settle(tester);
+      expect(find.text('김민수'), findsNothing);
+      expect(find.textContaining('이 날짜에는 일정이 없어요'), findsOneWidget);
+
+      // Book a session on the browsed day.
+      await tester.tap(find.text('＋ 새 일정 추가'));
+      await settle(tester);
+      await tester.tap(find.text('추가하기'));
+      await settle(tester);
+      expect(find.text('10:00'), findsOneWidget);
+      expect(find.textContaining('이 날짜에는 일정이 없어요'), findsNothing);
+
+      // Back to today — the seeded timeline is intact.
+      await tester.tap(find.byIcon(Icons.chevron_left));
+      await settle(tester);
+      expect(find.text('김민수'), findsOneWidget);
     });
 
     testWidgets('💬 채팅 jumps to the client detail chat', (tester) async {

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -434,19 +434,25 @@ void main() {
       expect(find.text('벤치 폼 안정적'), findsOneWidget);
     });
 
-    testWidgets('the week strip browses other days and books on them', (
+    testWidgets('picking another day browses it; 오늘로 returns to today', (
       tester,
     ) async {
       await openSchedule(tester);
       expect(find.text('김민수'), findsOneWidget);
+      // On today, the 오늘로 shortcut is hidden.
+      expect(find.text('오늘로'), findsNothing);
 
-      // Next week (same weekday) — nothing seeded there.
-      await tester.tap(find.byIcon(Icons.chevron_right));
+      // Default window is centred on today (D-3…D+3); tap tomorrow.
+      final tomorrow = DateTime.now().add(const Duration(days: 1));
+      await tester.tap(find.text('${tomorrow.day}').first);
       await settle(tester);
+
+      // Tomorrow has no seeded sessions → empty state, and 오늘로 appears.
       expect(find.text('김민수'), findsNothing);
       expect(find.textContaining('이 날짜에는 일정이 없어요'), findsOneWidget);
+      expect(find.text('오늘로'), findsOneWidget);
 
-      // Book a session on the browsed day.
+      // Book a session on the browsed day; the empty state clears.
       await tester.tap(find.text('＋ 새 일정 추가'));
       await settle(tester);
       await tester.tap(find.text('추가하기'));
@@ -454,10 +460,43 @@ void main() {
       expect(find.text('10:00'), findsOneWidget);
       expect(find.textContaining('이 날짜에는 일정이 없어요'), findsNothing);
 
-      // Back to today — the seeded timeline is intact.
-      await tester.tap(find.byIcon(Icons.chevron_left));
+      // 오늘로 → today's seeded timeline is intact and the button hides.
+      await tester.tap(find.text('오늘로'));
       await settle(tester);
       expect(find.text('김민수'), findsOneWidget);
+      expect(find.text('오늘로'), findsNothing);
+    });
+
+    testWidgets('the week strip fits a narrow column without overflowing', (
+      tester,
+    ) async {
+      // A narrow viewport is where the fixed-width cells used to overflow
+      // by ~4px; flexible cells must fit any width.
+      tester.view.physicalSize = const Size(360, 720);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await openSchedule(tester);
+
+      // The chevrons render and no RenderFlex overflow was thrown.
+      expect(find.byIcon(Icons.chevron_left), findsOneWidget);
+      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('the chevron scrubs the visible week without moving the '
+        'selection', (tester) async {
+      await openSchedule(tester);
+      expect(find.text('김민수'), findsOneWidget); // today selected
+
+      // Shifting the window a week forward keeps today selected, so the
+      // timeline still shows today's sessions.
+      await tester.tap(find.byIcon(Icons.chevron_right));
+      await settle(tester);
+      expect(find.text('김민수'), findsOneWidget);
+      // Today is now off the visible window, so 오늘로 is offered.
+      expect(find.text('오늘로'), findsOneWidget);
     });
 
     testWidgets('💬 채팅 jumps to the client detail chat', (tester) async {

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -240,6 +240,28 @@ void main() {
 
     test('completing a non-today session labels its own date', () async {
       final repo = ScheduleRepository(db);
+      // A PAST session — completing it retro-logs the class. Future
+      // sessions can't be completed (see the next test).
+      final yesterday = DateTime.now().subtract(const Duration(days: 1));
+      await repo.addSession(
+        date: ymd(yesterday),
+        clientName: '이지수',
+        time: '11:00',
+        type: '1:1 PT',
+        durationMinutes: 60,
+      );
+      final slot = (await repo.watchDate(ymd(yesterday)).first).single;
+
+      await repo.completeSession(slot.id, note: '어제 세션 뒤늦게 기록');
+
+      final history = await db.select(db.clientRoutineHistory).get();
+      final logged = history.firstWhere((h) => h.id.startsWith('hist-'));
+      expect(logged.dateLabel, '${yesterday.month}/${yesterday.day}');
+      expect(logged.dateLabel.contains('(오늘)'), isFalse);
+    });
+
+    test('completeSession refuses a future-dated session', () async {
+      final repo = ScheduleRepository(db);
       final tomorrow = DateTime.now().add(const Duration(days: 1));
       await repo.addSession(
         date: ymd(tomorrow),
@@ -250,12 +272,14 @@ void main() {
       );
       final slot = (await repo.watchDate(ymd(tomorrow)).first).single;
 
-      await repo.completeSession(slot.id, note: '내일 세션 선기록');
+      // You can't complete a class that hasn't happened yet — the call is
+      // a no-op, the session stays 예정 and nothing is logged (review 245).
+      await repo.completeSession(slot.id, note: '미리 완료 시도');
 
+      final after = (await repo.watchDate(ymd(tomorrow)).first).single;
+      expect(after.status, '예정');
       final history = await db.select(db.clientRoutineHistory).get();
-      final logged = history.firstWhere((h) => h.id.startsWith('hist-'));
-      expect(logged.dateLabel, '${tomorrow.month}/${tomorrow.day}');
-      expect(logged.dateLabel.contains('(오늘)'), isFalse);
+      expect(history.where((h) => h.id.startsWith('hist-')), isEmpty);
     });
 
     test('deleteSession removes the slot', () async {
@@ -488,6 +512,29 @@ void main() {
       await settle(tester);
       expect(find.textContaining('(오늘)'), findsWidgets);
       expect(find.text('벤치 폼 안정적'), findsOneWidget);
+    });
+
+    testWidgets('a future session offers no ✓ 완료 action', (tester) async {
+      await openSchedule(tester);
+
+      // Browse to tomorrow and book a session there.
+      final tomorrow = DateTime.now().add(const Duration(days: 1));
+      await tester.tap(find.text('${tomorrow.day}').first);
+      await settle(tester);
+      await tester.tap(find.text('＋ 새 일정 추가'));
+      await settle(tester);
+      await tester.tap(find.text('추가하기'));
+      await settle(tester);
+
+      // Expand the freshly booked 예정 card.
+      await tester.tap(find.text('김민수'));
+      await tester.pump();
+
+      // Manage actions are there, but 완료 is not — the class is in the
+      // future (review PR 245).
+      expect(find.text('✎ 수정'), findsOneWidget);
+      expect(find.text('💬 채팅'), findsOneWidget);
+      expect(find.text('✓ 완료'), findsNothing);
     });
 
     testWidgets('picking another day browses it; 오늘로 returns to today', (


### PR DESCRIPTION
## Summary
* 스케줄 탭에 오늘 중심(D-3…D+3) 7일 주간 스트립을 추가했습니다(사용자 앱 식단 탭 스트립 참고). chevron으로 주 단위 창 이동, 예약 있는 날 dot 표시, 다른 날 볼 때 '오늘로' 버튼, 일정 없는 날 안내 카드. 셀은 유연폭이라 좁은 폭에서도 넘치지 않습니다.
* 타임라인·예약 시트·헤더가 선택한 날짜를 따릅니다. chevron은 창만 이동하고 선택일은 유지 — 날짜 변경은 셀 탭.
* AI 루틴 등록에 오늘…+6일 칩을 추가해 다가올 날짜로 예약할 수 있습니다.
* 리포지토리: `watchToday → watchDate(date)`, `addSession`/`registerToSchedule`에 날짜 파라미터, `watchBookedDates`·`scheduleForDate`/`bookedDates` provider 추가. 완료 기록의 dateLabel은 세션 자신의 날짜로(오늘일 때만 '오늘' 태그).

## Changes
### ✨ Features
* 스케줄 오늘 중심 주간 스트립(예약 dot·오늘로·빈 날짜 안내), 선택 날짜 연동
* AI 루틴 오늘…+6일 등록일 칩
* 리포지토리 날짜 파라미터화 + 신규 provider
### 🐛 Fixes
* 주간 스트립 오버플로우(고정폭 셀 → 유연폭)와 일요일 시작 회귀 → 오늘 중심으로 복원(리뷰 반영)

## Commits
1. `352f4fa` feat: date navigation for the schedule and AI routine tabs
2. `1fe63de` fix(schedule): center the week strip on today and stop it overflowing

## Notes
* 스케줄은 오늘 단위 mock — 미래 날짜에 등록/예약한 'sched-' 행은 자기 날짜로 영속(재시딩 시 seed 행만 오늘로 슬라이드).
* 테스트: repo 날짜 분리·완료 라벨, 위젯(날짜 선택+오늘로, chevron 스크럽, 360px 오버플로우 가드, AI 내일 등록). `testWidgets`에서 drift 스트림 `.first`는 `tester.runAsync`로 감쌈(fake-async 데드락 회피).

## Test Plan
* [ ] 기능 정상 동작 확인
* [ ] 예외 케이스 확인
* [ ] UI 확인
* [ ] 빌드 성공
* [ ] 관련 테스트 통과
### Manual Test Steps
1. 스케줄 탭 → 주간 스트립에서 오늘이 가운데인지, 좁은 창에서 안 넘치는지 확인
2. 내일 셀 탭 → 빈 안내 + 오늘로 버튼 → ＋새 일정 추가로 예약 → 오늘로 복귀 시 오늘 타임라인 유지
3. AI 루틴 → 내일 칩 → 등록 → 스케줄 내일 날짜에서 프로그램 확인

## Related Issues
Closes #244 

## Checklist
* [ ] 코드 리뷰 준비 완료
* [ ] 불필요한 코드 제거
* [ ] 하드코딩 값 점검
* [ ] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인