### PR TITLE
feat(trainer-api): add client roster with real member diet/history sharing

### DIFF
--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -103,6 +103,6 @@ def trainer_client_history(
     trainer: RequireTrainer,
     db: Annotated[Session, Depends(get_db)],
 ) -> list[RoutineHistoryOut]:
-    """담당 고객의 운동 완료 기록(최신순)."""
+    """담당 고객의 운동 완료 기록(최신순). 타 트레이너 기록/메모는 제외한다."""
     _require_client(db, trainer.id, member_id)
-    return trainer_service.build_client_history(db, member_id)
+    return trainer_service.build_client_history(db, member_id, trainer.id)

--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -12,16 +12,32 @@ from __future__ import annotations
 import json
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.deps import RequireTrainer
 from app.db.session import get_db
-from app.models.models import TrainerProfile
-from app.schemas.trainer_api import TrainerGymOut, TrainerMe
+from app.models.models import TrainerClient, TrainerProfile
+from app.schemas.trainer_api import (
+    ClientDietEntryOut, RoutineHistoryOut, TrainerClientOut, TrainerGymOut, TrainerMe,
+)
+from app.services import trainer_service
 
 router = APIRouter(tags=["trainer"])
+
+
+def _require_client(db: Session, trainer_id: str, member_id: str) -> TrainerClient:
+    """(trainer, member) 담당 링크를 확인. 남의 고객/미담당이면 404(소유권 경계)."""
+    link = db.scalar(
+        select(TrainerClient).where(
+            TrainerClient.trainer_id == trainer_id,
+            TrainerClient.member_id == member_id,
+        )
+    )
+    if link is None:
+        raise HTTPException(status_code=404, detail="담당 고객을 찾을 수 없습니다.")
+    return link
 
 
 @router.get("/trainer/me", response_model=TrainerMe)
@@ -56,3 +72,37 @@ def trainer_me(
             phone=profile.gym_phone,
         ),
     )
