### PR TITLE
feat(trainer-api): add trainer schedule CRUD and session-completion loop

### DIFF
--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -257,11 +257,15 @@ def trainer_update_session(
     trainer: RequireTrainer,
     db: Annotated[Session, Depends(get_db)],
 ) -> ScheduleSessionOut:
-    """예약 수정(제공된 필드만). member_id 변경 시 담당 고객이어야 한다."""
+    """예약 수정(제공된 필드만). member_id 변경 시 담당 고객이어야 한다.
+    완료된 세션은 기록과의 정합성을 위해 수정 불가(409)."""
     fields = payload.model_dump(exclude_unset=True)
     if fields.get("member_id"):
         _require_client(db, trainer.id, fields["member_id"])
-    out = trainer_service.update_session(db, trainer.id, session_id, fields)
+    try:
+        out = trainer_service.update_session(db, trainer.id, session_id, fields)
+    except trainer_service.ScheduleConflict as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
     if out is None:
         raise HTTPException(status_code=404, detail="일정을 찾을 수 없습니다.")
     return out

--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -22,7 +22,8 @@ from app.db.session import get_db
 from app.models.models import TrainerClient, TrainerProfile
 from app.schemas.trainer_api import (
     ChatMessageOut, ChatSendRequest, ClientDietEntryOut, RoutineAssignRequest, RoutineOut,
-    RoutineHistoryOut, TrainerClientOut, TrainerGymOut, TrainerMe,
+    RoutineHistoryOut, ScheduleCompleteRequest, ScheduleCreateRequest, ScheduleSessionOut,
+    ScheduleUpdateRequest, TrainerClientOut, TrainerGymOut, TrainerMe,
 )
 from app.services import trainer_service
 
@@ -207,3 +208,89 @@ def trainer_assign_routine(
         name=payload.name.strip(), minutes=payload.minutes,
         type_=payload.type, reason=payload.reason, source=payload.source,
     )
