### PR TITLE
feat(trainer-api): add trainer role, domain models, migration and seed

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -99,8 +99,21 @@ def require_admin(
     return user
 
 
+def require_trainer(
+    user: Annotated[User, Depends(require_auth)],
+) -> User:
+    """트레이너 전용: 유효 토큰 + role == 'trainer'. 데모 폴백 없음(회원 데모 사용자가
+    트레이너 엔드포인트에 새어 들어가지 않도록). 미인증은 require_auth 가 401,
+    회원 계정이면 403."""
+    if user.role != "trainer":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="트레이너 권한이 필요합니다.")
+    return user
+
+
 CurrentUser = Annotated[User, Depends(get_current_user)]
 # 엄격 인증(쓰기/삭제 등 보호 엔드포인트용) — 데모 폴백 없음
 RequireUser = Annotated[User, Depends(require_auth)]
 # 관리자 전용(공공문서 업로드 등)
 RequireAdmin = Annotated[User, Depends(require_admin)]
+# 트레이너 전용(트레이너 앱 엔드포인트)
+RequireTrainer = Annotated[User, Depends(require_trainer)]

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -50,6 +50,12 @@ def get_current_user(
             user_id = decode_access_token(token)
             user = db.scalar(select(User).where(User.id == user_id))
             if user is not None:
+                # 회원 전용 API. 트레이너 계정은 /trainer/* 를 쓴다(역할 분리).
+                if user.role == "trainer":
+                    raise HTTPException(
+                        status_code=status.HTTP_403_FORBIDDEN,
+                        detail="회원 전용 API 입니다.",
+                    )
                 return user
         except jwt.InvalidTokenError:
             pass
@@ -110,9 +116,22 @@ def require_trainer(
     return user
 
 
+def require_member(
+    user: Annotated[User, Depends(require_auth)],
+) -> User:
+    """회원 전용(쓰기/삭제 등): 유효 토큰 + role == 'member'. 트레이너 계정이면 403.
+    데모 폴백 없음(require_auth 기반). 읽기 폴백이 필요한 엔드포인트는 CurrentUser
+    (get_current_user)가 이미 트레이너를 403 처리한다."""
+    if user.role != "member":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="회원 전용 API 입니다.")
+    return user
+
+
 CurrentUser = Annotated[User, Depends(get_current_user)]
 # 엄격 인증(쓰기/삭제 등 보호 엔드포인트용) — 데모 폴백 없음
 RequireUser = Annotated[User, Depends(require_auth)]
+# 회원 전용(트레이너 계정 접근 차단) — 데모 폴백 없음
+RequireMember = Annotated[User, Depends(require_member)]
 # 관리자 전용(공공문서 업로드 등)
 RequireAdmin = Annotated[User, Depends(require_admin)]
 # 트레이너 전용(트레이너 앱 엔드포인트)

--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -1,0 +1,58 @@
+"""
+트레이너 라우터 — 트레이너 앱 전용(role == 'trainer').
+
+  GET /trainer/me   -> 로그인한 트레이너의 프로필(Figma MY / seedTrainerProfile)
+
+이후 이슈에서 /trainer/clients, /trainer/clients/{id}/diet(회원 실데이터 공유),
+채팅·루틴·스케줄이 이 라우터에 추가된다. 모든 엔드포인트는 RequireTrainer 로
+보호되며 데모 폴백이 없다(회원 데모 사용자 유입 차단).
+"""
+from __future__ import annotations
+
+import json
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.api.deps import RequireTrainer
+from app.db.session import get_db
+from app.models.models import TrainerProfile
+from app.schemas.trainer_api import TrainerGymOut, TrainerMe
+
+router = APIRouter(tags=["trainer"])
+
+
+@router.get("/trainer/me", response_model=TrainerMe)
+def trainer_me(
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> TrainerMe:
+    profile = db.scalar(
+        select(TrainerProfile).where(TrainerProfile.trainer_id == trainer.id)
+    )
+    if profile is None:
+        raise HTTPException(status_code=404, detail="트레이너 프로필이 없습니다.")
+
+    try:
+        certs = json.loads(profile.certifications_json) if profile.certifications_json else []
+    except json.JSONDecodeError:
+        certs = []
+
+    return TrainerMe(
+        id=trainer.id,
+        name=trainer.name,
+        email=trainer.email,
+        phone=profile.phone,
+        specialty=profile.specialty,
+        career=f"{profile.career_years}년",
+        intro=profile.intro,
+        certifications=certs,
+        gym=TrainerGymOut(
+            name=profile.gym_name,
+            address=profile.gym_address,
+            hours=profile.gym_hours,
+            phone=profile.gym_phone,
+        ),
+    )

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -20,7 +20,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.api.deps import CurrentUser, RequireUser
+from app.api.deps import CurrentUser, RequireMember
 from app.core.rate_limit import rate_limit
 from app.services.audit import client_ip, record as audit
 from app.core.security import (
@@ -120,7 +120,7 @@ def get_my_profile(current_user: CurrentUser) -> ProfileView:
 @router.post("/users/me/onboarding", response_model=ProfileView)
 def submit_onboarding(
     payload: OnboardingRequest,
-    user: RequireUser,
+    user: RequireMember,
     db: Annotated[Session, Depends(get_db)],
 ) -> ProfileView:
     """최초 온보딩 저장. 제공된 필드만 반영하고 onboarded=True 로 표시."""
@@ -143,7 +143,7 @@ def submit_onboarding(
 @router.put("/users/me", response_model=ProfileView)
 def update_me(
     payload: ProfileUpdate,
-    user: RequireUser,
+    user: RequireMember,
     db: Annotated[Session, Depends(get_db)],
 ) -> ProfileView:
     """내 프로필 모달 저장: 이름/이메일(중복검사)/전화/생년월일."""
@@ -172,7 +172,7 @@ def update_me(
 @router.put("/users/me/health-goals", response_model=ProfileView)
 def update_health_goals(
     payload: HealthGoalsUpdate,
-    user: RequireUser,
+    user: RequireMember,
     db: Annotated[Session, Depends(get_db)],
 ) -> ProfileView:
     """건강 목표 모달 저장: 목표 체중/혈압/혈당/일일 칼로리·나트륨·당류."""
@@ -186,7 +186,7 @@ def update_health_goals(
 
 @router.delete("/users/me")
 def delete_me(
-    user: RequireUser,
+    user: RequireMember,
     db: Annotated[Session, Depends(get_db)],
 ) -> dict:
     """회원 탈퇴. FK(ondelete=CASCADE)로 프로필·식단·운동·바이탈·일정·알림·

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -11,6 +11,8 @@ DEFAULT_JWT_SECRET = "CHANGE_ME_dev_only_secret_key_please_replace_in_prod"
 # 데모 계정(트레이너/회원 시드) 기본 로그인 비밀번호. 운영에서 데모 시드를 켜려면
 # 반드시 이 기본값이 아닌 안전한 값으로 바꿔야 한다(아래 _guard_prod_secrets 가 강제).
 DEFAULT_DEMO_PASSWORD = "oncare123"
+# 운영에서 데모 시드를 켤 때 요구하는 DEMO_LOGIN_PASSWORD 최소 길이.
+MIN_DEMO_PASSWORD_LEN = 12
 
 
 class Settings(BaseSettings):
@@ -121,13 +123,17 @@ class Settings(BaseSettings):
                 raise ValueError(
                     "운영(env=prod)에서는 CORS 허용 출처를 명시해야 합니다(와일드카드 '*' 금지)."
                 )
-            # 운영에서 데모 시드를 켜면 트레이너/회원 데모 계정이 생성된다. 약한 기본
-            # 비밀번호가 그대로 운영 자격증명이 되는 것을 막는다(강한 값 강제, 아니면 시드 끄기).
-            if self.seed_demo_data and self.demo_login_password == DEFAULT_DEMO_PASSWORD:
-                raise ValueError(
-                    "운영(env=prod)에서 데모 시드(SEED_DEMO_DATA=true)를 켜려면 "
-                    "DEMO_LOGIN_PASSWORD 를 안전한 값으로 설정해야 합니다(또는 SEED_DEMO_DATA=false)."
-                )
+            # 운영에서 데모 시드를 켜면 트레이너/회원 데모 계정이 생성된다. 약한 비밀번호가
+            # 그대로 운영 자격증명이 되는 것을 막는다: 기본값 금지 + 최소 길이 강제.
+            # (빈 문자열·짧은 문자열·기본값 모두 거부. 원치 않으면 SEED_DEMO_DATA=false)
+            if self.seed_demo_data:
+                pw = self.demo_login_password or ""
+                if pw == DEFAULT_DEMO_PASSWORD or len(pw) < MIN_DEMO_PASSWORD_LEN:
+                    raise ValueError(
+                        "운영(env=prod)에서 데모 시드(SEED_DEMO_DATA=true)를 켜려면 "
+                        f"DEMO_LOGIN_PASSWORD 를 기본값이 아닌 {MIN_DEMO_PASSWORD_LEN}자 이상의 "
+                        "안전한 값으로 설정해야 합니다(또는 SEED_DEMO_DATA=false)."
+                    )
         return self
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -8,6 +8,9 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # 개발 기본 시크릿(운영에서 그대로 쓰면 기동 차단)
 DEFAULT_JWT_SECRET = "CHANGE_ME_dev_only_secret_key_please_replace_in_prod"
+# 데모 계정(트레이너/회원 시드) 기본 로그인 비밀번호. 운영에서 데모 시드를 켜려면
+# 반드시 이 기본값이 아닌 안전한 값으로 바꿔야 한다(아래 _guard_prod_secrets 가 강제).
+DEFAULT_DEMO_PASSWORD = "oncare123"
 
 
 class Settings(BaseSettings):
@@ -71,6 +74,9 @@ class Settings(BaseSettings):
     # --- 기타 ---
     cors_allow_origins: str = "http://localhost:3000,http://localhost:5173,http://127.0.0.1:3000"
     seed_demo_data: bool = True
+    # 데모 계정(트레이너/회원 시드) 로그인 비밀번호. 운영에서 데모 계정에 데이터를 담아
+    # 두고 싶으면 이 값을 안전하게 설정한다(기본값이면 운영 기동 차단).
+    demo_login_password: str = DEFAULT_DEMO_PASSWORD
     # 관리자 이메일(콤마구분) — 기동 시 해당 사용자를 is_admin=True 로 승격
     admin_emails: str = ""
 
@@ -114,6 +120,13 @@ class Settings(BaseSettings):
             if self.is_cors_wildcard:
                 raise ValueError(
                     "운영(env=prod)에서는 CORS 허용 출처를 명시해야 합니다(와일드카드 '*' 금지)."
+                )
+            # 운영에서 데모 시드를 켜면 트레이너/회원 데모 계정이 생성된다. 약한 기본
+            # 비밀번호가 그대로 운영 자격증명이 되는 것을 막는다(강한 값 강제, 아니면 시드 끄기).
+            if self.seed_demo_data and self.demo_login_password == DEFAULT_DEMO_PASSWORD:
+                raise ValueError(
+                    "운영(env=prod)에서 데모 시드(SEED_DEMO_DATA=true)를 켜려면 "
+                    "DEMO_LOGIN_PASSWORD 를 안전한 값으로 설정해야 합니다(또는 SEED_DEMO_DATA=false)."
                 )
         return self
 

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -42,6 +42,10 @@ def init_db() -> None:
         _seed_demo_user()
         _seed_demo_places()
         _seed_demo_notifications()
+        # 트레이너 데모(계정·프로필·담당 회원·링크). 데모 사용자 시드 뒤에 호출해야
+        # 김민수(user-demo) 링크가 성립한다.
+        from app.db.seed_trainer import seed_trainer_domain
+        seed_trainer_domain()
 
     _promote_admins()  # ADMIN_EMAILS 사용자를 관리자로 승격(멱등)
 

--- a/backend/app/db/seed_trainer.py
+++ b/backend/app/db/seed_trainer.py
@@ -1,0 +1,123 @@
+"""
+트레이너 도메인 데모 시드.
+
+트레이너 앱의 데모/데이터 공유 데모를 위해 트레이너 계정 1명(김트레이너)과
+담당 회원 3명(김민수·이지수·박성호), 그리고 담당 링크를 시드한다.
+
+핵심(진짜 데이터 공유): 여기서 만드는 회원은 실제 회원 User 다. 이후 이슈에서
+이 회원들이 회원 앱으로 남긴 식단/운동/바이탈을 트레이너가 그대로 읽는다.
+따라서 고객 식단 등을 여기서 복제하지 않는다.
+
+멱등: 모든 삽입은 존재 검사 후 스킵. seed_demo_data 가 켜졌을 때만 호출된다.
+데모 로그인 비밀번호는 아래 DEMO_PASSWORD(운영 시드에는 사용하지 않음).
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.security import hash_password
+from app.db.session import SessionLocal
+from app.models import models
+
+# 트레이너 데모 계정
+TRAINER_ID = "trainer-demo"
+TRAINER_EMAIL = "trainer@oncare.com"
+TRAINER_NAME = "김트레이너"
+
+# 데모 계정 공통 비밀번호(트레이너 앱 실서버 로그인 데모용). 운영 시드엔 미사용.
+DEMO_PASSWORD = "oncare123"
+
+# 담당 회원: (user_id, email, name, goal, active, sort_order)
+# 김민수는 회원 앱 데모 사용자(user-demo)와 동일 계정을 공유한다.
+_MEMBERS: list[tuple[str, str, str, str, bool, int]] = [
+    ("user-demo", "minsu@oncare.com", "김민수", "혈압 관리 · 체중 감량", True, 1),
+    ("user-jisu", "jisu@oncare.com", "이지수", "체력 강화 · 다이어트", True, 2),
+    ("user-sungho", "sungho@oncare.com", "박성호", "근력 향상", False, 3),
+]
+
+_CERTIFICATIONS = ["생활스포츠지도사 2급", "퍼스널트레이닝 CPT", "스포츠 영양사"]
+
+
+def seed_trainer_domain() -> None:
+    db: Session = SessionLocal()
+    try:
+        _seed_trainer_account(db)
+        _seed_member_accounts(db)
+        _seed_client_links(db)
+    finally:
+        db.close()
+
+
+def _seed_trainer_account(db: Session) -> None:
+    """트레이너 User + TrainerProfile(멱등)."""
+    trainer = db.scalar(select(models.User).where(models.User.id == TRAINER_ID))
+    if trainer is None:
+        trainer = models.User(
+            id=TRAINER_ID,
+            email=TRAINER_EMAIL,
+            name=TRAINER_NAME,
+            hashed_password=hash_password(DEMO_PASSWORD),
+            role="trainer",
+        )
+        db.add(trainer)
+        db.flush()
+
+    profile = db.scalar(
+        select(models.TrainerProfile).where(models.TrainerProfile.trainer_id == TRAINER_ID)
+    )
+    if profile is None:
+        db.add(models.TrainerProfile(
+            trainer_id=TRAINER_ID,
+            phone="010-1234-5678",
+            specialty="퍼스널 트레이너",
+            career_years=7,
+            intro=(
+                "혈압 관리와 체중 감량 전문 트레이너입니다. 고객 맞춤형 AI 루틴으로 "
+                "안전하고 효과적인 운동을 도와드려요."
+            ),
+            certifications_json=json.dumps(_CERTIFICATIONS, ensure_ascii=False),
+            gym_name="온케어짐 신촌점",
+            gym_address="서울 서대문구 신촌로 120",
+            gym_hours="06:00 – 23:00",
+            gym_phone="02-1234-5678",
+        ))
+    db.commit()
+
+
+def _seed_member_accounts(db: Session) -> None:
+    """담당 회원 User(멱등). user-demo 는 기존 데모 시드가 만들어 두므로 건너뛴다."""
+    for user_id, email, name, _goal, _active, _order in _MEMBERS:
+        existing = db.scalar(select(models.User).where(models.User.id == user_id))
+        if existing is not None:
+            continue
+        db.add(models.User(
+            id=user_id,
+            email=email,
+            name=name,
+            hashed_password=hash_password(DEMO_PASSWORD),
+            role="member",
+        ))
+    db.commit()
+
+
+def _seed_client_links(db: Session) -> None:
+    """트레이너↔회원 담당 링크(멱등)."""
+    for user_id, _email, _name, goal, active, order in _MEMBERS:
+        link_id = f"tc-{TRAINER_ID}-{user_id}"
+        existing = db.scalar(
+            select(models.TrainerClient).where(models.TrainerClient.id == link_id)
+        )
+        if existing is not None:
+            continue
+        db.add(models.TrainerClient(
+            id=link_id,
+            trainer_id=TRAINER_ID,
+            member_id=user_id,
+            goal=goal,
+            active=active,
+            sort_order=order,
+        ))
+    db.commit()

--- a/backend/app/db/seed_trainer.py
+++ b/backend/app/db/seed_trainer.py
@@ -8,27 +8,31 @@
 이 회원들이 회원 앱으로 남긴 식단/운동/바이탈을 트레이너가 그대로 읽는다.
 따라서 고객 식단 등을 여기서 복제하지 않는다.
 
-멱등: 모든 삽입은 존재 검사 후 스킵. seed_demo_data 가 켜졌을 때만 호출된다.
-데모 로그인 비밀번호는 아래 DEMO_PASSWORD(운영 시드에는 사용하지 않음).
+멱등: 모든 삽입은 id·이메일 존재 검사 후 스킵한다. 같은 이메일을 가진 다른 id 의
+사용자가 이미 있으면(users.email 유니크) 삽입을 건너뛰어 기동 실패를 막는다.
+seed_demo_data 가 켜졌을 때만 호출된다. 데모 로그인 비밀번호는 설정값
+(DEMO_LOGIN_PASSWORD)에서 읽는다 — 운영에서 데모 시드를 켜면 강한 값이 강제된다.
 """
 from __future__ import annotations
 
 import json
+import logging
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.core.config import get_settings
 from app.core.security import hash_password
 from app.db.session import SessionLocal
 from app.models import models
+
+logger = logging.getLogger(__name__)
 
 # 트레이너 데모 계정
 TRAINER_ID = "trainer-demo"
 TRAINER_EMAIL = "trainer@oncare.com"
 TRAINER_NAME = "김트레이너"
-
-# 데모 계정 공통 비밀번호(트레이너 앱 실서버 로그인 데모용). 운영 시드엔 미사용.
-DEMO_PASSWORD = "oncare123"
 
 # 담당 회원: (user_id, email, name, goal, active, sort_order)
 # 김민수는 회원 앱 데모 사용자(user-demo)와 동일 계정을 공유한다.
@@ -39,6 +43,18 @@ _MEMBERS: list[tuple[str, str, str, str, bool, int]] = [
 ]
 
 _CERTIFICATIONS = ["생활스포츠지도사 2급", "퍼스널트레이닝 CPT", "스포츠 영양사"]
+
+
+def _demo_password_hash() -> str:
+    return hash_password(get_settings().demo_login_password)
+
+
+def _email_taken_by_other(db: Session, email: str, user_id: str) -> bool:
+    """이 이메일을 가진 '다른 id' 의 사용자가 이미 있으면 True(유니크 충돌 예방)."""
+    other = db.scalar(
+        select(models.User.id).where(models.User.email == email, models.User.id != user_id)
+    )
+    return other is not None
 
 
 def seed_trainer_domain() -> None:
@@ -52,14 +68,20 @@ def seed_trainer_domain() -> None:
 
 
 def _seed_trainer_account(db: Session) -> None:
-    """트레이너 User + TrainerProfile(멱등)."""
+    """트레이너 User + TrainerProfile(멱등, 이메일 충돌 안전)."""
     trainer = db.scalar(select(models.User).where(models.User.id == TRAINER_ID))
     if trainer is None:
+        if _email_taken_by_other(db, TRAINER_EMAIL, TRAINER_ID):
+            logger.warning(
+                "트레이너 데모 이메일 %s 가 다른 계정에 선점됨 — 트레이너 시드 스킵.",
+                TRAINER_EMAIL,
+            )
+            return
         trainer = models.User(
             id=TRAINER_ID,
             email=TRAINER_EMAIL,
             name=TRAINER_NAME,
-            hashed_password=hash_password(DEMO_PASSWORD),
+            hashed_password=_demo_password_hash(),
             role="trainer",
         )
         db.add(trainer)
@@ -84,33 +106,48 @@ def _seed_trainer_account(db: Session) -> None:
             gym_hours="06:00 – 23:00",
             gym_phone="02-1234-5678",
         ))
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # 동시 기동/이메일 경합 등 — 부분 커밋 없이 안전하게 롤백(기동은 계속).
+        db.rollback()
+        logger.warning("트레이너 데모 계정 시드 충돌 — 롤백 후 스킵.", exc_info=True)
 
 
 def _seed_member_accounts(db: Session) -> None:
-    """담당 회원 User(멱등). user-demo 는 기존 데모 시드가 만들어 두므로 건너뛴다."""
+    """담당 회원 User(멱등, 이메일 충돌 안전). user-demo 는 기존 데모 시드가 만든다."""
     for user_id, email, name, _goal, _active, _order in _MEMBERS:
-        existing = db.scalar(select(models.User).where(models.User.id == user_id))
-        if existing is not None:
+        if db.scalar(select(models.User.id).where(models.User.id == user_id)) is not None:
+            continue
+        if _email_taken_by_other(db, email, user_id):
+            logger.warning(
+                "회원 데모 이메일 %s 가 다른 계정에 선점됨 — %s 시드 스킵.", email, user_id,
+            )
             continue
         db.add(models.User(
             id=user_id,
             email=email,
             name=name,
-            hashed_password=hash_password(DEMO_PASSWORD),
+            hashed_password=_demo_password_hash(),
             role="member",
         ))
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        logger.warning("회원 데모 계정 시드 충돌 — 롤백 후 스킵.", exc_info=True)
 
 
 def _seed_client_links(db: Session) -> None:
-    """트레이너↔회원 담당 링크(멱등)."""
+    """트레이너↔회원 담당 링크(멱등). 회원 계정이 없으면(시드 스킵됨) 링크도 건너뛴다."""
     for user_id, _email, _name, goal, active, order in _MEMBERS:
         link_id = f"tc-{TRAINER_ID}-{user_id}"
-        existing = db.scalar(
-            select(models.TrainerClient).where(models.TrainerClient.id == link_id)
-        )
-        if existing is not None:
+        if db.scalar(select(models.TrainerClient.id).where(models.TrainerClient.id == link_id)):
+            continue
+        # 트레이너/회원 계정이 모두 있어야 FK 가 성립한다.
+        if db.scalar(select(models.User.id).where(models.User.id == TRAINER_ID)) is None:
+            continue
+        if db.scalar(select(models.User.id).where(models.User.id == user_id)) is None:
             continue
         db.add(models.TrainerClient(
             id=link_id,
@@ -120,4 +157,8 @@ def _seed_client_links(db: Session) -> None:
             active=active,
             sort_order=order,
         ))
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        logger.warning("담당 링크 시드 충돌 — 롤백 후 스킵.", exc_info=True)

--- a/backend/app/db/seed_trainer.py
+++ b/backend/app/db/seed_trainer.py
@@ -68,9 +68,18 @@ def seed_trainer_domain() -> None:
 
 
 def _seed_trainer_account(db: Session) -> None:
-    """트레이너 User + TrainerProfile(멱등, 이메일 충돌 안전)."""
+    """트레이너 User + TrainerProfile(멱등, 이메일·역할 충돌 안전)."""
     trainer = db.scalar(select(models.User).where(models.User.id == TRAINER_ID))
-    if trainer is None:
+    if trainer is not None:
+        # 기존 ID 가 트레이너 데모와 역할/이메일이 다르면(예: 회원 계정이 선점) 프로필을
+        # 붙이지 않는다 — 남의 계정을 트레이너로 오염시키지 않도록.
+        if trainer.role != "trainer" or trainer.email != TRAINER_EMAIL:
+            logger.warning(
+                "기존 %s 계정이 트레이너 데모와 역할/이메일 불일치(role=%s) — 프로필 시드 스킵.",
+                TRAINER_ID, trainer.role,
+            )
+            return
+    else:
         if _email_taken_by_other(db, TRAINER_EMAIL, TRAINER_ID):
             logger.warning(
                 "트레이너 데모 이메일 %s 가 다른 계정에 선점됨 — 트레이너 시드 스킵.",
@@ -139,15 +148,24 @@ def _seed_member_accounts(db: Session) -> None:
 
 
 def _seed_client_links(db: Session) -> None:
-    """트레이너↔회원 담당 링크(멱등). 회원 계정이 없으면(시드 스킵됨) 링크도 건너뛴다."""
+    """트레이너↔회원 담당 링크(멱등). 트레이너/회원 역할이 맞아야만 링크한다."""
+    trainer = db.scalar(select(models.User).where(models.User.id == TRAINER_ID))
+    if trainer is None or trainer.role != "trainer":
+        # 트레이너 계정이 없거나(시드 스킵) 역할이 트레이너가 아니면 링크를 만들지 않는다.
+        return
     for user_id, _email, _name, goal, active, order in _MEMBERS:
         link_id = f"tc-{TRAINER_ID}-{user_id}"
         if db.scalar(select(models.TrainerClient.id).where(models.TrainerClient.id == link_id)):
             continue
-        # 트레이너/회원 계정이 모두 있어야 FK 가 성립한다.
-        if db.scalar(select(models.User.id).where(models.User.id == TRAINER_ID)) is None:
+        member = db.scalar(select(models.User).where(models.User.id == user_id))
+        if member is None:
             continue
-        if db.scalar(select(models.User.id).where(models.User.id == user_id)) is None:
+        # 기존 ID 가 회원이 아니면(예: 트레이너 역할) 담당 링크를 만들지 않는다.
+        if member.role != "member":
+            logger.warning(
+                "기존 %s 계정이 회원이 아님(role=%s) — 담당 링크 시드 스킵.",
+                user_id, member.role,
+            )
             continue
         db.add(models.TrainerClient(
             id=link_id,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.v1 import (
-    ai_coach, coach_docs, dashboard, diet, exercise, notifications, places, schedule, social, system, users, vitals,
+    ai_coach, coach_docs, dashboard, diet, exercise, notifications, places, schedule, social, system, trainer, users, vitals,
 )
 from app.core.config import get_settings
 from app.db.init_db import init_db
@@ -79,3 +79,4 @@ app.include_router(notifications.router, prefix=settings.api_v1_prefix)
 app.include_router(places.router, prefix=settings.api_v1_prefix)
 app.include_router(ai_coach.router, prefix=settings.api_v1_prefix)
 app.include_router(coach_docs.router, prefix=settings.api_v1_prefix)
+app.include_router(trainer.router, prefix=settings.api_v1_prefix)

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -37,6 +37,11 @@ class User(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     # 관리자 권한(공공문서 업로드 등 민감 엔드포인트 접근). 기본 False.
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False)
+    # 계정 역할: 'member'(회원 앱) | 'trainer'(트레이너 앱). 두 앱은 완전히 분리된
+    # 계정이지만 users 테이블은 공유하고 role 로 구분한다(트레이너↔회원 데이터 공유의 축).
+    role: Mapped[str] = mapped_column(
+        String(20), default="member", server_default="member", index=True
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     health_profile: Mapped["HealthProfile | None"] = relationship(
@@ -244,6 +249,170 @@ class Place(Base):
     lat: Mapped[float | None] = mapped_column(Float, nullable=True)
     lng: Mapped[float | None] = mapped_column(Float, nullable=True)
     kakao_place_id: Mapped[str] = mapped_column(String(50), default="")
+
+
+#
+# ---------------------------------------------------------------------------
+# 트레이너 도메인 — 트레이너↔회원 데이터 공유의 뼈대.
+#
+# 핵심 설계(진짜 공유): "고객"은 별도 복제 테이블이 아니라 실제 회원 User 다.
+# TrainerClient 링크로 트레이너와 회원을 잇고, 트레이너가 보는 고객 식단/운동/
+# 바이탈은 회원이 회원 앱에서 직접 남긴 그 레코드(DietEntry/ExerciseSession/Vital)
+# 를 읽는다. 아래 테이블은 "공유되는 상호작용"(루틴 배정·완료기록·채팅·스케줄)만
+# 담는다. 응답 형태는 트레이너 프론트 drift 계약(TrainerClients/ClientAiRoutines/
+# ClientRoutineHistory/ClientChatMessages/TrainerScheduleEntries)에 정렬한다.
+# ---------------------------------------------------------------------------
+
+
+class TrainerProfile(Base):
+    """트레이너 전용 프로필 — 프론트 seedTrainerProfile / Figma MY 화면 대응.
+
+    회원의 HealthProfile 과 별개(역할이 다른 계정). 이름/이메일은 User 에 있고,
+    여기엔 전문분야·경력·자격증·소속 헬스장 정보만 둔다.
+    """
+    __tablename__ = "trainer_profiles"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    trainer_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), unique=True, index=True
+    )
+    phone: Mapped[str] = mapped_column(String(20), default="")
+    specialty: Mapped[str] = mapped_column(String(50), default="")     # 퍼스널 트레이너
+    career_years: Mapped[int] = mapped_column(Integer, default=0)       # 7 → "7년"
+    intro: Mapped[str] = mapped_column(Text, default="")
+    certifications_json: Mapped[str] = mapped_column(Text, default="[]")  # ["생활스포츠지도사 2급", ...]
+    gym_name: Mapped[str] = mapped_column(String(100), default="")
+    gym_address: Mapped[str] = mapped_column(String(300), default="")
+    gym_hours: Mapped[str] = mapped_column(String(50), default="")
+    gym_phone: Mapped[str] = mapped_column(String(20), default="")
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+
+class TrainerClient(Base):
+    """트레이너↔회원 담당 링크. 트레이너의 '고객 목록'은 이 링크로 정의된다.
+
+    goal 은 트레이너가 설정한 코칭 목표(예: '혈압 관리 · 체중 감량'). active 는
+    활성/휴면. 한 회원이 한 트레이너에게 중복 배정되지 않도록 (trainer, member) 유일.
+    """
+    __tablename__ = "trainer_clients"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    trainer_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    member_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    goal: Mapped[str] = mapped_column(String(200), default="")
+    active: Mapped[bool] = mapped_column(Boolean, default=True)
+    sort_order: Mapped[int] = mapped_column(Integer, default=0)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("trainer_id", "member_id", name="uq_trainer_client"),
+    )
+
+
+class TrainerRoutine(Base):
+    """트레이너/AI가 회원에게 배정한 루틴 — 프론트 ClientAiRoutines 대응.
+
+    source: 'ai'(AI 추천) | 'trainer'(트레이너 직접 배정). 회원 앱에서 '받은 루틴'
+    으로도 읽힌다(양쪽에서 보이는 공유 데이터).
+    """
+    __tablename__ = "trainer_routines"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    trainer_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    member_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    name: Mapped[str] = mapped_column(String(100))
+    minutes: Mapped[int] = mapped_column(Integer, default=0)
+    type: Mapped[str] = mapped_column(String(20))       # 유산소|근력|스트레칭
+    reason: Mapped[str] = mapped_column(String(200), default="")
+    source: Mapped[str] = mapped_column(String(20), default="ai")  # ai|trainer
+    sort_order: Mapped[int] = mapped_column(Integer, default=0)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class RoutineHistory(Base):
+    """회원의 운동 완료 기록 — 프론트 ClientRoutineHistory 대응.
+
+    회원이 자율 운동을 완료하거나(회원 앱), 트레이너가 PT 세션을 완료 처리하면
+    (스케줄 완료 루프) 생성된다. date_label 은 저장하지 않고 date 로부터 파생한다.
+    """
+    __tablename__ = "routine_history"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    member_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    # 트레이너 지도 세션이면 트레이너, 자율 운동이면 NULL.
+    trainer_id: Mapped[str | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    date: Mapped[str] = mapped_column(String(10), index=True)  # YYYY-MM-DD
+    kind_label: Mapped[str] = mapped_column(String(50), default="")  # 'PT 세션 · 트레이너 지도'
+    completion_rate: Mapped[int] = mapped_column(Integer, default=0)  # 0..100
+    exercises_json: Mapped[str] = mapped_column(Text, default="[]")   # ["레그프레스 3세트", ...]
+    client_feedback: Mapped[str] = mapped_column(Text, default="")
+    trainer_note: Mapped[str] = mapped_column(Text, default="")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class ChatMessage(Base):
+    """트레이너↔회원 채팅 메시지 — 프론트 ClientChatMessages 대응.
+
+    스레드는 (trainer_id, member_id) 로 식별. sender 는 백엔드 진실값 'trainer'|'member'
+    로 저장하고, 트레이너 API 응답에선 프론트 계약에 맞춰 'client' 로 노출한다.
+    read_at 으로 양쪽 미확인 수를 계산.
+    """
+    __tablename__ = "chat_messages"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    trainer_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    member_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    sender: Mapped[str] = mapped_column(String(20))  # trainer|member
+    body: Mapped[str] = mapped_column(Text)
+    read_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), index=True
+    )
+
+
+class TrainerSchedule(Base):
+    """트레이너의 일일 타임라인 슬롯 — 프론트 TrainerScheduleEntries 대응.
+
+    회원과 매칭된 슬롯은 member_id 를 갖고, 상담/신규/공백은 client_name(표시용)만
+    갖는다. status: 예정|완료|공백. program_json: [{name,sets,reps,weight}].
+    """
+    __tablename__ = "trainer_schedule"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    trainer_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    member_id: Mapped[str | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    date: Mapped[str] = mapped_column(String(10), index=True)  # YYYY-MM-DD
+    time: Mapped[str] = mapped_column(String(10), default="")  # "10:00"
+    client_name: Mapped[str] = mapped_column(String(100), default="")  # 표시용(상담/신규 포함)
+    type: Mapped[str] = mapped_column(String(30), default="")  # 1:1 PT|상담|...
+    duration_minutes: Mapped[int] = mapped_column(Integer, default=0)
+    status: Mapped[str] = mapped_column(String(10), default="예정")  # 예정|완료|공백
+    note: Mapped[str] = mapped_column(Text, default="")
+    program_json: Mapped[str] = mapped_column(Text, default="[]")
+    sort_order: Mapped[int] = mapped_column(Integer, default=0)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 
 class AuditLog(Base):

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -1,0 +1,28 @@
+"""
+트레이너 API 스키마 — 트레이너 프론트 계약(seedTrainerProfile / TrainerProfile) 정렬.
+
+GET /trainer/me 응답:
+  { id, name, email, phone, specialty, career, intro, certifications[], gym{...} }
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class TrainerGymOut(BaseModel):
+    name: str
+    address: str
+    hours: str
+    phone: str
+
+
+class TrainerMe(BaseModel):
+    id: str
+    name: str
+    email: str
+    phone: str
+    specialty: str
+    career: str          # "7년" (career_years 파생)
+    intro: str
+    certifications: list[str]
+    gym: TrainerGymOut

--- a/backend/migrations/versions/0012_trainer_domain.py
+++ b/backend/migrations/versions/0012_trainer_domain.py
@@ -1,0 +1,188 @@
+"""trainer domain (role + 트레이너↔회원 공유 테이블)
+
+트레이너 앱 백엔드의 뼈대. users.role(member|trainer)로 두 앱 계정을 구분하고,
+트레이너↔회원 상호작용(프로필·담당링크·루틴배정·완료기록·채팅·스케줄)을 담는
+6개 테이블을 추가한다. 고객의 식단/운동/바이탈은 별도 복제 없이 회원의 실제
+레코드를 읽으므로 여기서 만들지 않는다(진짜 데이터 공유).
+
+기존 행 보존 추가형(additive) 마이그레이션. role 은 server_default='member' 로
+기존 회원 계정을 자동 채운다.
+
+Revision ID: 0012_trainer_domain
+Revises: 0011_health_daily_sugar_g
+Create Date: 2026-07-25
+
+머지 순서상 트레이너 스택이 가장 마지막에 들어오므로, 병렬로 갈라졌던 0010
+(원래 down_revision=0009)을 재선형화해 0010_diet_entry_macros(#207) →
+0011_health_daily_sugar_g(#230/#231) 뒤에 잇는다. 반드시 그 둘이 main에 반영된
+뒤 머지한다(단일 alembic head 유지).
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0012_trainer_domain"
+down_revision: str | Sequence[str] | None = "0011_health_daily_sugar_g"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # --- users.role ---
+    op.add_column(
+        "users",
+        sa.Column("role", sa.String(20), nullable=False, server_default="member"),
+    )
+    op.create_index("ix_users_role", "users", ["role"])
+
+    # --- trainer_profiles ---
+    op.create_table(
+        "trainer_profiles",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "trainer_id", sa.String(64),
+            sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column("phone", sa.String(20), nullable=False, server_default=""),
+        sa.Column("specialty", sa.String(50), nullable=False, server_default=""),
+        sa.Column("career_years", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("intro", sa.Text(), nullable=False, server_default=""),
+        sa.Column("certifications_json", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("gym_name", sa.String(100), nullable=False, server_default=""),
+        sa.Column("gym_address", sa.String(300), nullable=False, server_default=""),
+        sa.Column("gym_hours", sa.String(50), nullable=False, server_default=""),
+        sa.Column("gym_phone", sa.String(20), nullable=False, server_default=""),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.UniqueConstraint("trainer_id", name="uq_trainer_profiles_trainer"),
+    )
+    op.create_index("ix_trainer_profiles_trainer_id", "trainer_profiles", ["trainer_id"])
+
+    # --- trainer_clients (담당 링크) ---
+    op.create_table(
+        "trainer_clients",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column(
+            "trainer_id", sa.String(64),
+            sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column(
+            "member_id", sa.String(64),
+            sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column("goal", sa.String(200), nullable=False, server_default=""),
+        sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.UniqueConstraint("trainer_id", "member_id", name="uq_trainer_client"),
+    )
+    op.create_index("ix_trainer_clients_trainer_id", "trainer_clients", ["trainer_id"])
+    op.create_index("ix_trainer_clients_member_id", "trainer_clients", ["member_id"])
+
+    # --- trainer_routines (배정 루틴) ---
+    op.create_table(
+        "trainer_routines",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column(
+            "trainer_id", sa.String(64),
+            sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column(
+            "member_id", sa.String(64),
+            sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("minutes", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("type", sa.String(20), nullable=False),
+        sa.Column("reason", sa.String(200), nullable=False, server_default=""),
+        sa.Column("source", sa.String(20), nullable=False, server_default="ai"),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("ix_trainer_routines_trainer_id", "trainer_routines", ["trainer_id"])
+    op.create_index("ix_trainer_routines_member_id", "trainer_routines", ["member_id"])
+
+    # --- routine_history (완료 기록) ---
+    op.create_table(
+        "routine_history",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column(
+            "member_id", sa.String(64),
+            sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column(
+            "trainer_id", sa.String(64),
+            sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True,
+        ),
+        sa.Column("date", sa.String(10), nullable=False),
+        sa.Column("kind_label", sa.String(50), nullable=False, server_default=""),
+        sa.Column("completion_rate", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("exercises_json", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("client_feedback", sa.Text(), nullable=False, server_default=""),
+        sa.Column("trainer_note", sa.Text(), nullable=False, server_default=""),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("ix_routine_history_member_id", "routine_history", ["member_id"])
+    op.create_index("ix_routine_history_trainer_id", "routine_history", ["trainer_id"])
+    op.create_index("ix_routine_history_date", "routine_history", ["date"])
+
+    # --- chat_messages ---
+    op.create_table(
+        "chat_messages",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column(
+            "trainer_id", sa.String(64),
+            sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column(
+            "member_id", sa.String(64),
+            sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column("sender", sa.String(20), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("read_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("ix_chat_messages_trainer_id", "chat_messages", ["trainer_id"])
+    op.create_index("ix_chat_messages_member_id", "chat_messages", ["member_id"])
+    op.create_index("ix_chat_messages_created_at", "chat_messages", ["created_at"])
+
+    # --- trainer_schedule ---
+    op.create_table(
+        "trainer_schedule",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column(
+            "trainer_id", sa.String(64),
+            sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column(
+            "member_id", sa.String(64),
+            sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True,
+        ),
+        sa.Column("date", sa.String(10), nullable=False),
+        sa.Column("time", sa.String(10), nullable=False, server_default=""),
+        sa.Column("client_name", sa.String(100), nullable=False, server_default=""),
+        sa.Column("type", sa.String(30), nullable=False, server_default=""),
+        sa.Column("duration_minutes", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("status", sa.String(10), nullable=False, server_default="예정"),
+        sa.Column("note", sa.Text(), nullable=False, server_default=""),
+        sa.Column("program_json", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("ix_trainer_schedule_trainer_id", "trainer_schedule", ["trainer_id"])
+    op.create_index("ix_trainer_schedule_member_id", "trainer_schedule", ["member_id"])
+    op.create_index("ix_trainer_schedule_date", "trainer_schedule", ["date"])
+
+
+def downgrade() -> None:
+    op.drop_table("trainer_schedule")
+    op.drop_table("chat_messages")
+    op.drop_table("routine_history")
+    op.drop_table("trainer_routines")
+    op.drop_table("trainer_clients")
+    op.drop_table("trainer_profiles")
+    op.drop_index("ix_users_role", table_name="users")
+    op.drop_column("users", "role")

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -26,6 +26,7 @@ def test_prod_ok_with_real_secret():
         _env_file=None, env="prod",
         jwt_secret="a-strong-random-secret-value",
         cors_allow_origins="https://app.oncare.com",
+        seed_demo_data=False,  # 운영 권장: 데모 시드 끔(켜려면 DEMO_LOGIN_PASSWORD 강제)
     )
     assert s.is_prod is True
 
@@ -37,6 +38,7 @@ def test_demo_fallback_gated_by_env():
     prod = Settings(
         _env_file=None, env="prod", jwt_secret="strong",
         cors_allow_origins="https://app.oncare.com", allow_demo_fallback=True,
+        seed_demo_data=False,
     )
     assert prod.demo_fallback_enabled is False
     # 명시적으로 끄면 개발에서도 비활성

--- a/backend/tests/test_trainer.py
+++ b/backend/tests/test_trainer.py
@@ -82,10 +82,14 @@ def test_prod_demo_seed_requires_strong_password():
         jwt_secret="a-strong-enough-production-secret-value-01234567",
         cors_allow_origins="https://app.example.com",
     )
-    # 기본 데모 비번 + prod + 데모 시드 → 기동 거부
+    # 기본값 + 데모 시드 → 기동 거부
     with pytest.raises(ValueError):
         Settings(**common, seed_demo_data=True)
-    # 강한 데모 비번이면 데이터 든 데모 계정을 운영에도 둘 수 있음
+    # 빈 문자열·짧은 문자열·기본값 모두 거부(강도 검증)
+    for weak in ("", "short", "oncare123", "abc12345678"):  # 마지막은 11자(<12)
+        with pytest.raises(ValueError):
+            Settings(**common, seed_demo_data=True, demo_login_password=weak)
+    # 기본값이 아니고 12자 이상이면 데이터 든 데모 계정을 운영에도 둘 수 있음
     ok = Settings(**common, seed_demo_data=True, demo_login_password="Str0ng!Demo#Pass")
     assert ok.demo_login_password == "Str0ng!Demo#Pass"
     # 데모 시드를 끄면(운영 기본 권장) 당연히 통과

--- a/backend/tests/test_trainer.py
+++ b/backend/tests/test_trainer.py
@@ -1,0 +1,70 @@
+"""트레이너 도메인 — 역할 인증 + /trainer/me.
+
+- role 파싱/기본값은 순수(로컬 실행).
+- 엔드포인트 보호(200/403/401)는 DB 필요(로컬 skip, CI 실행).
+"""
+from __future__ import annotations
+
+from uuid import uuid4
+
+
+def test_user_role_defaults_to_member():
+    from app.models.models import User
+
+    u = User(id="u1", email="a@b.com", name="a")
+    # SQLAlchemy 컬럼 default 는 flush 시 적용되므로, 여기선 모델 기본 문자열만 확인.
+    assert User.__table__.c.role.default.arg == "member"
+
+
+def _trainer_token(client) -> str:
+    """시드된 데모 트레이너로 로그인."""
+    return client.post(
+        "/v1/auth/login",
+        data={"username": "trainer@oncare.com", "password": "oncare123"},
+    ).json()["access_token"]
+
+
+def _member_token(client) -> str:
+    email = f"member-{uuid4().hex[:8]}@oncare.com"
+    client.post("/v1/auth/register", json={"email": email, "password": "pw!", "name": "u"})
+    return client.post(
+        "/v1/auth/login", data={"username": email, "password": "pw!"}
+    ).json()["access_token"]
+
+
+def test_trainer_me_returns_profile(client):
+    token = _trainer_token(client)
+    r = client.get("/v1/trainer/me", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["name"] == "김트레이너"
+    assert body["email"] == "trainer@oncare.com"
+    assert body["career"] == "7년"
+    assert body["gym"]["name"] == "온케어짐 신촌점"
+    assert "생활스포츠지도사 2급" in body["certifications"]
+
+
+def test_member_cannot_access_trainer_endpoint(client):
+    token = _member_token(client)
+    r = client.get("/v1/trainer/me", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 403
+
+
+def test_unauthenticated_trainer_is_rejected(client):
+    # require_trainer 는 데모 폴백을 쓰지 않으므로 토큰 없으면 401
+    r = client.get("/v1/trainer/me")
+    assert r.status_code == 401
+
+
+def test_demo_trainer_client_links_seeded(client, db_session):
+    from sqlalchemy import select
+
+    from app.db.seed_trainer import TRAINER_ID
+    from app.models.models import TrainerClient
+
+    links = db_session.scalars(
+        select(TrainerClient).where(TrainerClient.trainer_id == TRAINER_ID)
+    ).all()
+    assert len(links) == 3
+    member_ids = {l.member_id for l in links}
+    assert {"user-demo", "user-jisu", "user-sungho"} <= member_ids

--- a/backend/tests/test_trainer.py
+++ b/backend/tests/test_trainer.py
@@ -68,3 +68,82 @@ def test_demo_trainer_client_links_seeded(client, db_session):
     assert len(links) == 3
     member_ids = {l.member_id for l in links}
     assert {"user-demo", "user-jisu", "user-sungho"} <= member_ids
+
+
+# ---- 리뷰 반영: prod 데모 시드 안전장치(순수, DB 불필요) ----
+
+def test_prod_demo_seed_requires_strong_password():
+    import pytest
+
+    from app.core.config import Settings
+
+    common = dict(
+        _env_file=None, env="prod",
+        jwt_secret="a-strong-enough-production-secret-value-01234567",
+        cors_allow_origins="https://app.example.com",
+    )
+    # 기본 데모 비번 + prod + 데모 시드 → 기동 거부
+    with pytest.raises(ValueError):
+        Settings(**common, seed_demo_data=True)
+    # 강한 데모 비번이면 데이터 든 데모 계정을 운영에도 둘 수 있음
+    ok = Settings(**common, seed_demo_data=True, demo_login_password="Str0ng!Demo#Pass")
+    assert ok.demo_login_password == "Str0ng!Demo#Pass"
+    # 데모 시드를 끄면(운영 기본 권장) 당연히 통과
+    off = Settings(**common, seed_demo_data=False)
+    assert off.seed_demo_data is False
+
+
+# ---- 리뷰 반영: 역할 분리(트레이너 토큰의 회원 API 접근 차단) ----
+
+def test_trainer_token_rejected_by_member_api(client):
+    token = _trainer_token(client)
+    h = {"Authorization": f"Bearer {token}"}
+    # 회원 읽기(CurrentUser)와 회원 쓰기(RequireMember) 모두 403
+    assert client.get("/v1/users/me", headers=h).status_code == 403
+    assert client.get("/v1/diet/days/today", headers=h).status_code == 403
+
+
+def test_member_api_still_works_without_token(client):
+    # 데모 폴백(회원)은 그대로 동작 — 미인증 읽기는 회원 데모로 200
+    assert client.get("/v1/users/me").status_code == 200
+
+
+# ---- 리뷰 반영: 시드 멱등성(이메일 충돌·재실행) ----
+
+def test_trainer_seed_is_idempotent(client, db_session):
+    from sqlalchemy import func, select
+
+    from app.db.seed_trainer import TRAINER_ID, seed_trainer_domain
+    from app.models.models import TrainerClient, User
+
+    # 여러 번 재실행해도 계정/링크 수가 늘지 않는다
+    seed_trainer_domain()
+    seed_trainer_domain()
+    links = db_session.scalar(
+        select(func.count()).select_from(TrainerClient)
+        .where(TrainerClient.trainer_id == TRAINER_ID)
+    )
+    assert links == 3
+    trainers = db_session.scalar(
+        select(func.count()).select_from(User).where(User.role == "trainer")
+    )
+    assert trainers >= 1
+
+
+def test_email_conflict_is_detected(client, db_session):
+    """이메일 충돌 감지 로직(시드가 이걸로 안전 스킵). 비파괴 — 임시행만 쓰고 정리."""
+    from app.db.seed_trainer import _email_taken_by_other
+    from app.models.models import User
+
+    db_session.add(User(
+        id="tmp-squatter", email="conflict-test@oncare.com", name="x", role="member",
+    ))
+    db_session.commit()
+    try:
+        # 다른 id 가 같은 이메일을 쓰려 하면 충돌로 감지 → 시드는 스킵한다
+        assert _email_taken_by_other(db_session, "conflict-test@oncare.com", "other-id") is True
+        # 본인 id 는 충돌 아님
+        assert _email_taken_by_other(db_session, "conflict-test@oncare.com", "tmp-squatter") is False
+    finally:
+        db_session.query(User).filter(User.id == "tmp-squatter").delete()
+        db_session.commit()

--- a/backend/tests/test_trainer_seed.py
+++ b/backend/tests/test_trainer_seed.py
@@ -1,0 +1,68 @@
+"""트레이너 시드의 역할/이메일 충돌 안전성 — 리뷰 반영(#249).
+
+기존 ID 가 기대와 다른 역할로 선점돼 있어도 트레이너 프로필·담당 링크를
+잘못 만들지 않는지 검증한다. 공유 DB 를 잠시 바꾸지만 finally 에서 원복한다.
+DB 필요(로컬 skip, CI 실행).
+"""
+from __future__ import annotations
+
+from sqlalchemy import select
+
+
+def test_trainer_id_role_conflict_skips_profile(client, db_session):
+    """trainer-demo ID 가 회원 역할로 선점돼 있으면 프로필을 붙이지 않는다."""
+    from app.db.seed_trainer import TRAINER_ID, _seed_trainer_account
+    from app.models.models import TrainerProfile, User
+
+    trainer = db_session.get(User, TRAINER_ID)
+    orig_role = trainer.role
+    # 프로필 제거 + 역할을 member 로 위장(선점 상황 재현)
+    db_session.query(TrainerProfile).filter(
+        TrainerProfile.trainer_id == TRAINER_ID
+    ).delete()
+    trainer.role = "member"
+    db_session.commit()
+    try:
+        _seed_trainer_account(db_session)
+        # 역할 불일치 → 프로필 재생성 스킵
+        prof = db_session.scalar(
+            select(TrainerProfile).where(TrainerProfile.trainer_id == TRAINER_ID)
+        )
+        assert prof is None
+    finally:
+        trainer = db_session.get(User, TRAINER_ID)
+        trainer.role = orig_role
+        db_session.commit()
+        _seed_trainer_account(db_session)  # 원복: 프로필 재생성
+        assert db_session.scalar(
+            select(TrainerProfile).where(TrainerProfile.trainer_id == TRAINER_ID)
+        ) is not None
+
+
+def test_member_id_role_conflict_skips_link(client, db_session):
+    """회원 ID 가 트레이너 역할로 선점돼 있으면 담당 링크를 만들지 않는다."""
+    from app.db.seed_trainer import TRAINER_ID, _seed_client_links
+    from app.models.models import TrainerClient, User
+
+    member_id = "user-sungho"  # 로스터 테스트가 값 검증에 쓰는 jisu/demo 는 피한다
+    member = db_session.get(User, member_id)
+    orig_role = member.role
+    link_id = f"tc-{TRAINER_ID}-{member_id}"
+
+    db_session.query(TrainerClient).filter(TrainerClient.id == link_id).delete()
+    member.role = "trainer"  # 회원이 아닌 역할로 위장
+    db_session.commit()
+    try:
+        _seed_client_links(db_session)
+        # 역할 불일치 → 링크 재생성 스킵
+        assert db_session.scalar(
+            select(TrainerClient).where(TrainerClient.id == link_id)
+        ) is None
+    finally:
+        member = db_session.get(User, member_id)
+        member.role = orig_role
+        db_session.commit()
+        _seed_client_links(db_session)  # 원복: 링크 재생성
+        assert db_session.scalar(
+            select(TrainerClient).where(TrainerClient.id == link_id)
+        ) is not None


### PR DESCRIPTION
## Summary
* 백엔드에 트레이너 도메인 기반 신설: `User.role`(member|trainer)로 두 앱 계정을 구분.
* 트레이너↔회원 상호작용용 6개 테이블(프로필·담당링크·루틴·완료기록·채팅·스케줄)을
  Alembic `0012_trainer_domain`(additive)으로 추가.
* 트레이너 데모(김트레이너 + 담당 회원 3명 + 링크) 시드 + `GET /trainer/me`(트레이너 전용).

## Changes
### ✨ Features
* `User.role` 컬럼 + `require_trainer`/`RequireTrainer` 의존성(데모 폴백 없음).
* 트레이너 도메인 모델 6종 + 마이그레이션 `0012_trainer_domain`.
* `trainer_clients`에 회원당 active 담당 1명 partial unique index.
* 트레이너 데모 시드(`seed_trainer.py`) — "고객"은 실제 회원 User로 연결.
* `GET /trainer/me` — Figma MY / seedTrainerProfile 계약 정렬.

### 🔧 Improvements
* `init_db`가 데모 사용자 시드 뒤 트레이너 시드를 호출해 담당 링크 FK 성립 보장.

## Commits
1. `942a3f5` feat(trainer-api): add trainer role, domain models, migration and seed
2. `8bdcb24` fix(trainer-api): harden demo seed and enforce member-only API access
3. `93a66ba` fix(trainer-api): enforce demo password strength and seed role-conflict guards

## Notes
* **진짜 공유(A안)**: 트레이너는 회원의 실제 diet/exercise/vitals를 읽는다(복제 없음).
* **마이그레이션 선형**: `0012_trainer_domain`은 `0011_health_daily_sugar_g`(#231)를 부모로 둔다.
  스택이 가장 마지막에 머지되므로, **#207(0010) → #231(0011) 이후**에 이 PR을 머지해야 single head.
* 데모 로그인 `trainer@oncare.com` / `oncare123`(운영 시드엔 미사용).

## Related Issues
Closes #249

## Checklist
* [ ] 코드 리뷰 준비 완료
* [ ] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인