+
+
+@router.get("/trainer/clients", response_model=list[TrainerClientOut])
+def trainer_clients(
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> list[TrainerClientOut]:
+    """담당 고객 로스터. 각 카드의 오늘 칼로리/나트륨/당류와 나트륨 추세는
+    회원의 실제 식단 기록(DietEntry)에서 집계한다 — 트레이너↔회원 실데이터 공유."""
+    return trainer_service.build_roster(db, trainer.id)
+
+
+@router.get("/trainer/clients/{member_id}/diet", response_model=list[ClientDietEntryOut])
+def trainer_client_diet(
+    member_id: str,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+    date: str | None = Query(None, description="YYYY-MM-DD (기본: 오늘)"),
+) -> list[ClientDietEntryOut]:
+    """담당 고객의 식단(회원이 회원 앱에서 기록한 실제 데이터)."""
+    _require_client(db, trainer.id, member_id)
+    day = date or trainer_service.today_iso()
+    return trainer_service.build_client_diet(db, member_id, day)
+
+
+@router.get("/trainer/clients/{member_id}/history", response_model=list[RoutineHistoryOut])
+def trainer_client_history(
+    member_id: str,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> list[RoutineHistoryOut]:
+    """담당 고객의 운동 완료 기록(최신순)."""
+    _require_client(db, trainer.id, member_id)
+    return trainer_service.build_client_history(db, member_id)

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -46,6 +46,10 @@ def init_db() -> None:
         # 김민수(user-demo) 링크가 성립한다.
         from app.db.seed_trainer import seed_trainer_domain
         seed_trainer_domain()
+        # 담당 회원 실데이터(식단·운동기록) — 트레이너 로스터/식단/기록을 실데이터로 채운다.
+        # 회원 계정 시드(seed_trainer_domain) 뒤에 호출.
+        from app.db.seed_member_data import seed_member_health_data
+        seed_member_health_data()
 
     _promote_admins()  # ADMIN_EMAILS 사용자를 관리자로 승격(멱등)
 

--- a/backend/app/db/seed_member_data.py
+++ b/backend/app/db/seed_member_data.py
@@ -1,0 +1,190 @@
+"""
+담당 회원의 건강 데이터 데모 시드 — 트레이너 로스터/식단/기록을 실데이터로 채운다.
+
+여기서 넣는 식단(DietEntry)·운동기록(RoutineHistory)은 "회원이 회원 앱에서 남긴
+실제 데이터"다. 트레이너 API 는 이 데이터를 그대로 읽어 로스터를 집계하므로,
+트레이너↔회원 데이터 공유가 시드 단계에서부터 실제로 성립한다.
+
+멱등 + 날짜 인식:
+- 오늘 식단은 회원에게 오늘 DietEntry 가 없을 때만 3끼를 넣는다.
+- 최근 6일 나트륨 추세는 해당 날짜에 DietEntry 가 없을 때만 1건씩 넣는다
+  (이미 '오늘'로 들어갔던 날은 건너뛰어 중복 합산을 막는다).
+- 운동기록은 회원에게 오늘 기록이 없을 때만 최근 3세션을 넣는다.
+날짜가 넘어가면 자연히 '오늘'이 새로 시드되고 과거 데이터는 누적되어 실제 이력이 된다.
+"""
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.seed_trainer import TRAINER_ID, _MEMBERS
+from app.db.session import SessionLocal
+from app.models import models
+
+# 회원별 오늘 3끼 (meal_type, 음식, 칼로리, 나트륨, 당류) — 프론트 seed 와 동일 수치.
+# 하루 나트륨 합 == _SODIUM_WEEK[member][-1](오늘) 이 되도록 맞춰 둠.
+_TODAY_MEALS: dict[str, list[tuple[str, str, int, int, int]]] = {
+    "user-demo": [
+        ("breakfast", "오트밀, 바나나", 315, 380, 0),
+        ("lunch", "닭가슴살 샐러드, 현미밥", 620, 890, 45),
+        ("dinner", "두부찌개, 잡곡밥", 485, 830, 0),
+    ],
+    "user-jisu": [
+        ("breakfast", "그릭요거트, 과일", 280, 200, 38),
+        ("lunch", "현미밥, 불고기, 나물", 750, 980, 0),
+        ("dinner", "연어 샐러드", 650, 620, 0),
+    ],
+    "user-sungho": [
+        ("breakfast", "계란 3개, 토스트", 480, 520, 0),
+        ("lunch", "짜장면", 890, 1200, 55),
+        ("dinner", "삼겹살, 쌈채소", 730, 680, 0),
+    ],
+}
+
+# 최근 7일 일별 나트륨(오래된→오늘). 마지막 값은 오늘 3끼 합과 일치.
+_SODIUM_WEEK: dict[str, list[int]] = {
+    "user-demo": [2400, 2200, 1900, 2050, 2300, 1850, 2100],
+    "user-jisu": [1700, 1950, 1600, 1800, 2100, 1750, 1800],
+    "user-sungho": [2600, 2500, 2300, 2450, 2200, 2550, 2400],
+}
+
+# 최근 운동 세션(최신순): (완료율, 종류라벨, 운동목록, 회원피드백, 트레이너메모).
+# 오늘/이틀전/나흘전 날짜로 시드. PT 세션은 trainer_id 를 붙인다.
+_HISTORY: dict[str, list[tuple[int, str, list[str], str, str]]] = {
+    "user-demo": [
+        (100, "PT 세션 · 트레이너 지도", ["레그프레스 3세트", "레그컬 3세트", "하체 스트레칭"],
+         "무릎이 좀 당겼지만 트레이너님 덕분에 잘 마쳤어요 😊",
+         "무릎 가동범위 체크 필요. 다음 세션 중량 조절 예정."),
+        (67, "AI 루틴 · 자율 운동", ["걷기 30분 ✓", "코어 강화 10분 ✓", "스트레칭 ✗ (생략)"],
+         "스트레칭은 시간이 없어서 못 했어요", ""),
+        (100, "AI 루틴 · 자율 운동", ["걷기 30분 ✓", "코어 강화 10분 ✓", "하체 스트레칭 15분 ✓"],
+         "오늘은 다 했어요! 뿌듯해요 💪", ""),
+    ],
+    "user-jisu": [
+        (100, "AI 루틴 · 자율 운동", ["인터벌 런닝 25분 ✓", "스쿼트 3세트 ✓", "플랭크 10분 ✓"],
+         "런닝이 힘들었는데 다 했어요! 숨이 많이 찼어요",
+         "심폐지구력 향상 중. 다음 주 런닝 강도 소폭 올릴 예정."),
+        (100, "PT 세션 · 트레이너 지도", ["데드리프트 3세트", "런지 3세트", "코어 서킷"],
+         "데드리프트 자세 교정 도움 많이 됐어요!", ""),
+        (67, "AI 루틴 · 자율 운동", ["런닝 25분 ✓", "스쿼트 ✓", "플랭크 ✗ (피로)"],
+         "마지막 플랭크는 너무 지쳐서 못 했어요", ""),
+    ],
+    "user-sungho": [
+        (100, "PT 세션 · 트레이너 지도", ["벤치프레스 4세트", "인클라인 덤벨 3세트", "트라이셉스 딥"],
+         "가슴이 많이 타는 느낌이었어요. 좋았어요!",
+         "벤치 중량 62.5kg → 65kg 도전 가능. 다음 PT 때 시도 예정."),
+        (33, "AI 루틴 · 자율 운동", ["벤치프레스 ✓", "데드리프트 ✗", "유산소 ✗"],
+         "회사 일이 생겨서 벤치만 하고 나왔어요", ""),
+        (0, "AI 루틴 · 자율 운동", ["벤치프레스 ✗", "데드리프트 ✗", "유산소 ✗"],
+         "못 갔어요 😓", ""),
+    ],
+}
+
+
+def seed_member_health_data() -> None:
+    db: Session = SessionLocal()
+    try:
+        for user_id, *_ in _MEMBERS:
+            _seed_diet(db, user_id)
+            _seed_history(db, user_id)
+    finally:
+        db.close()
+
+
+def _has_diet_on(db: Session, member_id: str, day: str) -> bool:
+    return db.scalar(
+        select(models.DietEntry.id)
+        .where(models.DietEntry.user_id == member_id, models.DietEntry.date == day)
+        .limit(1)
+    ) is not None
+
+
+def _seed_diet(db: Session, member_id: str) -> None:
+    meals = _TODAY_MEALS.get(member_id)
+    sodium_week = _SODIUM_WEEK.get(member_id)
+    if not meals or not sodium_week:
+        return
+
+    today = date.today()
+    today_str = today.isoformat()
+
+    # 오늘 3끼 (오늘 기록이 아직 없을 때만)
+    if not _has_diet_on(db, member_id, today_str):
+        for i, (meal_type, items, cal, na, sugar) in enumerate(meals):
+            db.add(models.DietEntry(
+                id=f"seed-diet-{member_id}-{today_str}-{i}",
+                user_id=member_id,
+                date=today_str,
+                meal_type=meal_type,
+                time_label={"breakfast": "08:00", "lunch": "12:30", "dinner": "19:00"}.get(meal_type, ""),
+                foods_json=json.dumps(
+                    [{"name": items, "calories": cal, "sodium_mg": na, "sugar_g": sugar}],
+                    ensure_ascii=False,
+                ),
+                total_calories=cal,
+                sodium_mg=na,
+                sugar_g=sugar,
+                engine="seed",
+            ))
+
+    # 최근 6일 나트륨 추세 (해당 날짜에 기록이 없을 때만 — 중복 합산 방지)
+    for offset in range(1, 7):
+        d = (today - timedelta(days=offset)).isoformat()
+        if _has_diet_on(db, member_id, d):
+            continue
+        na = sodium_week[6 - offset]
+        db.add(models.DietEntry(
+            id=f"seed-diet-{member_id}-{d}-agg",
+            user_id=member_id,
+            date=d,
+            meal_type="lunch",
+            time_label="",
+            foods_json=json.dumps(
+                [{"name": "기록된 식단", "calories": 1500, "sodium_mg": na, "sugar_g": 0}],
+                ensure_ascii=False,
+            ),
+            total_calories=1500,
+            sodium_mg=na,
+            sugar_g=0,
+            engine="seed",
+        ))
+    db.commit()
+
+
+def _seed_history(db: Session, member_id: str) -> None:
+    sessions = _HISTORY.get(member_id)
+    if not sessions:
+        return
+
+    today = date.today()
+    # 오늘 기록이 이미 있으면 스킵(멱등, 날짜 넘어가면 새로 시드)
+    if db.scalar(
+        select(models.RoutineHistory.id)
+        .where(
+            models.RoutineHistory.member_id == member_id,
+            models.RoutineHistory.date == today.isoformat(),
+        )
+        .limit(1)
+    ) is not None:
+        return
+
+    for idx, (rate, kind, exercises, feedback, note) in enumerate(sessions):
+        d = (today - timedelta(days=idx * 2)).isoformat()  # 오늘/이틀전/나흘전
+        hid = f"seed-hist-{member_id}-{d}"
+        if db.get(models.RoutineHistory, hid) is not None:
+            continue
+        db.add(models.RoutineHistory(
+            id=hid,
+            member_id=member_id,
+            trainer_id=TRAINER_ID if kind.startswith("PT") else None,
+            date=d,
+            kind_label=kind,
+            completion_rate=rate,
+            exercises_json=json.dumps(exercises, ensure_ascii=False),
+            client_feedback=feedback,
+            trainer_note=note,
+        ))
+    db.commit()

--- a/backend/app/db/seed_member_data.py
+++ b/backend/app/db/seed_member_data.py
@@ -84,10 +84,31 @@ _HISTORY: dict[str, list[tuple[int, str, list[str], str, str]]] = {
 }
 
 
+def _valid_member_ids(db: Session) -> set[str]:
+    """트레이너 데모에 실제로 링크되고 회원 역할인 member_id 집합.
+
+    이메일 충돌 등으로 회원 계정/링크가 만들어지지 않았으면(#249 시드가 스킵) 그 회원의
+    건강 데이터를 넣으면 FK 오류로 기동이 죽는다. 유효한 회원만 시드 대상으로 삼는다.
+    """
+    rows = db.execute(
+        select(models.TrainerClient.member_id)
+        .join(models.User, models.User.id == models.TrainerClient.member_id)
+        .where(
+            models.TrainerClient.trainer_id == TRAINER_ID,
+            models.User.role == "member",
+        )
+    ).all()
+    return {r[0] for r in rows}
+
+
 def seed_member_health_data() -> None:
     db: Session = SessionLocal()
     try:
+        valid = _valid_member_ids(db)
         for user_id, *_ in _MEMBERS:
+            if user_id not in valid:
+                # 계정/링크 없음(이메일 충돌 등) → FK 오류 방지 위해 건너뛴다.
+                continue
             _seed_diet(db, user_id)
             _seed_history(db, user_id)
     finally:

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -26,3 +26,42 @@ class TrainerMe(BaseModel):
     intro: str
     certifications: list[str]
     gym: TrainerGymOut
+
+
+class TrainerClientOut(BaseModel):
+    """고객 로스터 카드 — 프론트 TrainerClient 계약 정렬.
+
+    id 는 회원 User id(하위 엔드포인트 키). calories/sodium_mg/sugar_g 는 회원의
+    실제 오늘 식단(DietEntry)에서 집계한 값이다(진짜 데이터 공유).
+    """
+    id: str                      # member_id — /trainer/clients/{id}/... 키
+    name: str
+    avatar: str
+    goal: str
+    last_message: str
+    last_time: str
+    active: bool
+    calories: int                # 오늘 총 칼로리(회원 실데이터)
+    sodium_mg: int               # 오늘 총 나트륨
+    sugar_g: int                 # 오늘 총 당류
+    last_routine: str            # 마지막 루틴 전송 라벨(오늘/어제/N일 전)
+    week_completion: list[int]   # 이번 주 일별 완료율 7개(월→일)
+    sodium_week: list[int]       # 최근 7일 일별 나트륨(오래된→오늘)
+
+
+class ClientDietEntryOut(BaseModel):
+    """고객 식단 서브탭 한 끼 — 프론트 ClientDietEntry 계약 정렬."""
+    meal: str        # 아침|점심|저녁|간식
+    items: str       # 음식명 나열
+    calories: int
+    sodium_mg: int
+
+
+class RoutineHistoryOut(BaseModel):
+    """고객 운동기록 서브탭 항목 — 프론트 RoutineHistoryEntry 계약 정렬."""
+    date_label: str          # "7/12 (오늘)"
+    label: str               # "PT 세션 · 트레이너 지도"
+    completion_rate: int     # 0..100
+    exercises: list[str]
+    client_feedback: str
+    trainer_note: str

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -81,6 +81,16 @@ def relative_time_label(ts: datetime) -> str:
     return f"{int(secs // 86400)}일 전"
 
 
+def _local_date_iso(ts: datetime) -> str:
+    """tz-aware(또는 naive=UTC 가정) 시각 → 로컬(서버 TZ) 날짜 YYYY-MM-DD.
+
+    created_at 은 UTC 로 저장되므로, 로컬 '오늘/어제' 판정과 맞추려면 로컬 날짜로 변환해야
+    한다(안 그러면 KST 새벽엔 UTC 가 전날이라 '어제'로 어긋난다)."""
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts.astimezone().date().isoformat()
+
+
 def _today_totals(diet_rows: list[DietEntry], today_str: str) -> tuple[int, int, int]:
     cal = na = sugar = 0
     for e in diet_rows:
@@ -201,7 +211,7 @@ def build_roster(db: Session, trainer_id: str) -> list[TrainerClientOut]:
             sodium_mg=na,
             sugar_g=sugar,
             last_routine=(
-                relative_day_label(last_rt.created_at.date().isoformat())
+                relative_day_label(_local_date_iso(last_rt.created_at))
                 if last_rt else "-"
             ),
             week_completion=_week_completion(hist_by_member.get(link.member_id, []), monday),

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -1,0 +1,229 @@
+"""
+트레이너 도메인 서비스 — 로스터/식단/기록 집계.
+
+핵심(진짜 데이터 공유): 고객의 칼로리·나트륨·당류·나트륨 추세는 별도 복제본이 아니라
+회원이 회원 앱에서 남긴 실제 DietEntry 를 집계한 값이다. 라우터는 얇게 두고 도메인
+로직(집계·라벨링·계약 매핑)은 여기에 모은다.
+"""
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.models import (
+    ChatMessage, DietEntry, RoutineHistory, TrainerClient, TrainerRoutine, User,
+)
+from app.schemas.trainer_api import (
+    ClientDietEntryOut, RoutineHistoryOut, TrainerClientOut,
+)
+
+
+def _today() -> date:
+    return datetime.now().date()
+
+
+def today_iso() -> str:
+    """오늘 날짜 YYYY-MM-DD (라우터 기본 날짜용)."""
+    return _today().isoformat()
+
+
+def _meal_kr(meal_type: str) -> str:
+    return {"breakfast": "아침", "lunch": "점심", "dinner": "저녁", "snack": "간식"}.get(
+        meal_type, meal_type
+    )
+
+
+def relative_day_label(day: str) -> str:
+    """YYYY-MM-DD → 오늘/어제/N일 전 (마지막 루틴 전송 라벨용)."""
+    try:
+        then = date.fromisoformat(day)
+    except ValueError:
+        return day
+    delta = (_today() - then).days
+    if delta <= 0:
+        return "오늘"
+    if delta == 1:
+        return "어제"
+    return f"{delta}일 전"
+
+
+def history_date_label(day: str) -> str:
+    """YYYY-MM-DD → 'M/D' (+ ' (오늘)'/' (어제)') 운동기록 라벨."""
+    try:
+        then = date.fromisoformat(day)
+    except ValueError:
+        return day
+    label = f"{then.month}/{then.day}"
+    delta = (_today() - then).days
+    if delta == 0:
+        label += " (오늘)"
+    elif delta == 1:
+        label += " (어제)"
+    return label
+
+
+def relative_time_label(ts: datetime) -> str:
+    """채팅 최근시각 → 방금/N분 전/N시간 전/N일 전."""
+    now = datetime.now(timezone.utc)
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    secs = (now - ts).total_seconds()
+    if secs < 60:
+        return "방금"
+    if secs < 3600:
+        return f"{int(secs // 60)}분 전"
+    if secs < 86400:
+        return f"{int(secs // 3600)}시간 전"
+    return f"{int(secs // 86400)}일 전"
+
+
+def _today_totals(diet_rows: list[DietEntry], today_str: str) -> tuple[int, int, int]:
+    cal = na = sugar = 0
+    for e in diet_rows:
+        if e.date == today_str:
+            cal += e.total_calories
+            na += e.sodium_mg
+            sugar += e.sugar_g
+    return cal, na, sugar
+
+
+def _sodium_week(diet_rows: list[DietEntry], today: date) -> list[int]:
+    """최근 7일 일별 나트륨 합(오래된→오늘). 기록 없는 날은 0."""
+    by_date: dict[str, int] = {}
+    for e in diet_rows:
+        by_date[e.date] = by_date.get(e.date, 0) + e.sodium_mg
+    return [
+        by_date.get((today - timedelta(days=off)).isoformat(), 0)
+        for off in range(6, -1, -1)
+    ]
+
+
+def _week_completion(hist_rows: list[RoutineHistory], monday: date) -> list[int]:
+    """이번 주(월→일) 일별 완료율. 같은 날 여러 기록이면 최댓값, 없으면 0."""
+    by_date: dict[str, list[int]] = {}
+    for h in hist_rows:
+        by_date.setdefault(h.date, []).append(h.completion_rate)
+    out: list[int] = []
+    for i in range(7):
+        vals = by_date.get((monday + timedelta(days=i)).isoformat())
+        out.append(max(vals) if vals else 0)
+    return out
+
+
+def build_roster(db: Session, trainer_id: str) -> list[TrainerClientOut]:
+    """트레이너의 담당 고객 로스터. 각 카드의 영양 지표는 회원 실데이터에서 집계."""
+    links = db.scalars(
+        select(TrainerClient)
+        .where(TrainerClient.trainer_id == trainer_id)
+        .order_by(TrainerClient.sort_order, TrainerClient.created_at)
+    ).all()
+
+    today = _today()
+    today_str = today.isoformat()
+    monday = today - timedelta(days=today.weekday())
+
+    out: list[TrainerClientOut] = []
+    for link in links:
+        member = db.get(User, link.member_id)
+        if member is None:
+            continue
+
+        diet_rows = db.scalars(
+            select(DietEntry).where(DietEntry.user_id == link.member_id)
+        ).all()
+        hist_rows = db.scalars(
+            select(RoutineHistory).where(RoutineHistory.member_id == link.member_id)
+        ).all()
+
+        cal, na, sugar = _today_totals(diet_rows, today_str)
+
+        last_msg = db.scalar(
+            select(ChatMessage)
+            .where(
+                ChatMessage.trainer_id == trainer_id,
+                ChatMessage.member_id == link.member_id,
+            )
+            .order_by(ChatMessage.created_at.desc())
+            .limit(1)
+        )
+        last_rt = db.scalar(
+            select(TrainerRoutine)
+            .where(
+                TrainerRoutine.trainer_id == trainer_id,
+                TrainerRoutine.member_id == link.member_id,
+            )
+            .order_by(TrainerRoutine.created_at.desc())
+            .limit(1)
+        )
+
+        out.append(TrainerClientOut(
+            id=link.member_id,
+            name=member.name,
+            avatar=member.name[:1] if member.name else "?",
+            goal=link.goal,
+            last_message=last_msg.body if last_msg else "",
+            last_time=relative_time_label(last_msg.created_at) if last_msg else "-",
+            active=link.active,
+            calories=cal,
+            sodium_mg=na,
+            sugar_g=sugar,
+            last_routine=(
+                relative_day_label(last_rt.created_at.date().isoformat())
+                if last_rt else "-"
+            ),
+            week_completion=_week_completion(hist_rows, monday),
+            sodium_week=_sodium_week(diet_rows, today),
+        ))
+    return out
+
+
+def build_client_diet(db: Session, member_id: str, day: str) -> list[ClientDietEntryOut]:
+    """회원의 특정 날짜 식단(회원 실데이터)을 고객 식단 서브탭 형태로."""
+    rows = db.scalars(
+        select(DietEntry)
+        .where(DietEntry.user_id == member_id, DietEntry.date == day)
+        .order_by(DietEntry.created_at, DietEntry.id)
+    ).all()
+
+    out: list[ClientDietEntryOut] = []
+    for r in rows:
+        try:
+            foods = json.loads(r.foods_json) if r.foods_json else []
+        except json.JSONDecodeError:
+            foods = []
+        items = ", ".join(f.get("name", "") for f in foods if f.get("name"))
+        out.append(ClientDietEntryOut(
+            meal=_meal_kr(r.meal_type),
+            items=items,
+            calories=r.total_calories,
+            sodium_mg=r.sodium_mg,
+        ))
+    return out
+
+
+def build_client_history(db: Session, member_id: str) -> list[RoutineHistoryOut]:
+    """회원의 운동 완료 기록(최신순)."""
+    rows = db.scalars(
+        select(RoutineHistory)
+        .where(RoutineHistory.member_id == member_id)
+        .order_by(RoutineHistory.date.desc(), RoutineHistory.created_at.desc())
+    ).all()
+
+    out: list[RoutineHistoryOut] = []
+    for r in rows:
+        try:
+            exercises = json.loads(r.exercises_json) if r.exercises_json else []
+        except json.JSONDecodeError:
+            exercises = []
+        out.append(RoutineHistoryOut(
+            date_label=history_date_label(r.date),
+            label=r.kind_label,
+            completion_rate=r.completion_rate,
+            exercises=exercises,
+            client_feedback=r.client_feedback,
+            trainer_note=r.trainer_note,
+        ))
+    return out

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -8,9 +8,10 @@
 from __future__ import annotations
 
 import json
+from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
 from app.models.models import (
@@ -113,51 +114,76 @@ def _week_completion(hist_rows: list[RoutineHistory], monday: date) -> list[int]
     return out
 
 
+def _latest_by_member(db: Session, model, trainer_id: str, member_ids: list[str]):
+    """(trainer, member) 스레드별 최신 1건을 member_id → row 로. 배치 1쿼리."""
+    rows = db.scalars(
+        select(model)
+        .where(model.trainer_id == trainer_id, model.member_id.in_(member_ids))
+        .order_by(model.created_at.desc())
+    ).all()
+    latest: dict = {}
+    for r in rows:
+        latest.setdefault(r.member_id, r)  # 최신순 정렬 → 첫 등장이 최신
+    return latest
+
+
 def build_roster(db: Session, trainer_id: str) -> list[TrainerClientOut]:
-    """트레이너의 담당 고객 로스터. 각 카드의 영양 지표는 회원 실데이터에서 집계."""
+    """트레이너의 담당 고객 로스터. 각 카드의 영양 지표는 회원 실데이터에서 집계.
+
+    쿼리는 고객 수와 무관하게 상수개(배치)로 유지하고, 식단/기록은 필요한 창(최근 7일 /
+    이번 주)만 로드한다(N+1·무제한 이력 로드 방지, 리뷰 PR 250-#3).
+    """
     links = db.scalars(
         select(TrainerClient)
         .where(TrainerClient.trainer_id == trainer_id)
         .order_by(TrainerClient.sort_order, TrainerClient.created_at)
     ).all()
+    if not links:
+        return []
+    member_ids = [l.member_id for l in links]
 
     today = _today()
     today_str = today.isoformat()
     monday = today - timedelta(days=today.weekday())
+    week_ago_str = (today - timedelta(days=6)).isoformat()
+    monday_str = monday.isoformat()
+
+    # 최근 7일 식단(오늘 합계 + 나트륨 추세) — 전 고객 배치, 날짜 한정
+    diet_by_member: dict[str, list[DietEntry]] = defaultdict(list)
+    for e in db.scalars(
+        select(DietEntry).where(
+            DietEntry.user_id.in_(member_ids), DietEntry.date >= week_ago_str
+        )
+    ).all():
+        diet_by_member[e.user_id].append(e)
+
+    # 이번 주 운동기록(완료율용) — 트레이너 소유(PT) or 자율(NULL)만, 날짜 한정.
+    # 타 트레이너의 기록은 제외한다(메모 노출 방지, 리뷰 PR 250-#1).
+    hist_by_member: dict[str, list[RoutineHistory]] = defaultdict(list)
+    for h in db.scalars(
+        select(RoutineHistory).where(
+            RoutineHistory.member_id.in_(member_ids),
+            RoutineHistory.date >= monday_str,
+            or_(RoutineHistory.trainer_id.is_(None), RoutineHistory.trainer_id == trainer_id),
+        )
+    ).all():
+        hist_by_member[h.member_id].append(h)
+
+    last_msg_by = _latest_by_member(db, ChatMessage, trainer_id, member_ids)
+    last_rt_by = _latest_by_member(db, TrainerRoutine, trainer_id, member_ids)
+    members = {
+        m.id: m for m in db.scalars(select(User).where(User.id.in_(member_ids))).all()
+    }
 
     out: list[TrainerClientOut] = []
     for link in links:
-        member = db.get(User, link.member_id)
+        member = members.get(link.member_id)
         if member is None:
             continue
-
-        diet_rows = db.scalars(
-            select(DietEntry).where(DietEntry.user_id == link.member_id)
-        ).all()
-        hist_rows = db.scalars(
-            select(RoutineHistory).where(RoutineHistory.member_id == link.member_id)
-        ).all()
-
+        diet_rows = diet_by_member.get(link.member_id, [])
         cal, na, sugar = _today_totals(diet_rows, today_str)
-
-        last_msg = db.scalar(
-            select(ChatMessage)
-            .where(
-                ChatMessage.trainer_id == trainer_id,
-                ChatMessage.member_id == link.member_id,
-            )
-            .order_by(ChatMessage.created_at.desc())
-            .limit(1)
-        )
-        last_rt = db.scalar(
-            select(TrainerRoutine)
-            .where(
-                TrainerRoutine.trainer_id == trainer_id,
-                TrainerRoutine.member_id == link.member_id,
-            )
-            .order_by(TrainerRoutine.created_at.desc())
-            .limit(1)
-        )
+        last_msg = last_msg_by.get(link.member_id)
+        last_rt = last_rt_by.get(link.member_id)
 
         out.append(TrainerClientOut(
             id=link.member_id,
@@ -174,7 +200,7 @@ def build_roster(db: Session, trainer_id: str) -> list[TrainerClientOut]:
                 relative_day_label(last_rt.created_at.date().isoformat())
                 if last_rt else "-"
             ),
-            week_completion=_week_completion(hist_rows, monday),
+            week_completion=_week_completion(hist_by_member.get(link.member_id, []), monday),
             sodium_week=_sodium_week(diet_rows, today),
         ))
     return out
@@ -204,12 +230,23 @@ def build_client_diet(db: Session, member_id: str, day: str) -> list[ClientDietE
     return out
 
 
-def build_client_history(db: Session, member_id: str) -> list[RoutineHistoryOut]:
-    """회원의 운동 완료 기록(최신순)."""
+def build_client_history(
+    db: Session, member_id: str, trainer_id: str, limit: int = 60
+) -> list[RoutineHistoryOut]:
+    """회원의 운동 완료 기록(최신순).
+
+    이 트레이너에게 보이는 기록만 반환한다: 자율 운동(trainer_id NULL) + 이 트레이너가
+    지도한 세션(trainer_id == 본인). 타 트레이너가 작성한 메모(trainer_note)는 노출하지
+    않는다(리뷰 PR 250-#1). 오래된 이력 무제한 로드를 막기 위해 limit 로 제한.
+    """
     rows = db.scalars(
         select(RoutineHistory)
-        .where(RoutineHistory.member_id == member_id)
+        .where(
+            RoutineHistory.member_id == member_id,
+            or_(RoutineHistory.trainer_id.is_(None), RoutineHistory.trainer_id == trainer_id),
+        )
         .order_by(RoutineHistory.date.desc(), RoutineHistory.created_at.desc())
+        .limit(limit)
     ).all()
 
     out: list[RoutineHistoryOut] = []

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -115,16 +115,20 @@ def _week_completion(hist_rows: list[RoutineHistory], monday: date) -> list[int]
 
 
 def _latest_by_member(db: Session, model, trainer_id: str, member_ids: list[str]):
-    """(trainer, member) 스레드별 최신 1건을 member_id → row 로. 배치 1쿼리."""
+    """(trainer, member) 스레드별 최신 1건을 member_id → row 로.
+
+    Postgres DISTINCT ON 으로 회원당 1행만 DB 에서 반환한다 — 오래된 메시지/루틴이
+    아무리 많아도 반환 행 수는 회원 수 이하다(전체 로드 후 Python 선별 금지, 리뷰 PR 250-#2).
+    """
     rows = db.scalars(
         select(model)
         .where(model.trainer_id == trainer_id, model.member_id.in_(member_ids))
-        .order_by(model.created_at.desc())
+        # DISTINCT ON (member_id) + 최신순 → 회원별 최신 1건. ORDER BY 선두는
+        # distinct 컬럼(member_id)이어야 한다.
+        .order_by(model.member_id, model.created_at.desc())
+        .distinct(model.member_id)
     ).all()
-    latest: dict = {}
-    for r in rows:
-        latest.setdefault(r.member_id, r)  # 최신순 정렬 → 첫 등장이 최신
-    return latest
+    return {r.member_id: r for r in rows}
 
 
 def build_roster(db: Session, trainer_id: str) -> list[TrainerClientOut]:

--- a/backend/tests/test_stack_seed.py
+++ b/backend/tests/test_stack_seed.py
@@ -1,0 +1,52 @@
+"""스택 시드 통합 — 이메일 충돌 시 하위 건강 데이터 시드가 FK 오류로 죽지 않는지(#250).
+
+#249(계정/링크 시드)와 #250(건강 데이터 시드)을 이메일 충돌 상황에서 연속 실행해도
+기동이 실패하지 않고, 링크가 성립하지 않은 회원은 시드에서 안전하게 제외되는지 검증한다.
+DB 필요(로컬 skip, CI 실행). 공유 DB 를 잠시 바꾸지만 finally 에서 원복한다.
+"""
+from __future__ import annotations
+
+from sqlalchemy import select
+
+
+def test_email_conflict_seed_is_safe(client, db_session):
+    from app.db.seed_member_data import seed_member_health_data
+    from app.db.seed_trainer import seed_trainer_domain
+    from app.models.models import DietEntry, TrainerClient, User
+
+    victim = "user-sungho"
+    squatter_id = "sq-sungho"
+    squatter_email = "sungho@oncare.com"
+
+    v = db_session.get(User, victim)
+    assert v is not None
+    # victim 계정 제거(FK CASCADE 로 링크·식단·기록·채팅·루틴 정리). 이메일 유니크 충돌을
+    # 피하려 삭제를 먼저 커밋한 뒤, 같은 이메일을 선점하는 계정을 만든다.
+    db_session.delete(v)
+    db_session.commit()
+    db_session.add(User(id=squatter_id, email=squatter_email, name="선점", role="member"))
+    db_session.commit()
+    try:
+        # 이메일 충돌 상태에서 두 시드를 연속 실행 — FK 오류로 죽으면 여기서 예외 발생
+        seed_trainer_domain()        # victim 재생성 실패(이메일 선점) + 링크 스킵
+        seed_member_health_data()    # 링크 없는 victim/squatter 는 시드 대상에서 제외
+        db_session.expire_all()
+
+        # 크래시 없이 도달 + victim/squatter 의 링크·식단이 만들어지지 않음
+        assert db_session.scalar(
+            select(TrainerClient.id).where(TrainerClient.member_id == victim).limit(1)
+        ) is None
+        assert db_session.scalar(
+            select(DietEntry.id).where(DietEntry.user_id == victim).limit(1)
+        ) is None
+        assert db_session.scalar(
+            select(DietEntry.id).where(DietEntry.user_id == squatter_id).limit(1)
+        ) is None
+    finally:
+        # 원복: 선점 계정 제거 → 시드 재실행으로 victim 계정·링크·데이터 복구
+        db_session.query(User).filter(User.id == squatter_id).delete()
+        db_session.commit()
+        seed_trainer_domain()
+        seed_member_health_data()
+        db_session.expire_all()
+        assert db_session.get(User, victim) is not None

--- a/backend/tests/test_trainer.py
+++ b/backend/tests/test_trainer.py
@@ -151,3 +151,60 @@ def test_email_conflict_is_detected(client, db_session):
     finally:
         db_session.query(User).filter(User.id == "tmp-squatter").delete()
         db_session.commit()
+
+
+# ---- #250: 로스터 + 회원 실데이터 공유 ----
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_trainer_clients_roster_aggregates_real_diet(client):
+    token = _trainer_token(client)
+    r = client.get("/v1/trainer/clients", headers=_auth(token))
+    assert r.status_code == 200, r.text
+    clients = {c["id"]: c for c in r.json()}
+    assert {"user-demo", "user-jisu", "user-sungho"} <= set(clients)
+
+    minsu = clients["user-demo"]
+    # 오늘 3끼 합(회원 실데이터에서 집계): 315+620+485=1420, 380+890+830=2100, 당류 45
+    assert minsu["calories"] == 1420
+    assert minsu["sodium_mg"] == 2100
+    assert minsu["sugar_g"] == 45
+    assert minsu["name"] == "김민수"
+    assert len(minsu["sodium_week"]) == 7
+    assert minsu["sodium_week"][-1] == 2100  # 오늘 = 3끼 나트륨 합
+    assert len(minsu["week_completion"]) == 7
+
+
+def test_trainer_client_diet_maps_member_meals(client):
+    token = _trainer_token(client)
+    r = client.get("/v1/trainer/clients/user-demo/diet", headers=_auth(token))
+    assert r.status_code == 200, r.text
+    meals = r.json()
+    assert len(meals) == 3
+    assert meals[0]["meal"] == "아침"
+    assert "오트밀" in meals[0]["items"]
+    assert meals[0]["calories"] == 315
+
+
+def test_trainer_client_history_newest_first(client):
+    token = _trainer_token(client)
+    r = client.get("/v1/trainer/clients/user-demo/history", headers=_auth(token))
+    assert r.status_code == 200, r.text
+    hist = r.json()
+    assert len(hist) >= 1
+    assert hist[0]["label"] == "PT 세션 · 트레이너 지도"
+    assert "(오늘)" in hist[0]["date_label"]
+
+
+def test_trainer_cannot_read_unassigned_client(client):
+    token = _trainer_token(client)
+    r = client.get("/v1/trainer/clients/user-nobody/diet", headers=_auth(token))
+    assert r.status_code == 404
+
+
+def test_member_cannot_read_roster(client):
+    token = _member_token(client)
+    r = client.get("/v1/trainer/clients", headers=_auth(token))
+    assert r.status_code == 403

--- a/backend/tests/test_trainer.py
+++ b/backend/tests/test_trainer.py
@@ -159,6 +159,8 @@ def _auth(token: str) -> dict:
     return {"Authorization": f"Bearer {token}"}
 
 
+# 고정 수치 검증은 test_diet 가 건드리지 않는 회원(user-jisu)으로 한다 — user-demo 는
+# 데모 폴백 대상이라 다른 테스트가 오늘 식단을 추가해 합계가 흔들린다(리뷰 PR 250-#2).
 def test_trainer_clients_roster_aggregates_real_diet(client):
     token = _trainer_token(client)
     r = client.get("/v1/trainer/clients", headers=_auth(token))
@@ -166,36 +168,70 @@ def test_trainer_clients_roster_aggregates_real_diet(client):
     clients = {c["id"]: c for c in r.json()}
     assert {"user-demo", "user-jisu", "user-sungho"} <= set(clients)
 
-    minsu = clients["user-demo"]
-    # 오늘 3끼 합(회원 실데이터에서 집계): 315+620+485=1420, 380+890+830=2100, 당류 45
-    assert minsu["calories"] == 1420
-    assert minsu["sodium_mg"] == 2100
-    assert minsu["sugar_g"] == 45
-    assert minsu["name"] == "김민수"
-    assert len(minsu["sodium_week"]) == 7
-    assert minsu["sodium_week"][-1] == 2100  # 오늘 = 3끼 나트륨 합
-    assert len(minsu["week_completion"]) == 7
+    jisu = clients["user-jisu"]
+    # 오늘 3끼 합(회원 실데이터 집계): 280+750+650=1680, 200+980+620=1800, 당류 38
+    assert jisu["calories"] == 1680
+    assert jisu["sodium_mg"] == 1800
+    assert jisu["sugar_g"] == 38
+    assert jisu["name"] == "이지수"
+    assert len(jisu["sodium_week"]) == 7
+    assert jisu["sodium_week"][-1] == 1800  # 오늘 = 3끼 나트륨 합
+    assert len(jisu["week_completion"]) == 7
 
 
 def test_trainer_client_diet_maps_member_meals(client):
     token = _trainer_token(client)
-    r = client.get("/v1/trainer/clients/user-demo/diet", headers=_auth(token))
+    r = client.get("/v1/trainer/clients/user-jisu/diet", headers=_auth(token))
     assert r.status_code == 200, r.text
     meals = r.json()
     assert len(meals) == 3
     assert meals[0]["meal"] == "아침"
-    assert "오트밀" in meals[0]["items"]
-    assert meals[0]["calories"] == 315
+    assert "그릭요거트" in meals[0]["items"]
+    assert meals[0]["calories"] == 280
 
 
 def test_trainer_client_history_newest_first(client):
     token = _trainer_token(client)
-    r = client.get("/v1/trainer/clients/user-demo/history", headers=_auth(token))
+    r = client.get("/v1/trainer/clients/user-jisu/history", headers=_auth(token))
     assert r.status_code == 200, r.text
     hist = r.json()
     assert len(hist) >= 1
-    assert hist[0]["label"] == "PT 세션 · 트레이너 지도"
+    assert hist[0]["label"] == "AI 루틴 · 자율 운동"
     assert "(오늘)" in hist[0]["date_label"]
+
+
+def test_history_excludes_other_trainers_records(client, db_session):
+    """다른 트레이너가 작성한 기록/메모는 이 트레이너의 조회에 노출되지 않는다(PR 250-#1)."""
+    from datetime import date
+
+    from app.db.seed_trainer import TRAINER_ID
+    from app.models.models import RoutineHistory, User
+    from app.services.trainer_service import build_client_history
+
+    db_session.add(User(
+        id="trainer-other", email="other-t@oncare.com", name="타트레이너", role="trainer",
+    ))
+    db_session.flush()  # RoutineHistory.trainer_id FK 성립을 위해 User 를 먼저 반영
+    db_session.add(RoutineHistory(
+        id="hist-other-secret", member_id="user-jisu", trainer_id="trainer-other",
+        date=date.today().isoformat(), kind_label="PT 세션 · 타트레이너",
+        completion_rate=100, exercises_json="[]",
+        client_feedback="", trainer_note="비밀 메모",
+    ))
+    db_session.commit()
+    try:
+        mine = build_client_history(db_session, "user-jisu", TRAINER_ID)
+        assert all(h.trainer_note != "비밀 메모" for h in mine)
+        assert all(h.label != "PT 세션 · 타트레이너" for h in mine)
+        # 타 트레이너 본인 조회에는 보인다(격리 확인)
+        theirs = build_client_history(db_session, "user-jisu", "trainer-other")
+        assert any(h.trainer_note == "비밀 메모" for h in theirs)
+    finally:
+        db_session.query(RoutineHistory).filter(
+            RoutineHistory.id == "hist-other-secret"
+        ).delete()
+        db_session.query(User).filter(User.id == "trainer-other").delete()
+        db_session.commit()
 
 
 def test_trainer_cannot_read_unassigned_client(client):

--- a/backend/tests/test_trainer_service.py
+++ b/backend/tests/test_trainer_service.py
@@ -1,0 +1,39 @@
+"""트레이너 서비스 배치 쿼리 — 리뷰 반영(#250).
+
+_latest_by_member 가 회원당 최신 1건만 DB 에서 반환하는지(반환 행 수가 메시지 수가
+아니라 회원 수에 비례) 검증한다. DB 필요(로컬 skip, CI 실행).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+
+def test_latest_by_member_returns_one_row_per_member(client, db_session):
+    from app.db.seed_trainer import TRAINER_ID
+    from app.models.models import ChatMessage
+    from app.services.trainer_service import _latest_by_member
+
+    # user-jisu 스레드에 메시지 5건을 서로 다른 시각으로 삽입(오래된 것 다수)
+    base = datetime.now(timezone.utc) - timedelta(hours=5)
+    ids = [f"chat-test-{i}" for i in range(5)]
+    for i, cid in enumerate(ids):
+        db_session.add(ChatMessage(
+            id=cid, trainer_id=TRAINER_ID, member_id="user-jisu",
+            sender="member", body=f"msg{i}", created_at=base + timedelta(minutes=i),
+        ))
+    db_session.commit()
+    try:
+        latest = _latest_by_member(
+            db_session, ChatMessage, TRAINER_ID,
+            ["user-jisu", "user-demo", "user-sungho"],
+        )
+        # 반환 행 수는 회원 수 이하(메시지 5건이어도) — 회원당 최신 1건만
+        assert len(latest) <= 3
+        assert "user-jisu" in latest
+        # 최신(msg4)이 선택됨
+        assert latest["user-jisu"].body == "msg4"
+    finally:
+        db_session.query(ChatMessage).filter(
+            ChatMessage.id.in_(ids)
+        ).delete(synchronize_session=False)
+        db_session.commit()


### PR DESCRIPTION
## Summary
* `GET /trainer/clients` 로스터가 각 고객의 오늘 칼로리/나트륨/당류·주간 추세를
  **회원의 실제 DietEntry/RoutineHistory에서 집계** — 진짜 데이터 공유 동작.
* `/clients/{id}/diet`·`/history`가 회원 실데이터를 노출, 담당 링크로 소유권 보호(미담당 404, 회원 403).
* 집계·라벨링을 `trainer_service`로 분리, 담당 회원 건강 데이터 시드.

## Changes
### ✨ Features
* `GET /trainer/clients` — 오늘 영양 합계 + `sodium_week[7]` + `week_completion[7]`.
* `GET /trainer/clients/{id}/diet?date=` — 회원 실제 식단(끼니별).
* `GET /trainer/clients/{id}/history` — 회원 운동 완료 기록(최신순).
* `seed_member_data` — 담당 회원 3명의 식단·운동기록 데모 시드.

### 🔧 Improvements
* 로스터 배치 조회(회원별 최신 1건 DISTINCT ON), 소유권 가드, 이메일 충돌 FK 방어,
  last_routine 라벨을 UTC가 아닌 로컬 날짜로 계산.

## Commits
1. `2c7eb68` feat: add client roster with real member diet/history sharing
2. `d8b33d1` fix: scope client history by trainer and batch roster queries
3. `5ffea0d` fix: fetch latest chat/routine per member via DISTINCT ON
4. `e8b0806` fix: guard member health seed against email-conflict FK failures
5. `ac78be0` fix: compute last_routine label from local date, not UTC

## Notes
* 고객 `id` = 회원 User id. 회원이 새 식단을 기록하면 로스터에 그대로 반영(핵심 데모 루프).

## Related Issues
Closes #251

## Checklist
* [ ] 코드 리뷰 준비 완료
* [ ] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인