+
+
+# ---- 스케줄 (트레이너 타임라인 + 예약→수업→기록 완료 루프) ----
+
+@router.get("/trainer/schedule/booked-dates", response_model=list[str])
+def trainer_booked_dates(
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> list[str]:
+    """예약이 있는(공백 아닌) 날짜 목록 — 주간 스트립 도트용."""
+    return trainer_service.booked_dates(db, trainer.id)
+
+
+@router.get("/trainer/schedule", response_model=list[ScheduleSessionOut])
+def trainer_schedule(
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+    date: str | None = Query(None, description="YYYY-MM-DD (기본: 오늘)"),
+) -> list[ScheduleSessionOut]:
+    """하루 타임라인(시간순, 공백 포함)."""
+    day = date or trainer_service.today_iso()
+    return trainer_service.build_schedule(db, trainer.id, day)
+
+
+@router.post("/trainer/schedule", response_model=ScheduleSessionOut, status_code=201)
+def trainer_create_session(
+    payload: ScheduleCreateRequest,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> ScheduleSessionOut:
+    """예약 추가(status 예정). member_id 를 주면 담당 고객이어야 한다(아니면 404)."""
+    if payload.member_id:
+        _require_client(db, trainer.id, payload.member_id)
+    return trainer_service.create_session(
+        db, trainer.id,
+        date=payload.date, time=payload.time, client_name=payload.client_name,
+        member_id=payload.member_id, type_=payload.type,
+        duration_minutes=payload.duration_minutes, note=payload.note,
+        program=payload.program,
+    )
+
+
+@router.put("/trainer/schedule/{session_id}", response_model=ScheduleSessionOut)
+def trainer_update_session(
+    session_id: str,
+    payload: ScheduleUpdateRequest,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> ScheduleSessionOut:
+    """예약 수정(제공된 필드만). member_id 변경 시 담당 고객이어야 한다."""
+    fields = payload.model_dump(exclude_unset=True)
+    if fields.get("member_id"):
+        _require_client(db, trainer.id, fields["member_id"])
+    out = trainer_service.update_session(db, trainer.id, session_id, fields)
+    if out is None:
+        raise HTTPException(status_code=404, detail="일정을 찾을 수 없습니다.")
+    return out
+
+
+@router.delete("/trainer/schedule/{session_id}")
+def trainer_delete_session(
+    session_id: str,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> dict:
+    """예약 삭제."""
+    if not trainer_service.delete_session(db, trainer.id, session_id):
+        raise HTTPException(status_code=404, detail="일정을 찾을 수 없습니다.")
+    return {"status": "deleted"}
+
+
+@router.post("/trainer/schedule/{session_id}/complete", response_model=ScheduleSessionOut)
+def trainer_complete_session(
+    session_id: str,
+    payload: ScheduleCompleteRequest,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> ScheduleSessionOut:
+    """세션 완료(예정→완료). 매칭된 회원이 있으면 운동기록으로 적재."""
+    try:
+        out = trainer_service.complete_session(db, trainer.id, session_id, payload.note)
+    except trainer_service.ScheduleError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    if out is None:
+        raise HTTPException(status_code=404, detail="일정을 찾을 수 없습니다.")
+    return out

--- a/backend/app/db/seed_member_data.py
+++ b/backend/app/db/seed_member_data.py
@@ -145,6 +145,32 @@ _ROUTINES: dict[str, list[tuple[str, int, str, str]]] = {
 }
 
 
+# 트레이너 오늘 타임라인 (time, client, member_id, type, duration, status, note, program).
+# member_id 는 유효 회원일 때만 연결(아니면 표시용 이름만). 프론트 TRAINER_SCHEDULE 정렬.
+_SCHEDULE: list[tuple[str, str, str | None, str, int, str, str, list[dict]]] = [
+    ("10:00", "김민수", "user-demo", "1:1 PT", 60, "완료", "무릎 컨디션 양호. 레그프레스 중량 소폭 증가 가능.", [
+        {"name": "레그프레스", "sets": 3, "reps": "12회", "weight": "80kg"},
+        {"name": "레그컬", "sets": 3, "reps": "12회", "weight": "40kg"},
+        {"name": "카프레이즈", "sets": 3, "reps": "20회", "weight": "자체중량"},
+        {"name": "하체 스트레칭", "sets": 1, "reps": "10분", "weight": "-"},
+    ]),
+    ("12:00", "이지수", "user-jisu", "1:1 PT", 50, "완료", "데드리프트 자세 안정적. 다음 세션 60kg 도전.", [
+        {"name": "데드리프트", "sets": 4, "reps": "8회", "weight": "55kg"},
+        {"name": "루마니안 데드리프트", "sets": 3, "reps": "10회", "weight": "40kg"},
+        {"name": "플랭크", "sets": 3, "reps": "45초", "weight": "-"},
+        {"name": "코어 서킷", "sets": 2, "reps": "12회", "weight": "-"},
+    ]),
+    ("14:00", "", None, "", 0, "공백", "", []),
+    ("15:00", "박성호", "user-sungho", "1:1 PT", 60, "예정", "", [
+        {"name": "벤치프레스", "sets": 4, "reps": "8회", "weight": "65kg"},
+        {"name": "인클라인 덤벨 프레스", "sets": 3, "reps": "10회", "weight": "26kg"},
+        {"name": "트라이셉스 딥", "sets": 3, "reps": "12회", "weight": "-"},
+    ]),
+    ("17:00", "신규 회원", None, "상담", 30, "예정", "", []),
+    ("19:00", "", None, "", 0, "공백", "", []),
+]
+
+
 def seed_member_health_data() -> None:
     db: Session = SessionLocal()
     try:
@@ -157,8 +183,47 @@ def seed_member_health_data() -> None:
             _seed_history(db, user_id)
             _seed_chat(db, user_id)
             _seed_routines(db, user_id)
+        _seed_schedule(db, valid)
     finally:
         db.close()
+
+
+def _seed_schedule(db: Session, valid: set[str]) -> None:
+    """트레이너 오늘 타임라인 시드(멱등, 날짜 인식). 트레이너 계정이 없으면 스킵."""
+    if db.scalar(
+        select(models.User.id).where(
+            models.User.id == TRAINER_ID, models.User.role == "trainer"
+        )
+    ) is None:
+        return
+    today = date.today().isoformat()
+    # 오늘 스케줄이 이미 있으면 스킵(날짜 넘어가면 새로 시드)
+    if db.scalar(
+        select(models.TrainerSchedule.id)
+        .where(
+            models.TrainerSchedule.trainer_id == TRAINER_ID,
+            models.TrainerSchedule.date == today,
+        )
+        .limit(1)
+    ) is not None:
+        return
+    for i, (time, cname, mid, typ, dur, status, note, program) in enumerate(_SCHEDULE):
+        member_id = mid if (mid and mid in valid) else None
+        db.add(models.TrainerSchedule(
+            id=f"seed-schedule-{today}-{i}",
+            trainer_id=TRAINER_ID,
+            member_id=member_id,
+            date=today,
+            time=time,
+            client_name=cname,
+            type=typ,
+            duration_minutes=dur,
+            status=status,
+            note=note,
+            program_json=json.dumps(program, ensure_ascii=False),
+            sort_order=i,
+        ))
+    db.commit()
 
 
 def _seed_chat(db: Session, member_id: str) -> None:

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -6,9 +6,26 @@ GET /trainer/me 응답:
 """
 from __future__ import annotations
 
+from datetime import date as _date, datetime as _datetime
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+
+def _validate_ymd(v: str) -> str:
+    try:
+        _date.fromisoformat(v)  # 2026-99-99 / 2026-02-31 등 달력상 불가능한 값 거부
+    except ValueError as e:
+        raise ValueError("유효한 날짜(YYYY-MM-DD)가 아닙니다.") from e
+    return v
+
+
+def _validate_hhmm(v: str) -> str:
+    try:
+        _datetime.strptime(v, "%H:%M")  # 25:99 / 빈 문자열 등 거부
+    except ValueError as e:
+        raise ValueError("유효한 시간(HH:MM)이 아닙니다.") from e
+    return v
 
 
 class TrainerGymOut(BaseModel):
@@ -140,7 +157,7 @@ class ScheduleSessionOut(BaseModel):
 
 
 class ScheduleCreateRequest(BaseModel):
-    date: str = Field(pattern=r"^\d{4}-\d{2}-\d{2}$")
+    date: str = Field(max_length=10)
     time: str = Field(max_length=10)
     client_name: str = Field(default="", max_length=100)
     member_id: str | None = Field(default=None, max_length=64)
@@ -148,6 +165,9 @@ class ScheduleCreateRequest(BaseModel):
     duration_minutes: int = Field(default=0, ge=0, le=600)
     note: str = Field(default="", max_length=500)
     program: list[ProgramItem] = Field(default_factory=list, max_length=30)
+
+    _v_date = field_validator("date")(_validate_ymd)
+    _v_time = field_validator("time")(_validate_hhmm)
 
 
 class ScheduleUpdateRequest(BaseModel):
@@ -159,6 +179,11 @@ class ScheduleUpdateRequest(BaseModel):
     duration_minutes: int | None = Field(default=None, ge=0, le=600)
     note: str | None = Field(default=None, max_length=500)
     program: list[ProgramItem] | None = Field(default=None, max_length=30)
+
+    @field_validator("time")
+    @classmethod
+    def _v_time(cls, v: str | None) -> str | None:
+        return _validate_hhmm(v) if v is not None else v
 
 
 class ScheduleCompleteRequest(BaseModel):

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -111,3 +111,55 @@ class RoutineAssignRequest(BaseModel):
     type: RoutineType
     reason: str = Field(default="", max_length=200)
     source: Literal["trainer", "ai"] = "trainer"
+
+
+# ---- 스케줄 (트레이너 타임라인 + 예약→수업→기록 루프) ----
+
+ScheduleStatus = Literal["예정", "완료", "공백"]
+
+
+class ProgramItem(BaseModel):
+    """세션 프로그램 한 항목 — 프론트 ProgramItem 계약({name,sets,reps,weight})."""
+    name: str = Field(min_length=1, max_length=100)
+    sets: int = Field(default=0, ge=0, le=99)
+    reps: str = Field(default="", max_length=30)
+    weight: str = Field(default="", max_length=30)
+
+
+class ScheduleSessionOut(BaseModel):
+    """스케줄 슬롯 — 프론트 ScheduleSession 계약 정렬."""
+    id: str
+    date: str
+    time: str
+    client_name: str
+    type: str
+    duration_minutes: int
+    status: str          # 예정|완료|공백
+    note: str
+    program: list[ProgramItem]
+
+
+class ScheduleCreateRequest(BaseModel):
+    date: str = Field(pattern=r"^\d{4}-\d{2}-\d{2}$")
+    time: str = Field(max_length=10)
+    client_name: str = Field(default="", max_length=100)
+    member_id: str | None = Field(default=None, max_length=64)
+    type: str = Field(default="", max_length=30)
+    duration_minutes: int = Field(default=0, ge=0, le=600)
+    note: str = Field(default="", max_length=500)
+    program: list[ProgramItem] = Field(default_factory=list, max_length=30)
+
+
+class ScheduleUpdateRequest(BaseModel):
+    """부분 수정 — 제공된 필드만 반영."""
+    time: str | None = Field(default=None, max_length=10)
+    client_name: str | None = Field(default=None, max_length=100)
+    member_id: str | None = Field(default=None, max_length=64)
+    type: str | None = Field(default=None, max_length=30)
+    duration_minutes: int | None = Field(default=None, ge=0, le=600)
+    note: str | None = Field(default=None, max_length=500)
+    program: list[ProgramItem] | None = Field(default=None, max_length=30)
+
+
+class ScheduleCompleteRequest(BaseModel):
+    note: str = Field(default="", max_length=500)

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -16,10 +16,11 @@ from sqlalchemy import func, or_, select, tuple_, update
 from sqlalchemy.orm import Session
 
 from app.models.models import (
-    ChatMessage, DietEntry, RoutineHistory, TrainerClient, TrainerRoutine, User,
+    ChatMessage, DietEntry, RoutineHistory, TrainerClient, TrainerRoutine, TrainerSchedule, User,
 )
 from app.schemas.trainer_api import (
-    ChatMessageOut, ClientDietEntryOut, RoutineHistoryOut, RoutineOut, TrainerClientOut,
+    ChatMessageOut, ClientDietEntryOut, ProgramItem, RoutineHistoryOut, RoutineOut,
+    ScheduleSessionOut, TrainerClientOut,
 )
 
 
@@ -436,3 +437,181 @@ def assign_routine(
         id=rt.id, name=rt.name, minutes=rt.minutes, type=rt.type,
         reason=rt.reason, source=rt.source,
     )
+
+
+# ---- 스케줄 (트레이너 타임라인 + 예약→수업→기록 완료 루프) ----
+
+class ScheduleError(ValueError):
+    """스케줄 도메인 오류(라우터가 400 으로 변환)."""
+
+
+def _program_items(program_json: str) -> list[ProgramItem]:
+    try:
+        raw = json.loads(program_json) if program_json else []
+    except json.JSONDecodeError:
+        raw = []
+    out: list[ProgramItem] = []
+    for m in raw:
+        if not isinstance(m, dict):
+            continue
+        out.append(ProgramItem(
+            name=str(m.get("name", "") or "-"),
+            sets=int(m.get("sets", 0) or 0),
+            reps=str(m.get("reps", "")),
+            weight=str(m.get("weight", "")),
+        ))
+    return out
+
+
+def _schedule_out(s: TrainerSchedule) -> ScheduleSessionOut:
+    return ScheduleSessionOut(
+        id=s.id, date=s.date, time=s.time, client_name=s.client_name,
+        type=s.type, duration_minutes=s.duration_minutes, status=s.status,
+        note=s.note, program=_program_items(s.program_json),
+    )
+
+
+def build_schedule(db: Session, trainer_id: str, day: str) -> list[ScheduleSessionOut]:
+    """하루 타임라인(시간순, 공백 포함)."""
+    rows = db.scalars(
+        select(TrainerSchedule)
+        .where(TrainerSchedule.trainer_id == trainer_id, TrainerSchedule.date == day)
+        .order_by(TrainerSchedule.time, TrainerSchedule.sort_order)
+    ).all()
+    return [_schedule_out(s) for s in rows]
+
+
+def booked_dates(db: Session, trainer_id: str) -> list[str]:
+    """예약이 있는(공백 아닌) 날짜 목록 — 주간 스트립 도트용."""
+    rows = db.scalars(
+        select(TrainerSchedule.date)
+        .where(TrainerSchedule.trainer_id == trainer_id, TrainerSchedule.status != "공백")
+        .distinct()
+    ).all()
+    return sorted(rows)
+
+
+def _get_owned_session(db: Session, trainer_id: str, session_id: str) -> TrainerSchedule | None:
+    s = db.get(TrainerSchedule, session_id)
+    if s is None or s.trainer_id != trainer_id:
+        return None
+    return s
+
+
+def create_session(
+    db: Session, trainer_id: str, *, date: str, time: str, client_name: str,
+    member_id: str | None, type_: str, duration_minutes: int, note: str,
+    program: list[ProgramItem],
+) -> ScheduleSessionOut:
+    s = TrainerSchedule(
+        id=f"sched-{uuid.uuid4().hex[:12]}",
+        trainer_id=trainer_id,
+        member_id=member_id,
+        date=date,
+        time=time,
+        client_name=client_name,
+        type=type_,
+        duration_minutes=duration_minutes,
+        status="예정",
+        note=note,
+        program_json=json.dumps([p.model_dump() for p in program], ensure_ascii=False),
+        sort_order=0,
+    )
+    db.add(s)
+    db.commit()
+    db.refresh(s)
+    return _schedule_out(s)
+
+
+def update_session(
+    db: Session, trainer_id: str, session_id: str, fields: dict
+) -> ScheduleSessionOut | None:
+    """예약 부분 수정. 소유 슬롯이 아니면 None(라우터 404)."""
+    s = _get_owned_session(db, trainer_id, session_id)
+    if s is None:
+        return None
+    if "time" in fields:
+        s.time = fields["time"]
+    if "client_name" in fields:
+        s.client_name = fields["client_name"]
+    if "member_id" in fields:
+        s.member_id = fields["member_id"]
+    if "type" in fields:
+        s.type = fields["type"]
+    if "duration_minutes" in fields:
+        s.duration_minutes = fields["duration_minutes"]
+    if "note" in fields:
+        s.note = fields["note"]
+    if "program" in fields and fields["program"] is not None:
+        s.program_json = json.dumps(
+            [p.model_dump() for p in fields["program"]], ensure_ascii=False
+        )
+    db.commit()
+    db.refresh(s)
+    return _schedule_out(s)
+
+
+def delete_session(db: Session, trainer_id: str, session_id: str) -> bool:
+    s = _get_owned_session(db, trainer_id, session_id)
+    if s is None:
+        return False
+    db.delete(s)
+    db.commit()
+    return True
+
+
+def complete_session(
+    db: Session, trainer_id: str, session_id: str, note: str
+) -> ScheduleSessionOut | None:
+    """예정→완료. 매칭된 회원이 있으면 운동기록(RoutineHistory)으로 적재해
+    '예약→수업→기록' 루프를 닫는다.
+
+    - 소유 슬롯 아님 → None(404).
+    - 공백/미래 일정 → ScheduleError(400).
+    - 이미 완료 → 그대로 반환(멱등, 중복 기록 없음).
+    기록 id 는 슬롯 기준 결정론적(sched-hist-{id})이라 동시/재호출에도 중복되지 않는다.
+    """
+    s = _get_owned_session(db, trainer_id, session_id)
+    if s is None:
+        return None
+    if s.status == "공백":
+        raise ScheduleError("빈 슬롯은 완료할 수 없습니다.")
+    if s.date > _today().isoformat():
+        raise ScheduleError("미래 일정은 완료할 수 없습니다.")
+    if s.status == "완료":
+        return _schedule_out(s)  # 멱등 no-op
+
+    # 조건부 전환(예정 → 완료). rowcount==1 인 호출만 '방금 전환한' 것이므로 그 호출만
+    # 운동기록을 쓴다 — 동시 완료 요청이 둘 다 예정을 보고 중복 기록하는 것을 막는다.
+    values: dict = {"status": "완료"}
+    if note:
+        values["note"] = note
+    changed = db.execute(
+        update(TrainerSchedule)
+        .where(TrainerSchedule.id == session_id, TrainerSchedule.status == "예정")
+        .values(**values)
+    ).rowcount
+    if changed != 1:
+        db.commit()
+        db.refresh(s)
+        return _schedule_out(s)  # 동시 호출이 먼저 완료 처리함 — 기록 없이 현재 상태 반환
+
+    if s.member_id:
+        program = _program_items(s.program_json)
+        exercises = [
+            f"{p.name} {p.sets}세트" if p.sets > 1 else f"{p.name} {p.reps}".strip()
+            for p in program
+        ]
+        db.add(RoutineHistory(
+            id=f"sched-hist-{s.id}",
+            member_id=s.member_id,
+            trainer_id=trainer_id,
+            date=s.date,
+            kind_label="PT 세션 · 트레이너 지도",
+            completion_rate=100,
+            exercises_json=json.dumps(exercises, ensure_ascii=False),
+            trainer_note=note,
+        ))
+    db.commit()
+    db.refresh(s)
+    return _schedule_out(s)

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -445,6 +445,10 @@ class ScheduleError(ValueError):
     """스케줄 도메인 오류(라우터가 400 으로 변환)."""
 
 
+class ScheduleConflict(Exception):
+    """완료 세션 수정 등 상태 충돌(라우터가 409 로 변환)."""
+
+
 def _program_items(program_json: str) -> list[ProgramItem]:
     try:
         raw = json.loads(program_json) if program_json else []
@@ -526,10 +530,16 @@ def create_session(
 def update_session(
     db: Session, trainer_id: str, session_id: str, fields: dict
 ) -> ScheduleSessionOut | None:
-    """예약 부분 수정. 소유 슬롯이 아니면 None(라우터 404)."""
+    """예약 부분 수정. 소유 슬롯이 아니면 None(라우터 404).
+
+    완료된 세션은 이미 회원 운동기록(RoutineHistory)으로 적재됐다. 이후 member_id·program·
+    note 등을 바꾸면 스케줄과 기록이 어긋나므로(리뷰 재-#2), 완료 세션 수정은 409 로 거부한다.
+    """
     s = _get_owned_session(db, trainer_id, session_id)
     if s is None:
         return None
+    if s.status == "완료":
+        raise ScheduleConflict("완료된 세션은 수정할 수 없습니다.")
     if "time" in fields:
         s.time = fields["time"]
     if "client_name" in fields:

--- a/backend/tests/test_trainer_schedule.py
+++ b/backend/tests/test_trainer_schedule.py
@@ -1,0 +1,161 @@
+"""트레이너 스케줄 CRUD + 예약→수업→기록 완료 루프(#252). DB 필요."""
+from __future__ import annotations
+
+
+def _tok(client) -> str:
+    return client.post(
+        "/v1/auth/login",
+        data={"username": "trainer@oncare.com", "password": "oncare123"},
+    ).json()["access_token"]
+
+
+def _h(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _today() -> str:
+    from datetime import date
+    return date.today().isoformat()
+
+
+def test_schedule_seeded_timeline(client):
+    token = _tok(client)
+    r = client.get("/v1/trainer/schedule", headers=_h(token))
+    assert r.status_code == 200, r.text
+    slots = r.json()
+    assert len(slots) >= 6
+    # 시간순 정렬
+    times = [s["time"] for s in slots]
+    assert times == sorted(times)
+    # 공백 슬롯 + program 포함 슬롯 존재
+    assert any(s["status"] == "공백" for s in slots)
+    assert any(len(s["program"]) > 0 for s in slots)
+
+
+def test_schedule_crud(client):
+    token = _tok(client)
+    # 생성(예정)
+    c = client.post(
+        "/v1/trainer/schedule",
+        json={
+            "date": _today(), "time": "16:00", "client_name": "이지수",
+            "member_id": "user-jisu", "type": "1:1 PT", "duration_minutes": 45,
+            "program": [{"name": "스쿼트", "sets": 3, "reps": "10회", "weight": "40kg"}],
+        },
+        headers=_h(token),
+    )
+    assert c.status_code == 201, c.text
+    sid = c.json()["id"]
+    assert c.json()["status"] == "예정"
+
+    # 수정
+    u = client.put(
+        f"/v1/trainer/schedule/{sid}",
+        json={"time": "16:30", "duration_minutes": 50},
+        headers=_h(token),
+    )
+    assert u.status_code == 200, u.text
+    assert u.json()["time"] == "16:30"
+    assert u.json()["duration_minutes"] == 50
+
+    # 삭제
+    d = client.delete(f"/v1/trainer/schedule/{sid}", headers=_h(token))
+    assert d.status_code == 200
+    # 삭제 후 다시 삭제 → 404
+    assert client.delete(f"/v1/trainer/schedule/{sid}", headers=_h(token)).status_code == 404
+
+
+def test_schedule_create_with_unlinked_member_404(client):
+    token = _tok(client)
+    r = client.post(
+        "/v1/trainer/schedule",
+        json={"date": _today(), "time": "11:00", "member_id": "user-nobody"},
+        headers=_h(token),
+    )
+    assert r.status_code == 404
+
+
+def test_complete_session_logs_history_and_is_idempotent(client):
+    token = _tok(client)
+    # 오늘 예정 세션 생성(user-jisu 매칭)
+    c = client.post(
+        "/v1/trainer/schedule",
+        json={
+            "date": _today(), "time": "18:30", "client_name": "이지수",
+            "member_id": "user-jisu", "type": "1:1 PT", "duration_minutes": 40,
+            "program": [
+                {"name": "레그프레스", "sets": 3, "reps": "12회", "weight": "80kg"},
+                {"name": "카프레이즈", "sets": 1, "reps": "20회", "weight": "-"},
+            ],
+        },
+        headers=_h(token),
+    )
+    sid = c.json()["id"]
+
+    before = client.get("/v1/trainer/clients/user-jisu/history", headers=_h(token)).json()
+    n_before = len(before)
+
+    # 완료 처리 → 완료 상태 + 운동기록 1건 추가
+    done = client.post(
+        f"/v1/trainer/schedule/{sid}/complete",
+        json={"note": "잘 마쳤어요"}, headers=_h(token),
+    )
+    assert done.status_code == 200, done.text
+    assert done.json()["status"] == "완료"
+
+    after = client.get("/v1/trainer/clients/user-jisu/history", headers=_h(token)).json()
+    assert len(after) == n_before + 1
+    assert after[0]["label"] == "PT 세션 · 트레이너 지도"
+    assert after[0]["trainer_note"] == "잘 마쳤어요"
+    assert "레그프레스 3세트" in after[0]["exercises"]
+
+    # 재호출(멱등) → 상태 유지, 기록 중복 없음
+    again = client.post(
+        f"/v1/trainer/schedule/{sid}/complete", json={"note": "x"}, headers=_h(token)
+    )
+    assert again.status_code == 200
+    after2 = client.get("/v1/trainer/clients/user-jisu/history", headers=_h(token)).json()
+    assert len(after2) == n_before + 1  # 중복 기록 없음
+
+
+def test_complete_future_session_rejected(client):
+    from datetime import date, timedelta
+
+    token = _tok(client)
+    future = (date.today() + timedelta(days=3)).isoformat()
+    c = client.post(
+        "/v1/trainer/schedule",
+        json={"date": future, "time": "10:00", "member_id": "user-jisu", "type": "1:1 PT"},
+        headers=_h(token),
+    )
+    sid = c.json()["id"]
+    r = client.post(f"/v1/trainer/schedule/{sid}/complete", json={}, headers=_h(token))
+    assert r.status_code == 400  # 미래 일정 완료 불가
+
+
+def test_schedule_ownership_and_role(client):
+    token = _tok(client)
+    # 없는 일정 완료/수정 → 404
+    assert client.post(
+        "/v1/trainer/schedule/nope/complete", json={}, headers=_h(token)
+    ).status_code == 404
+    assert client.put(
+        "/v1/trainer/schedule/nope", json={"time": "09:00"}, headers=_h(token)
+    ).status_code == 404
+
+    # 회원 계정 → 403
+    from uuid import uuid4
+    email = f"m-{uuid4().hex[:8]}@oncare.com"
+    client.post("/v1/auth/register", json={"email": email, "password": "pw!", "name": "u"})
+    mtok = client.post(
+        "/v1/auth/login", data={"username": email, "password": "pw!"}
+    ).json()["access_token"]
+    assert client.get("/v1/trainer/schedule", headers=_h(mtok)).status_code == 403
+
+
+def test_booked_dates(client):
+    token = _tok(client)
+    r = client.get("/v1/trainer/schedule/booked-dates", headers=_h(token))
+    assert r.status_code == 200, r.text
+    dates = r.json()
+    assert _today() in dates  # 오늘 시드에 예약(공백 아님)이 있음

--- a/backend/tests/test_trainer_schedule.py
+++ b/backend/tests/test_trainer_schedule.py
@@ -159,3 +159,50 @@ def test_booked_dates(client):
     assert r.status_code == 200, r.text
     dates = r.json()
     assert _today() in dates  # 오늘 시드에 예약(공백 아님)이 있음
+
+
+def test_completed_session_cannot_be_edited(client):
+    """완료된 세션 수정은 409 — 스케줄과 운동기록이 어긋나지 않게 한다(리뷰 재-#2)."""
+    token = _tok(client)
+    c = client.post(
+        "/v1/trainer/schedule",
+        json={
+            "date": _today(), "time": "08:30", "client_name": "이지수",
+            "member_id": "user-jisu", "type": "1:1 PT",
+            "program": [{"name": "스쿼트", "sets": 3, "reps": "10회", "weight": "40kg"}],
+        },
+        headers=_h(token),
+    )
+    sid = c.json()["id"]
+    client.post(f"/v1/trainer/schedule/{sid}/complete", json={"note": "완료"}, headers=_h(token))
+
+    # 완료 후 다른 회원으로 재배정 시도 → 409(데이터 분리 방지)
+    r = client.put(
+        f"/v1/trainer/schedule/{sid}", json={"member_id": "user-sungho"}, headers=_h(token)
+    )
+    assert r.status_code == 409
+    # note 등 다른 필드 수정도 409
+    assert client.put(
+        f"/v1/trainer/schedule/{sid}", json={"note": "바꿈"}, headers=_h(token)
+    ).status_code == 409
+    # 기록은 여전히 원래 회원(user-jisu)에 남아 있고 sungho 로 옮겨가지 않았다
+    jisu_hist = client.get("/v1/trainer/clients/user-jisu/history", headers=_h(token)).json()
+    assert any(h["label"] == "PT 세션 · 트레이너 지도" for h in jisu_hist)
+
+
+def test_schedule_invalid_date_time_422(client):
+    """달력상 불가능한 날짜/시간은 create·update 모두 422(DB 저장 방지, 리뷰 재-#4)."""
+    token = _tok(client)
+    base = {"date": _today(), "time": "10:00", "type": "1:1 PT"}
+    url = "/v1/trainer/schedule"
+    # 잘못된 날짜
+    assert client.post(url, json={**base, "date": "2026-99-99"}, headers=_h(token)).status_code == 422
+    assert client.post(url, json={**base, "date": "2026-02-31"}, headers=_h(token)).status_code == 422
+    # 잘못된/빈 시간
+    assert client.post(url, json={**base, "time": "25:99"}, headers=_h(token)).status_code == 422
+    assert client.post(url, json={**base, "time": ""}, headers=_h(token)).status_code == 422
+    # update 도 잘못된 시간 422
+    sid = client.post(url, json=base, headers=_h(token)).json()["id"]
+    assert client.put(
+        f"{url}/{sid}", json={"time": "99:99"}, headers=_h(token)
+    ).status_code == 422


### PR DESCRIPTION
## Summary
* 트레이너 타임라인(조회/예약날짜)·예약 CRUD·예약→수업→기록 완료 루프 추가.
* 완료는 조건부 UPDATE로 예정→완료 전환 + 매칭 회원 운동기록을 **정확히 1회** 적재.
* 새 마이그레이션 없음(TrainerSchedule는 #249의 `0012`에 포함).

## Changes
### ✨ Features
* `GET /trainer/schedule?date=`, `GET /trainer/schedule/booked-dates`.
* `POST/PUT/DELETE /trainer/schedule[/{id}]`(소유권 404).
* `POST /trainer/schedule/{id}/complete` — 예정→완료, 회원 매칭 시 RoutineHistory 적재.

### 🔧 Improvements
* 조건부 UPDATE(rowcount==1)로 동시 완료 중복 기록 차단 + 결정론적 기록 id.
* 완료 세션 수정은 409(기록 정합성), 미래/공백 완료 400.

## Commits
1. `4216378` feat: add trainer schedule CRUD and session-completion loop
2. `1dd57be` fix: reject editing completed sessions (409) and validate schedule date/time

## Notes
* 완료 처리 멱등(재호출 시 상태 유지, 중복 기록 없음).

## Related Issues
Closes #253

## Checklist
* [ ] 코드 리뷰 준비 완료
* [ ] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인