### PR TITLE
feat(trainer-api): add trainer-client chat and routine assignment

### DIFF
--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -20,7 +20,8 @@ from app.api.deps import RequireTrainer
 from app.db.session import get_db
 from app.models.models import TrainerClient, TrainerProfile
 from app.schemas.trainer_api import (
-    ClientDietEntryOut, RoutineHistoryOut, TrainerClientOut, TrainerGymOut, TrainerMe,
+    ChatMessageOut, ChatSendRequest, ClientDietEntryOut, RoutineAssignRequest, RoutineOut,
+    RoutineHistoryOut, TrainerClientOut, TrainerGymOut, TrainerMe,
 )
 from app.services import trainer_service
 
@@ -106,3 +107,84 @@ def trainer_client_history(
     """담당 고객의 운동 완료 기록(최신순). 타 트레이너 기록/메모는 제외한다."""
     _require_client(db, trainer.id, member_id)
     return trainer_service.build_client_history(db, member_id, trainer.id)
+
+
+# ---- 채팅 (트레이너↔회원) ----
+
+@router.get("/trainer/chat/unread", response_model=dict[str, int])
+def trainer_chat_unread(
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> dict[str, int]:
+    """회원별 미확인 메시지 수(회원 발신·미읽음). 고객 목록 배지용."""
+    return trainer_service.unread_counts_for_trainer(db, trainer.id)
+
+
+@router.get("/trainer/clients/{member_id}/chat", response_model=list[ChatMessageOut])
+def trainer_client_chat(
+    member_id: str,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> list[ChatMessageOut]:
+    """담당 고객과의 채팅 스레드(오래된→최신)."""
+    _require_client(db, trainer.id, member_id)
+    return trainer_service.build_chat_thread(db, trainer.id, member_id)
+
+
+@router.post("/trainer/clients/{member_id}/chat", response_model=ChatMessageOut, status_code=201)
+def trainer_send_chat(
+    member_id: str,
+    payload: ChatSendRequest,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> ChatMessageOut:
+    """트레이너가 담당 고객에게 메시지 발신."""
+    _require_client(db, trainer.id, member_id)
+    text = payload.text.strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="빈 메시지는 보낼 수 없습니다.")
+    return trainer_service.send_message(db, trainer.id, member_id, "trainer", text)
+
+
+@router.post("/trainer/clients/{member_id}/chat/read")
+def trainer_mark_chat_read(
+    member_id: str,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> dict:
+    """트레이너가 해당 고객 스레드를 읽음 처리."""
+    _require_client(db, trainer.id, member_id)
+    n = trainer_service.mark_thread_read(db, trainer.id, member_id, "trainer")
+    return {"marked_read": n}
+
+
+# ---- 루틴 배정 (트레이너/AI → 회원) ----
+
+@router.get("/trainer/clients/{member_id}/routines", response_model=list[RoutineOut])
+def trainer_client_routines(
+    member_id: str,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> list[RoutineOut]:
+    """담당 고객에게 배정된 루틴 목록."""
+    _require_client(db, trainer.id, member_id)
+    return trainer_service.build_routines(db, member_id, trainer.id)
+
+
+@router.post("/trainer/clients/{member_id}/routines", response_model=RoutineOut, status_code=201)
+def trainer_assign_routine(
+    member_id: str,
+    payload: RoutineAssignRequest,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> RoutineOut:
+    """담당 고객에게 루틴 배정(트레이너 직접 또는 AI 추천)."""
+    _require_client(db, trainer.id, member_id)
+    if not payload.name.strip():
+        raise HTTPException(status_code=400, detail="루틴 이름이 필요합니다.")
+    source = payload.source if payload.source in ("trainer", "ai") else "trainer"
+    return trainer_service.assign_routine(
+        db, trainer.id, member_id,
+        name=payload.name.strip(), minutes=payload.minutes,
+        type_=payload.type, reason=payload.reason, source=source,
+    )

--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -128,10 +128,13 @@ def trainer_client_chat(
     db: Annotated[Session, Depends(get_db)],
     limit: int = Query(50, ge=1, le=100, description="한 번에 가져올 최신 메시지 수"),
     before: str | None = Query(
-        None, description="ISO datetime 커서 — 이보다 오래된 메시지만(페이지네이션)"
+        None, description="ISO datetime 커서 — 이전 페이지 요청(응답 created_at 사용)"
+    ),
+    before_id: str | None = Query(
+        None, description="복합 커서 tie-break — 이전 페이지 가장 오래된 메시지의 id"
     ),
 ) -> list[ChatMessageOut]:
-    """담당 고객과의 채팅 스레드(오래된→최신). 기본 최신 50건, before 로 이전 페이지."""
+    """담당 고객과의 채팅 스레드(오래된→최신). 기본 최신 50건, (before, before_id)로 이전 페이지."""
     _require_client(db, trainer.id, member_id)
     before_dt: datetime | None = None
     if before:
@@ -142,7 +145,7 @@ def trainer_client_chat(
                 status_code=422, detail="before 는 ISO datetime 형식이어야 합니다."
             ) from e
     return trainer_service.build_chat_thread(
-        db, trainer.id, member_id, limit=limit, before=before_dt
+        db, trainer.id, member_id, limit=limit, before=before_dt, before_id=before_id
     )
 
 

--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -125,10 +126,24 @@ def trainer_client_chat(
     member_id: str,
     trainer: RequireTrainer,
     db: Annotated[Session, Depends(get_db)],
+    limit: int = Query(50, ge=1, le=100, description="한 번에 가져올 최신 메시지 수"),
+    before: str | None = Query(
+        None, description="ISO datetime 커서 — 이보다 오래된 메시지만(페이지네이션)"
+    ),
 ) -> list[ChatMessageOut]:
-    """담당 고객과의 채팅 스레드(오래된→최신)."""
+    """담당 고객과의 채팅 스레드(오래된→최신). 기본 최신 50건, before 로 이전 페이지."""
     _require_client(db, trainer.id, member_id)
-    return trainer_service.build_chat_thread(db, trainer.id, member_id)
+    before_dt: datetime | None = None
+    if before:
+        try:
+            before_dt = datetime.fromisoformat(before)
+        except ValueError as e:
+            raise HTTPException(
+                status_code=422, detail="before 는 ISO datetime 형식이어야 합니다."
+            ) from e
+    return trainer_service.build_chat_thread(
+        db, trainer.id, member_id, limit=limit, before=before_dt
+    )
 
 
 @router.post("/trainer/clients/{member_id}/chat", response_model=ChatMessageOut, status_code=201)
@@ -180,11 +195,12 @@ def trainer_assign_routine(
 ) -> RoutineOut:
     """담당 고객에게 루틴 배정(트레이너 직접 또는 AI 추천)."""
     _require_client(db, trainer.id, member_id)
+    # type/source/길이·범위는 RoutineAssignRequest(Field/Literal)가 이미 422 로 거른다.
+    # 공백만 있는 이름은 trim 후 400.
     if not payload.name.strip():
         raise HTTPException(status_code=400, detail="루틴 이름이 필요합니다.")
-    source = payload.source if payload.source in ("trainer", "ai") else "trainer"
     return trainer_service.assign_routine(
         db, trainer.id, member_id,
         name=payload.name.strip(), minutes=payload.minutes,
-        type_=payload.type, reason=payload.reason, source=source,
+        type_=payload.type, reason=payload.reason, source=payload.source,
     )

--- a/backend/app/db/seed_member_data.py
+++ b/backend/app/db/seed_member_data.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import json
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -101,6 +101,50 @@ def _valid_member_ids(db: Session) -> set[str]:
     return {r[0] for r in rows}
 
 
+# 회원별 채팅 스레드 (sender: trainer|client, text) — 프론트 seed_data 정렬.
+_CHAT: dict[str, list[tuple[str, str]]] = {
+    "user-demo": [
+        ("trainer", "민수님, AI 식단 분석 잘 받았어요 👍 오늘 나트륨이 목표치를 좀 넘었는데 어떠셨어요?"),
+        ("client", "찌개 먹을 때 국물을 많이 마셨나봐요 😅"),
+        ("trainer", "그렇군요! 오늘 PT 후에 부상이나 불편한 데는 없으셨나요?"),
+        ("client", "무릎이 가볍게 당기긴 했는데 괜찮아요"),
+        ("trainer", "확인했어요. AI가 오늘 식단 기반으로 유산소 루틴을 추천했는데, 무릎 상태 감안해서 "
+                    "런닝 대신 걷기로 조정해서 보낼게요. 다음 PT 때 봐요 💪"),
+    ],
+    "user-jisu": [
+        ("trainer", "지수님, AI 운동 데이터 수신했어요 — 오늘 인터벌 런닝 25분 완료! 컨디션은 어때요?"),
+        ("client", "생각보다 괜찮았어요. 숨이 금방 차더라고요 😮‍💨"),
+        ("trainer", "심폐 지구력 올라가는 과정이에요 💪 AI 분석 보니까 당류는 목표 안에 있고, "
+                    "루틴 다음 주부터 근력 비중 늘려볼게요. 식단도 AI 추천 참고해서 업데이트해 드릴게요"),
+    ],
+    "user-sungho": [
+        ("trainer", "성호님, 이번 주 운동 기록이 AI 쪽에서 안 잡히는데 몸은 괜찮으세요?"),
+        ("client", "이번 주 일이 너무 많아서 못 갔어요 😓"),
+        ("trainer", "이해해요! 대신 AI 식단 분석 보니까 나트륨이 좀 높더라고요. 주말에 30분 걷기라도 하면 "
+                    "도움 돼요. AI가 그에 맞는 루틴 다시 짜줬으니까 앱에서 확인해보세요 🙂"),
+    ],
+}
+
+# 회원별 AI 배정 루틴 (name, minutes, type, reason) — 프론트 aiRoutine 정렬.
+_ROUTINES: dict[str, list[tuple[str, int, str, str]]] = {
+    "user-demo": [
+        ("저강도 유산소 (걷기)", 30, "유산소", "혈압 안정에 효과적"),
+        ("하체 스트레칭", 15, "스트레칭", "혈액순환 개선"),
+        ("코어 강화", 10, "근력", "기초대사량 향상"),
+    ],
+    "user-jisu": [
+        ("인터벌 런닝", 25, "유산소", "체지방 연소 효율↑"),
+        ("스쿼트 3세트", 15, "근력", "하체 근력 강화"),
+        ("플랭크", 10, "근력", "코어 안정화"),
+    ],
+    "user-sungho": [
+        ("벤치프레스 4세트", 20, "근력", "상체 근력 목표"),
+        ("데드리프트 3세트", 15, "근력", "전신 근력 향상"),
+        ("유산소 쿨다운", 10, "유산소", "나트륨 배출 지원"),
+    ],
+}
+
+
 def seed_member_health_data() -> None:
     db: Session = SessionLocal()
     try:
@@ -111,8 +155,55 @@ def seed_member_health_data() -> None:
                 continue
             _seed_diet(db, user_id)
             _seed_history(db, user_id)
+            _seed_chat(db, user_id)
+            _seed_routines(db, user_id)
     finally:
         db.close()
+
+
+def _seed_chat(db: Session, member_id: str) -> None:
+    """트레이너↔회원 채팅 스레드(멱등, 결정론적 id). 최근 시각으로 정렬되게 시드."""
+    thread = _CHAT.get(member_id)
+    if not thread:
+        return
+    # 스레드가 최근으로 보이도록 base 를 몇 시간 전으로 두고 2분 간격.
+    base = datetime.now(timezone.utc) - timedelta(hours=2)
+    for i, (sender, text) in enumerate(thread):
+        cid = f"seed-chat-{member_id}-{i}"
+        if db.get(models.ChatMessage, cid) is not None:
+            continue
+        db.add(models.ChatMessage(
+            id=cid,
+            trainer_id=TRAINER_ID,
+            member_id=member_id,
+            sender="member" if sender == "client" else "trainer",
+            body=text,
+            created_at=base + timedelta(minutes=i * 2),
+        ))
+    db.commit()
+
+
+def _seed_routines(db: Session, member_id: str) -> None:
+    """AI 배정 루틴 시드(멱등, 결정론적 id)."""
+    routines = _ROUTINES.get(member_id)
+    if not routines:
+        return
+    for i, (name, minutes, rtype, reason) in enumerate(routines):
+        rid = f"seed-routine-{member_id}-{i}"
+        if db.get(models.TrainerRoutine, rid) is not None:
+            continue
+        db.add(models.TrainerRoutine(
+            id=rid,
+            trainer_id=TRAINER_ID,
+            member_id=member_id,
+            name=name,
+            minutes=minutes,
+            type=rtype,
+            reason=reason,
+            source="ai",
+            sort_order=i,
+        ))
+    db.commit()
 
 
 def _has_diet_on(db: Session, member_id: str, day: str) -> bool:

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -73,11 +73,14 @@ class ChatMessageOut(BaseModel):
     """채팅 메시지 — 프론트 ClientChatMessage 계약 정렬.
 
     sender 는 프론트 계약에 맞춰 'trainer'|'client' 로 노출(백엔드 저장값 member→client).
+    created_at(ISO)은 프론트 createdAt 이자 페이지네이션 커서다. 이전 페이지는 이 스레드
+    가장 오래된 메시지의 (created_at, id)를 before/before_id 로 넘겨 요청한다.
     """
     id: str
     sender: str        # trainer|client
     body: str
     time_label: str    # "18:10"
+    created_at: str    # ISO datetime — 커서/정렬용
 
 
 class ChatSendRequest(BaseModel):

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -6,7 +6,9 @@ GET /trainer/me 응답:
 """
 from __future__ import annotations
 
-from pydantic import BaseModel
+from typing import Literal
+
+from pydantic import BaseModel, Field
 
 
 class TrainerGymOut(BaseModel):
@@ -79,7 +81,11 @@ class ChatMessageOut(BaseModel):
 
 
 class ChatSendRequest(BaseModel):
-    text: str
+    # 상한만 둔다(빈/공백은 라우터에서 trim 후 400). 과도한 길이는 여기서 422.
+    text: str = Field(max_length=2000)
+
+
+RoutineType = Literal["유산소", "근력", "스트레칭"]
 
 
 class RoutineOut(BaseModel):
@@ -93,8 +99,12 @@ class RoutineOut(BaseModel):
 
 
 class RoutineAssignRequest(BaseModel):
-    name: str
-    minutes: int = 0
-    type: str          # 유산소|근력|스트레칭
-    reason: str = ""
-    source: str = "trainer"   # trainer|ai
+    """루틴 배정 입력. 잘못된 값은 DB 500 이 아니라 422 로 거른다.
+
+    type/source 는 허용값(Literal)만, 길이·범위는 Field 로 제한한다.
+    """
+    name: str = Field(min_length=1, max_length=100)
+    minutes: int = Field(default=0, ge=0, le=600)   # 0..600분(현실적 상한)
+    type: RoutineType
+    reason: str = Field(default="", max_length=200)
+    source: Literal["trainer", "ai"] = "trainer"

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -65,3 +65,36 @@ class RoutineHistoryOut(BaseModel):
     exercises: list[str]
     client_feedback: str
     trainer_note: str
+
+
+class ChatMessageOut(BaseModel):
+    """채팅 메시지 — 프론트 ClientChatMessage 계약 정렬.
+
+    sender 는 프론트 계약에 맞춰 'trainer'|'client' 로 노출(백엔드 저장값 member→client).
+    """
+    id: str
+    sender: str        # trainer|client
+    body: str
+    time_label: str    # "18:10"
+
+
+class ChatSendRequest(BaseModel):
+    text: str
+
+
+class RoutineOut(BaseModel):
+    """배정 루틴 — 프론트 ClientAiRoutine 계약 정렬."""
+    id: str
+    name: str
+    minutes: int
+    type: str          # 유산소|근력|스트레칭
+    reason: str
+    source: str        # ai|trainer
+
+
+class RoutineAssignRequest(BaseModel):
+    name: str
+    minutes: int = 0
+    type: str          # 유산소|근력|스트레칭
+    reason: str = ""
+    source: str = "trainer"   # trainer|ai

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -12,7 +12,7 @@ import uuid
 from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
 
-from sqlalchemy import func, or_, select, update
+from sqlalchemy import func, or_, select, tuple_, update
 from sqlalchemy.orm import Session
 
 from app.models.models import (
@@ -295,28 +295,42 @@ def _sender_out(sender: str) -> str:
     return "client" if sender == "member" else "trainer"
 
 
+def _iso(ts: datetime) -> str:
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts.astimezone(timezone.utc).isoformat()
+
+
 def build_chat_thread(
     db: Session, trainer_id: str, member_id: str,
-    limit: int = 50, before: datetime | None = None,
+    limit: int = 50, before: datetime | None = None, before_id: str | None = None,
 ) -> list[ChatMessageOut]:
     """(trainer, member) 스레드 메시지(오래된→최신).
 
-    무제한 로드를 막기 위해 기본 최신 `limit`건만 가져온다(리뷰 PR 251-#3). `before`
-    (created_at 커서)를 주면 그보다 오래된 이전 페이지를 반환한다. DB 에서는 최신순으로
-    limit 만큼 조회한 뒤, 화면 표시용으로 오래된→최신으로 뒤집어 반환한다.
+    무제한 로드를 막기 위해 기본 최신 `limit`건만 가져온다(리뷰 PR 251-#3). 이전 페이지는
+    가장 오래된 메시지의 (created_at, id)를 (before, before_id) 커서로 넘겨 요청한다.
+    같은 created_at 이 여러 건이어도 누락되지 않도록 (created_at, id) 복합 커서를 쓴다
+    (리뷰 재-#1). 응답의 created_at 으로 클라이언트가 다음 커서를 만든다.
     """
     q = select(ChatMessage).where(
         ChatMessage.trainer_id == trainer_id, ChatMessage.member_id == member_id
     )
     if before is not None:
-        q = q.where(ChatMessage.created_at < before)
+        if before_id is not None:
+            # (created_at, id) < (before, before_id) — 동일 created_at 경계도 안전하게 통과
+            q = q.where(
+                tuple_(ChatMessage.created_at, ChatMessage.id) < (before, before_id)
+            )
+        else:
+            q = q.where(ChatMessage.created_at < before)
     rows = list(db.scalars(
         q.order_by(ChatMessage.created_at.desc(), ChatMessage.id.desc()).limit(limit)
     ).all())
     rows.reverse()  # 최신 limit건을 오래된→최신 순으로
     return [
         ChatMessageOut(
-            id=r.id, sender=_sender_out(r.sender), body=r.body, time_label=_hhmm(r.created_at),
+            id=r.id, sender=_sender_out(r.sender), body=r.body,
+            time_label=_hhmm(r.created_at), created_at=_iso(r.created_at),
         )
         for r in rows
     ]
@@ -339,7 +353,8 @@ def send_message(
     db.commit()
     db.refresh(msg)
     return ChatMessageOut(
-        id=msg.id, sender=_sender_out(msg.sender), body=msg.body, time_label=_hhmm(msg.created_at),
+        id=msg.id, sender=_sender_out(msg.sender), body=msg.body,
+        time_label=_hhmm(msg.created_at), created_at=_iso(msg.created_at),
     )
 
 

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -295,13 +295,25 @@ def _sender_out(sender: str) -> str:
     return "client" if sender == "member" else "trainer"
 
 
-def build_chat_thread(db: Session, trainer_id: str, member_id: str) -> list[ChatMessageOut]:
-    """(trainer, member) 스레드 메시지(오래된→최신)."""
-    rows = db.scalars(
-        select(ChatMessage)
-        .where(ChatMessage.trainer_id == trainer_id, ChatMessage.member_id == member_id)
-        .order_by(ChatMessage.created_at, ChatMessage.id)
-    ).all()
+def build_chat_thread(
+    db: Session, trainer_id: str, member_id: str,
+    limit: int = 50, before: datetime | None = None,
+) -> list[ChatMessageOut]:
+    """(trainer, member) 스레드 메시지(오래된→최신).
+
+    무제한 로드를 막기 위해 기본 최신 `limit`건만 가져온다(리뷰 PR 251-#3). `before`
+    (created_at 커서)를 주면 그보다 오래된 이전 페이지를 반환한다. DB 에서는 최신순으로
+    limit 만큼 조회한 뒤, 화면 표시용으로 오래된→최신으로 뒤집어 반환한다.
+    """
+    q = select(ChatMessage).where(
+        ChatMessage.trainer_id == trainer_id, ChatMessage.member_id == member_id
+    )
+    if before is not None:
+        q = q.where(ChatMessage.created_at < before)
+    rows = list(db.scalars(
+        q.order_by(ChatMessage.created_at.desc(), ChatMessage.id.desc()).limit(limit)
+    ).all())
+    rows.reverse()  # 최신 limit건을 오래된→최신 순으로
     return [
         ChatMessageOut(
             id=r.id, sender=_sender_out(r.sender), body=r.body, time_label=_hhmm(r.created_at),

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -8,17 +8,18 @@
 from __future__ import annotations
 
 import json
+import uuid
 from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
 
-from sqlalchemy import or_, select
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.orm import Session
 
 from app.models.models import (
     ChatMessage, DietEntry, RoutineHistory, TrainerClient, TrainerRoutine, User,
 )
 from app.schemas.trainer_api import (
-    ClientDietEntryOut, RoutineHistoryOut, TrainerClientOut,
+    ChatMessageOut, ClientDietEntryOut, RoutineHistoryOut, RoutineOut, TrainerClientOut,
 )
 
 
@@ -278,3 +279,133 @@ def build_client_history(
             trainer_note=r.trainer_note,
         ))
     return out
+
+
+# ---- 채팅 (트레이너↔회원, 양방향 공유 스레드) ----
+
+def _hhmm(ts: datetime) -> str:
+    """created_at → 로컬 HH:MM (KST 서버면 KST)."""
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts.astimezone().strftime("%H:%M")
+
+
+def _sender_out(sender: str) -> str:
+    """저장값(trainer|member) → 프론트 계약(trainer|client)."""
+    return "client" if sender == "member" else "trainer"
+
+
+def build_chat_thread(db: Session, trainer_id: str, member_id: str) -> list[ChatMessageOut]:
+    """(trainer, member) 스레드 메시지(오래된→최신)."""
+    rows = db.scalars(
+        select(ChatMessage)
+        .where(ChatMessage.trainer_id == trainer_id, ChatMessage.member_id == member_id)
+        .order_by(ChatMessage.created_at, ChatMessage.id)
+    ).all()
+    return [
+        ChatMessageOut(
+            id=r.id, sender=_sender_out(r.sender), body=r.body, time_label=_hhmm(r.created_at),
+        )
+        for r in rows
+    ]
+
+
+def send_message(
+    db: Session, trainer_id: str, member_id: str, sender: str, text: str
+) -> ChatMessageOut:
+    """스레드에 메시지 추가(sender: 'trainer'|'member'). 로스터 last_message 는
+    build_roster 가 최신 메시지를 읽어 자동 반영하므로 별도 비정규화가 없다."""
+    msg = ChatMessage(
+        id=f"chat-{uuid.uuid4().hex[:12]}",
+        trainer_id=trainer_id,
+        member_id=member_id,
+        sender=sender,
+        body=text,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(msg)
+    db.commit()
+    db.refresh(msg)
+    return ChatMessageOut(
+        id=msg.id, sender=_sender_out(msg.sender), body=msg.body, time_label=_hhmm(msg.created_at),
+    )
+
+
+def mark_thread_read(db: Session, trainer_id: str, member_id: str, reader: str) -> int:
+    """reader 가 상대방이 보낸 미확인 메시지를 읽음 처리. 반환: 읽음 처리된 건수.
+
+    reader='trainer' → 상대(member)가 보낸 미확인 메시지에 read_at 을 채운다.
+    reader='member'  → 상대(trainer)가 보낸 미확인 메시지에 read_at 을 채운다.
+    """
+    other = "member" if reader == "trainer" else "trainer"
+    result = db.execute(
+        update(ChatMessage)
+        .where(
+            ChatMessage.trainer_id == trainer_id,
+            ChatMessage.member_id == member_id,
+            ChatMessage.sender == other,
+            ChatMessage.read_at.is_(None),
+        )
+        .values(read_at=datetime.now(timezone.utc))
+    )
+    db.commit()
+    return result.rowcount or 0
+
+
+def unread_counts_for_trainer(db: Session, trainer_id: str) -> dict[str, int]:
+    """트레이너 기준 회원별 미확인(회원이 보낸 read_at NULL) 메시지 수."""
+    rows = db.execute(
+        select(ChatMessage.member_id, func.count())
+        .where(
+            ChatMessage.trainer_id == trainer_id,
+            ChatMessage.sender == "member",
+            ChatMessage.read_at.is_(None),
+        )
+        .group_by(ChatMessage.member_id)
+    ).all()
+    return {member_id: count for member_id, count in rows}
+
+
+# ---- 루틴 배정 (트레이너/AI → 회원, 양쪽에서 보이는 공유 데이터) ----
+
+def build_routines(db: Session, member_id: str, trainer_id: str) -> list[RoutineOut]:
+    """이 트레이너가 회원에게 배정한 루틴(정렬순)."""
+    rows = db.scalars(
+        select(TrainerRoutine)
+        .where(TrainerRoutine.trainer_id == trainer_id, TrainerRoutine.member_id == member_id)
+        .order_by(TrainerRoutine.sort_order, TrainerRoutine.created_at)
+    ).all()
+    return [
+        RoutineOut(
+            id=r.id, name=r.name, minutes=r.minutes, type=r.type,
+            reason=r.reason, source=r.source,
+        )
+        for r in rows
+    ]
+
+
+def assign_routine(
+    db: Session, trainer_id: str, member_id: str,
+    name: str, minutes: int, type_: str, reason: str, source: str,
+) -> RoutineOut:
+    """회원에게 루틴 배정. 로스터 last_routine 은 build_roster 가 최신 루틴을 읽어 반영."""
+    rt = TrainerRoutine(
+        id=f"rt-{uuid.uuid4().hex[:12]}",
+        trainer_id=trainer_id,
+        member_id=member_id,
+        name=name,
+        minutes=minutes,
+        type=type_,
+        reason=reason,
+        source=source,
+        # 새 루틴을 목록 끝에 붙인다(기존 시드는 0..n).
+        sort_order=int(datetime.now(timezone.utc).timestamp()),
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(rt)
+    db.commit()
+    db.refresh(rt)
+    return RoutineOut(
+        id=rt.id, name=rt.name, minutes=rt.minutes, type=rt.type,
+        reason=rt.reason, source=rt.source,
+    )

--- a/backend/tests/test_trainer_chat.py
+++ b/backend/tests/test_trainer_chat.py
@@ -177,3 +177,58 @@ def test_chat_thread_is_paginated(client, db_session):
             ChatMessage.id.in_(ids)
         ).delete(synchronize_session=False)
         db_session.commit()
+
+
+def test_chat_pagination_two_pages_contiguous(client, db_session):
+    """(created_at, id) 복합 커서로 연속 페이지 조회 시 중복·누락 없이 전체가 이어진다."""
+    from datetime import datetime, timedelta, timezone
+    from uuid import uuid4
+
+    from app.db.seed_trainer import TRAINER_ID
+    from app.models.models import ChatMessage, TrainerClient, User
+
+    mid = f"pgmember-{uuid4().hex[:6]}"
+    db_session.add(User(id=mid, email=f"{mid}@oncare.com", name="페이지회원", role="member"))
+    db_session.flush()
+    db_session.add(TrainerClient(
+        id=f"tc-pg-{mid}", trainer_id=TRAINER_ID, member_id=mid,
+        goal="x", active=True, sort_order=999,
+    ))
+    base = datetime(2021, 1, 1, tzinfo=timezone.utc)
+    ids = [f"pgc-{mid}-{i:03d}" for i in range(60)]
+    for i, cid in enumerate(ids):
+        db_session.add(ChatMessage(
+            id=cid, trainer_id=TRAINER_ID, member_id=mid, sender="member",
+            body=f"m{i}", created_at=base + timedelta(minutes=i // 2),  # 짝수쌍은 같은 created_at
+        ))
+    db_session.commit()
+    try:
+        token = _tok(client)
+        url = f"/v1/trainer/clients/{mid}/chat"
+        p1 = client.get(url, params={"limit": 25}, headers=_h(token)).json()
+        assert len(p1) == 25
+        # 이전 페이지 커서 = 이번 페이지 가장 오래된 메시지(p1[0]) 의 (created_at, id).
+        # params= 로 넘겨야 타임존 오프셋 '+' 가 올바로 인코딩된다.
+        cur = p1[0]
+        p2 = client.get(
+            url,
+            params={"limit": 25, "before": cur["created_at"], "before_id": cur["id"]},
+            headers=_h(token),
+        ).json()
+        assert len(p2) == 25
+        cur2 = p2[0]
+        p3 = client.get(
+            url,
+            params={"limit": 25, "before": cur2["created_at"], "before_id": cur2["id"]},
+            headers=_h(token),
+        ).json()
+        assert len(p3) == 10  # 60 = 25 + 25 + 10
+
+        got = [m["id"] for m in p3] + [m["id"] for m in p2] + [m["id"] for m in p1]
+        assert len(set(got)) == 60          # 중복 없음
+        assert set(got) == set(ids)          # 누락 없음
+    finally:
+        db_session.query(ChatMessage).filter(ChatMessage.member_id == mid).delete()
+        db_session.query(TrainerClient).filter(TrainerClient.member_id == mid).delete()
+        db_session.query(User).filter(User.id == mid).delete()
+        db_session.commit()

--- a/backend/tests/test_trainer_chat.py
+++ b/backend/tests/test_trainer_chat.py
@@ -127,3 +127,53 @@ def test_chat_routine_ownership_and_role(client):
         "/v1/auth/login", data={"username": email, "password": "pw!"}
     ).json()["access_token"]
     assert client.get("/v1/trainer/clients/user-jisu/chat", headers=_h(mtok)).status_code == 403
+
+
+def test_routine_assign_input_validation(client):
+    token = _tok(client)
+    url = "/v1/trainer/clients/user-jisu/routines"
+    base = {"name": "테스트 루틴", "minutes": 10, "type": "근력", "reason": "x"}
+    # 잘못된 type / source → 422 (DB 500 아님)
+    assert client.post(url, json={**base, "type": "파워"}, headers=_h(token)).status_code == 422
+    assert client.post(url, json={**base, "source": "bot"}, headers=_h(token)).status_code == 422
+    # minutes 음수/과대 → 422
+    assert client.post(url, json={**base, "minutes": -5}, headers=_h(token)).status_code == 422
+    assert client.post(url, json={**base, "minutes": 9999}, headers=_h(token)).status_code == 422
+    # name 100자 초과 / reason 200자 초과 → 422
+    assert client.post(url, json={**base, "name": "가" * 101}, headers=_h(token)).status_code == 422
+    assert client.post(url, json={**base, "reason": "가" * 201}, headers=_h(token)).status_code == 422
+    # 정상 입력은 201
+    assert client.post(url, json=base, headers=_h(token)).status_code == 201
+
+
+def test_chat_thread_is_paginated(client, db_session):
+    from datetime import datetime, timedelta, timezone
+
+    from app.db.seed_trainer import TRAINER_ID
+    from app.models.models import ChatMessage
+
+    # 오래된 메시지 60건 삽입(하루 전, 초 간격)
+    base = datetime.now(timezone.utc) - timedelta(days=1)
+    ids = [f"chat-page-{i}" for i in range(60)]
+    for i, cid in enumerate(ids):
+        db_session.add(ChatMessage(
+            id=cid, trainer_id=TRAINER_ID, member_id="user-demo",
+            sender="member", body=f"m{i}", created_at=base + timedelta(seconds=i),
+        ))
+    db_session.commit()
+    try:
+        token = _tok(client)
+        # 기본 제한 50 이하 — 오래된 메시지가 60건 있어도 한 번에 다 오지 않는다
+        msgs = client.get("/v1/trainer/clients/user-demo/chat", headers=_h(token)).json()
+        assert len(msgs) <= 50
+        # limit 쿼리 존중
+        r10 = client.get("/v1/trainer/clients/user-demo/chat?limit=10", headers=_h(token))
+        assert len(r10.json()) == 10
+        # 잘못된 before → 422
+        bad = client.get("/v1/trainer/clients/user-demo/chat?before=notadate", headers=_h(token))
+        assert bad.status_code == 422
+    finally:
+        db_session.query(ChatMessage).filter(
+            ChatMessage.id.in_(ids)
+        ).delete(synchronize_session=False)
+        db_session.commit()

--- a/backend/tests/test_trainer_chat.py
+++ b/backend/tests/test_trainer_chat.py
@@ -1,0 +1,129 @@
+"""트레이너 채팅 + 루틴 배정(#251). DB 필요(로컬 skip, CI 실행)."""
+from __future__ import annotations
+
+
+def _tok(client) -> str:
+    return client.post(
+        "/v1/auth/login",
+        data={"username": "trainer@oncare.com", "password": "oncare123"},
+    ).json()["access_token"]
+
+
+def _h(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_chat_thread_seeded_and_sender_mapped(client):
+    token = _tok(client)
+    r = client.get("/v1/trainer/clients/user-jisu/chat", headers=_h(token))
+    assert r.status_code == 200, r.text
+    msgs = r.json()
+    assert len(msgs) >= 3
+    # 오래된→최신, sender 는 trainer|client 로 노출(member→client 매핑)
+    assert msgs[0]["sender"] == "trainer"
+    assert any(m["sender"] == "client" for m in msgs)
+    assert all(m["sender"] in ("trainer", "client") for m in msgs)
+
+
+def test_send_message_reflects_in_thread_and_roster(client):
+    token = _tok(client)
+    r = client.post(
+        "/v1/trainer/clients/user-jisu/chat",
+        json={"text": "  다음 주 루틴 보냈어요!  "},
+        headers=_h(token),
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["sender"] == "trainer"
+    assert r.json()["body"] == "다음 주 루틴 보냈어요!"  # trim 확인
+
+    # 스레드 마지막에 반영
+    thread = client.get("/v1/trainer/clients/user-jisu/chat", headers=_h(token)).json()
+    assert thread[-1]["body"] == "다음 주 루틴 보냈어요!"
+
+    # 로스터 last_message 가 방금 보낸 메시지로 갱신(자동 반영)
+    roster = client.get("/v1/trainer/clients", headers=_h(token)).json()
+    jisu = next(c for c in roster if c["id"] == "user-jisu")
+    assert jisu["last_message"] == "다음 주 루틴 보냈어요!"
+
+
+def test_empty_message_rejected(client):
+    token = _tok(client)
+    r = client.post(
+        "/v1/trainer/clients/user-jisu/chat", json={"text": "   "}, headers=_h(token)
+    )
+    assert r.status_code == 400
+
+
+def test_unread_and_mark_read(client, db_session):
+    from datetime import datetime, timezone
+    from uuid import uuid4
+
+    from app.db.seed_trainer import TRAINER_ID
+    from app.models.models import ChatMessage
+
+    cid = f"chat-unreadtest-{uuid4().hex[:6]}"
+    db_session.add(ChatMessage(
+        id=cid, trainer_id=TRAINER_ID, member_id="user-sungho",
+        sender="member", body="확인 부탁드려요", created_at=datetime.now(timezone.utc),
+    ))
+    db_session.commit()
+    try:
+        token = _tok(client)
+        unread = client.get("/v1/trainer/chat/unread", headers=_h(token)).json()
+        assert unread.get("user-sungho", 0) >= 1
+
+        rd = client.post("/v1/trainer/clients/user-sungho/chat/read", headers=_h(token))
+        assert rd.status_code == 200
+        assert rd.json()["marked_read"] >= 1
+
+        unread2 = client.get("/v1/trainer/chat/unread", headers=_h(token)).json()
+        assert unread2.get("user-sungho", 0) == 0
+    finally:
+        db_session.query(ChatMessage).filter(ChatMessage.id == cid).delete()
+        db_session.commit()
+
+
+def test_routines_seeded_and_assign_updates_last_routine(client):
+    token = _tok(client)
+    # 시드된 AI 루틴
+    r = client.get("/v1/trainer/clients/user-jisu/routines", headers=_h(token))
+    assert r.status_code == 200, r.text
+    routines = r.json()
+    assert len(routines) >= 3
+    assert all(rt["type"] in ("유산소", "근력", "스트레칭") for rt in routines)
+    assert any(rt["source"] == "ai" for rt in routines)
+
+    # 트레이너가 직접 배정
+    a = client.post(
+        "/v1/trainer/clients/user-jisu/routines",
+        json={"name": "코어 서킷", "minutes": 12, "type": "근력", "reason": "복부 안정화"},
+        headers=_h(token),
+    )
+    assert a.status_code == 201, a.text
+    assert a.json()["source"] == "trainer"
+
+    after = client.get("/v1/trainer/clients/user-jisu/routines", headers=_h(token)).json()
+    assert any(rt["name"] == "코어 서킷" for rt in after)
+
+    # 로스터 last_routine 이 "오늘"로 갱신(방금 배정)
+    roster = client.get("/v1/trainer/clients", headers=_h(token)).json()
+    jisu = next(c for c in roster if c["id"] == "user-jisu")
+    assert jisu["last_routine"] == "오늘"
+
+
+def test_chat_routine_ownership_and_role(client):
+    token = _tok(client)
+    # 미담당 회원 → 404
+    assert client.get("/v1/trainer/clients/user-nobody/chat", headers=_h(token)).status_code == 404
+    assert client.get(
+        "/v1/trainer/clients/user-nobody/routines", headers=_h(token)
+    ).status_code == 404
+
+    # 회원 계정 → 403
+    from uuid import uuid4
+    email = f"m-{uuid4().hex[:8]}@oncare.com"
+    client.post("/v1/auth/register", json={"email": email, "password": "pw!", "name": "u"})
+    mtok = client.post(
+        "/v1/auth/login", data={"username": email, "password": "pw!"}
+    ).json()["access_token"]
+    assert client.get("/v1/trainer/clients/user-jisu/chat", headers=_h(mtok)).status_code == 403

--- a/backend/tests/test_trainer_service.py
+++ b/backend/tests/test_trainer_service.py
@@ -13,8 +13,9 @@ def test_latest_by_member_returns_one_row_per_member(client, db_session):
     from app.models.models import ChatMessage
     from app.services.trainer_service import _latest_by_member
 
-    # user-jisu 스레드에 메시지 5건을 서로 다른 시각으로 삽입(오래된 것 다수)
-    base = datetime.now(timezone.utc) - timedelta(hours=5)
+    # user-jisu 스레드에 메시지 5건을 삽입. 다른 테스트가 남긴 런타임 메시지보다 확실히
+    # 최신이 되도록 미래 시각으로 두어(순서 독립) 마지막(msg4)이 선택되는지 검증한다.
+    base = datetime.now(timezone.utc) + timedelta(minutes=10)
     ids = [f"chat-test-{i}" for i in range(5)]
     for i, cid in enumerate(ids):
         db_session.add(ChatMessage(


### PR DESCRIPTION
## Summary
* 트레이너↔회원 채팅(조회/발신/읽음/미확인수)과 루틴 배정(조회/배정) 추가.
* 소유권 가드 + 트레이너 전용. sender는 계약(trainer|client)으로 노출.
* 로스터의 last_message/last_routine이 실제 채팅/루틴에서 자동 반영.

## Changes
### ✨ Features
* `GET/POST /trainer/clients/{id}/chat`, `POST .../chat/read`, `GET /trainer/chat/unread`.
* `GET/POST /trainer/clients/{id}/routines`(source=trainer|ai).
* 채팅 `(created_at, id)` 복합 커서 페이지네이션, 루틴 입력 검증.

## Commits
1. `294bd78` feat: add trainer-client chat and routine assignment
2. `9555a74` fix: validate routine input and paginate chat thread
3. `ef5ec34` fix: expose chat created_at and add (created_at,id) cursor pagination

## Notes
* 채팅은 멱등키 없음(재전송 중복 허용) — 식단 저장과 다른 정책.
* **회원측 미러(내 코치/받은 루틴/채팅)는 #254 에서** 붙습니다(양방향 완성).

## Related Issues
Closes #252

## Checklist
* [ ] 코드 리뷰 준비 완료
* [ ] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인