### PR TITLE
feat(member-api): add member-side coach mirror (coach, routines, chat, sessions)

### DIFF
--- a/backend/app/api/v1/member_coach.py
+++ b/backend/app/api/v1/member_coach.py
@@ -1,0 +1,121 @@
+"""
+회원측 트레이너 미러 — 회원 앱이 '내 담당 코치'와 상호작용하는 엔드포인트.
+
+트레이너 앱(#251/#252)이 쓰는 것과 같은 공유 테이블(ChatMessage, TrainerRoutine,
+TrainerSchedule, TrainerClient)을 회원 관점으로 읽고 쓴다. 이로써 트레이너↔회원
+상호작용이 양방향으로 닫힌다(트레이너 발신→회원 수신, 회원 발신→트레이너 로스터 반영).
+
+읽기는 CurrentUser(회원, 데모 폴백 허용, 트레이너 토큰 403)로, 쓰기는 RequireMember
+(엄격, 트레이너 계정 차단)로 보호한다.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.api.deps import CurrentUser, RequireMember
+from app.db.session import get_db
+from app.schemas.trainer_api import (
+    ChatMessageOut, ChatSendRequest, MemberCoachOut, RoutineOut, ScheduleSessionOut,
+)
+from app.services import trainer_service
+
+router = APIRouter(tags=["member-coach"])
+
+
+def _my_trainer_or_404(db: Session, member_id: str) -> str:
+    trainer_id = trainer_service.get_member_trainer_id(db, member_id)
+    if trainer_id is None:
+        raise HTTPException(status_code=404, detail="담당 트레이너가 없습니다.")
+    return trainer_id
+
+
+@router.get("/me/coach", response_model=MemberCoachOut)
+def my_coach(
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> MemberCoachOut:
+    """내 담당 트레이너 요약."""
+    coach = trainer_service.build_member_coach(db, current_user.id)
+    if coach is None:
+        raise HTTPException(status_code=404, detail="담당 트레이너가 없습니다.")
+    return coach
+
+
+@router.get("/me/coach/routines", response_model=list[RoutineOut])
+def my_routines(
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> list[RoutineOut]:
+    """트레이너/AI가 나에게 배정한 루틴."""
+    return trainer_service.build_member_routines(db, current_user.id)
+
+
+@router.get("/me/coach/sessions", response_model=list[ScheduleSessionOut])
+def my_sessions(
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> list[ScheduleSessionOut]:
+    """내 PT 세션(담당 트레이너 스케줄에서 나와 매칭된 것), 최신순."""
+    return trainer_service.build_member_sessions(db, current_user.id)
+
+
+@router.get("/me/coach/chat", response_model=list[ChatMessageOut])
+def my_chat(
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+    limit: int = Query(50, ge=1, le=100),
+    before: str | None = Query(None, description="ISO datetime 커서(이전 페이지)"),
+) -> list[ChatMessageOut]:
+    """담당 트레이너와의 채팅(오래된→최신). 발신자는 회원 관점(me|trainer)."""
+    trainer_id = _my_trainer_or_404(db, current_user.id)
+    before_dt: datetime | None = None
+    if before:
+        try:
+            before_dt = datetime.fromisoformat(before)
+        except ValueError as e:
+            raise HTTPException(status_code=422, detail="before 는 ISO datetime 이어야 합니다.") from e
+    return trainer_service.build_chat_thread(
+        db, trainer_id, current_user.id, limit=limit, before=before_dt, viewer="member",
+    )
+
+
+@router.get("/me/coach/chat/unread", response_model=dict)
+def my_unread(
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> dict:
+    """트레이너가 보낸 미확인 메시지 수."""
+    trainer_id = trainer_service.get_member_trainer_id(db, current_user.id)
+    count = trainer_service.member_unread_count(db, trainer_id, current_user.id) if trainer_id else 0
+    return {"unread": count}
+
+
+@router.post("/me/coach/chat", response_model=ChatMessageOut, status_code=201)
+def send_to_coach(
+    payload: ChatSendRequest,
+    member: RequireMember,
+    db: Annotated[Session, Depends(get_db)],
+) -> ChatMessageOut:
+    """회원이 담당 트레이너에게 메시지 발신(트레이너 로스터 last_message 에 자동 반영)."""
+    trainer_id = _my_trainer_or_404(db, member.id)
+    text = payload.text.strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="빈 메시지는 보낼 수 없습니다.")
+    return trainer_service.send_message(
+        db, trainer_id, member.id, "member", text, viewer="member",
+    )
+
+
+@router.post("/me/coach/chat/read")
+def mark_coach_chat_read(
+    member: RequireMember,
+    db: Annotated[Session, Depends(get_db)],
+) -> dict:
+    """담당 트레이너 스레드를 읽음 처리(트레이너 발신 메시지)."""
+    trainer_id = _my_trainer_or_404(db, member.id)
+    n = trainer_service.mark_thread_read(db, trainer_id, member.id, "member")
+    return {"marked_read": n}

--- a/backend/app/api/v1/member_coach.py
+++ b/backend/app/api/v1/member_coach.py
@@ -68,7 +68,8 @@ def my_chat(
     current_user: CurrentUser,
     db: Annotated[Session, Depends(get_db)],
     limit: int = Query(50, ge=1, le=100),
-    before: str | None = Query(None, description="ISO datetime 커서(이전 페이지)"),
+    before: str | None = Query(None, description="ISO datetime 커서(이전 페이지, 응답 created_at)"),
+    before_id: str | None = Query(None, description="복합 커서 tie-break — 이전 페이지 가장 오래된 id"),
 ) -> list[ChatMessageOut]:
     """담당 트레이너와의 채팅(오래된→최신). 발신자는 회원 관점(me|trainer)."""
     trainer_id = _my_trainer_or_404(db, current_user.id)
@@ -79,7 +80,8 @@ def my_chat(
         except ValueError as e:
             raise HTTPException(status_code=422, detail="before 는 ISO datetime 이어야 합니다.") from e
     return trainer_service.build_chat_thread(
-        db, trainer_id, current_user.id, limit=limit, before=before_dt, viewer="member",
+        db, trainer_id, current_user.id,
+        limit=limit, before=before_dt, before_id=before_id, viewer="member",
     )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.v1 import (
-    ai_coach, coach_docs, dashboard, diet, exercise, notifications, places, schedule, social, system, trainer, users, vitals,
+    ai_coach, coach_docs, dashboard, diet, exercise, member_coach, notifications, places, schedule, social, system, trainer, users, vitals,
 )
 from app.core.config import get_settings
 from app.db.init_db import init_db
@@ -80,3 +80,4 @@ app.include_router(places.router, prefix=settings.api_v1_prefix)
 app.include_router(ai_coach.router, prefix=settings.api_v1_prefix)
 app.include_router(coach_docs.router, prefix=settings.api_v1_prefix)
 app.include_router(trainer.router, prefix=settings.api_v1_prefix)
+app.include_router(member_coach.router, prefix=settings.api_v1_prefix)

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -188,3 +188,16 @@ class ScheduleUpdateRequest(BaseModel):
 
 class ScheduleCompleteRequest(BaseModel):
     note: str = Field(default="", max_length=500)
+
+
+# ---- 회원측 미러 (내 담당 코치 / 받은 루틴 / 채팅) ----
+
+class MemberCoachOut(BaseModel):
+    """회원 앱의 '내 담당 트레이너' 요약."""
+    trainer_id: str
+    name: str
+    specialty: str
+    career: str          # "7년"
+    intro: str
+    gym: TrainerGymOut
+    goal: str            # 트레이너가 설정한 내 코칭 목표(TrainerClient.goal)

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -16,11 +16,12 @@ from sqlalchemy import func, or_, select, tuple_, update
 from sqlalchemy.orm import Session
 
 from app.models.models import (
-    ChatMessage, DietEntry, RoutineHistory, TrainerClient, TrainerRoutine, TrainerSchedule, User,
+    ChatMessage, DietEntry, RoutineHistory, TrainerClient, TrainerProfile,
+    TrainerRoutine, TrainerSchedule, User,
 )
 from app.schemas.trainer_api import (
-    ChatMessageOut, ClientDietEntryOut, ProgramItem, RoutineHistoryOut, RoutineOut,
-    ScheduleSessionOut, TrainerClientOut,
+    ChatMessageOut, ClientDietEntryOut, MemberCoachOut, ProgramItem, RoutineHistoryOut,
+    RoutineOut, ScheduleSessionOut, TrainerClientOut, TrainerGymOut,
 )
 
 
@@ -291,8 +292,13 @@ def _hhmm(ts: datetime) -> str:
     return ts.astimezone().strftime("%H:%M")
 
 
-def _sender_out(sender: str) -> str:
-    """저장값(trainer|member) → 프론트 계약(trainer|client)."""
+def _sender_out(sender: str, viewer: str = "trainer") -> str:
+    """저장값(trainer|member) → 뷰어 관점 라벨.
+
+    트레이너 앱: 상대(member)는 'client'. 회원 앱: 자신(member)은 'me', 트레이너는 'trainer'.
+    """
+    if viewer == "member":
+        return "me" if sender == "member" else "trainer"
     return "client" if sender == "member" else "trainer"
 
 
@@ -305,6 +311,7 @@ def _iso(ts: datetime) -> str:
 def build_chat_thread(
     db: Session, trainer_id: str, member_id: str,
     limit: int = 50, before: datetime | None = None, before_id: str | None = None,
+    viewer: str = "trainer",
 ) -> list[ChatMessageOut]:
     """(trainer, member) 스레드 메시지(오래된→최신).
 
@@ -330,7 +337,7 @@ def build_chat_thread(
     rows.reverse()  # 최신 limit건을 오래된→최신 순으로
     return [
         ChatMessageOut(
-            id=r.id, sender=_sender_out(r.sender), body=r.body,
+            id=r.id, sender=_sender_out(r.sender, viewer), body=r.body,
             time_label=_hhmm(r.created_at), created_at=_iso(r.created_at),
         )
         for r in rows
@@ -338,7 +345,8 @@ def build_chat_thread(
 
 
 def send_message(
-    db: Session, trainer_id: str, member_id: str, sender: str, text: str
+    db: Session, trainer_id: str, member_id: str, sender: str, text: str,
+    viewer: str = "trainer",
 ) -> ChatMessageOut:
     """스레드에 메시지 추가(sender: 'trainer'|'member'). 로스터 last_message 는
     build_roster 가 최신 메시지를 읽어 자동 반영하므로 별도 비정규화가 없다."""
@@ -354,7 +362,7 @@ def send_message(
     db.commit()
     db.refresh(msg)
     return ChatMessageOut(
-        id=msg.id, sender=_sender_out(msg.sender), body=msg.body,
+        id=msg.id, sender=_sender_out(msg.sender, viewer), body=msg.body,
         time_label=_hhmm(msg.created_at), created_at=_iso(msg.created_at),
     )
 
@@ -625,3 +633,77 @@ def complete_session(
     db.commit()
     db.refresh(s)
     return _schedule_out(s)
+
+
+# ---- 회원측 미러 (내 담당 코치 / 받은 루틴 / 채팅 / 내 세션) ----
+
+def get_member_trainer_id(db: Session, member_id: str) -> str | None:
+    """회원의 담당 트레이너 id(활성 링크 우선, 없으면 None)."""
+    return db.scalar(
+        select(TrainerClient.trainer_id)
+        .where(TrainerClient.member_id == member_id)
+        .order_by(TrainerClient.active.desc(), TrainerClient.created_at)
+        .limit(1)
+    )
+
+
+def build_member_coach(db: Session, member_id: str) -> MemberCoachOut | None:
+    """회원의 '내 담당 코치' 요약. 담당이 없으면 None."""
+    link = db.scalar(
+        select(TrainerClient)
+        .where(TrainerClient.member_id == member_id)
+        .order_by(TrainerClient.active.desc(), TrainerClient.created_at)
+        .limit(1)
+    )
+    if link is None:
+        return None
+    trainer = db.get(User, link.trainer_id)
+    profile = db.scalar(
+        select(TrainerProfile).where(TrainerProfile.trainer_id == link.trainer_id)
+    )
+    if trainer is None or profile is None:
+        return None
+    return MemberCoachOut(
+        trainer_id=trainer.id,
+        name=trainer.name,
+        specialty=profile.specialty,
+        career=f"{profile.career_years}년",
+        intro=profile.intro,
+        gym=TrainerGymOut(
+            name=profile.gym_name, address=profile.gym_address,
+            hours=profile.gym_hours, phone=profile.gym_phone,
+        ),
+        goal=link.goal,
+    )
+
+
+def build_member_routines(db: Session, member_id: str) -> list[RoutineOut]:
+    """회원이 받은 루틴(담당 트레이너 배정). 담당 없으면 빈 목록."""
+    trainer_id = get_member_trainer_id(db, member_id)
+    if trainer_id is None:
+        return []
+    return build_routines(db, member_id, trainer_id)
+
+
+def build_member_sessions(db: Session, member_id: str) -> list[ScheduleSessionOut]:
+    """회원의 PT 세션(담당 트레이너 스케줄에서 나와 매칭된 것), 최신 날짜/시간 순."""
+    rows = db.scalars(
+        select(TrainerSchedule)
+        .where(TrainerSchedule.member_id == member_id)
+        .order_by(TrainerSchedule.date.desc(), TrainerSchedule.time.desc())
+    ).all()
+    return [_schedule_out(s) for s in rows]
+
+
+def member_unread_count(db: Session, trainer_id: str, member_id: str) -> int:
+    """회원 기준 미확인(트레이너가 보낸 read_at NULL) 메시지 수."""
+    return db.scalar(
+        select(func.count())
+        .select_from(ChatMessage)
+        .where(
+            ChatMessage.trainer_id == trainer_id,
+            ChatMessage.member_id == member_id,
+            ChatMessage.sender == "trainer",
+            ChatMessage.read_at.is_(None),
+        )
+    ) or 0

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -638,21 +638,25 @@ def complete_session(
 # ---- 회원측 미러 (내 담당 코치 / 받은 루틴 / 채팅 / 내 세션) ----
 
 def get_member_trainer_id(db: Session, member_id: str) -> str | None:
-    """회원의 담당 트레이너 id(활성 링크 우선, 없으면 None)."""
+    """회원의 현재 담당 트레이너 id. 활성(active) 링크만 인정하며 없으면 None.
+
+    휴면(비활성) 링크는 '현재 담당'이 아니므로 제외한다(리뷰 재-#3) — 비활성 링크만
+    가진 회원은 코치 조회/발신이 불가(404/빈 목록)해야 한다.
+    """
     return db.scalar(
         select(TrainerClient.trainer_id)
-        .where(TrainerClient.member_id == member_id)
-        .order_by(TrainerClient.active.desc(), TrainerClient.created_at)
+        .where(TrainerClient.member_id == member_id, TrainerClient.active.is_(True))
+        .order_by(TrainerClient.created_at)
         .limit(1)
     )
 
 
 def build_member_coach(db: Session, member_id: str) -> MemberCoachOut | None:
-    """회원의 '내 담당 코치' 요약. 담당이 없으면 None."""
+    """회원의 '내 담당 코치' 요약. 활성 담당이 없으면 None(라우터 404)."""
     link = db.scalar(
         select(TrainerClient)
-        .where(TrainerClient.member_id == member_id)
-        .order_by(TrainerClient.active.desc(), TrainerClient.created_at)
+        .where(TrainerClient.member_id == member_id, TrainerClient.active.is_(True))
+        .order_by(TrainerClient.created_at)
         .limit(1)
     )
     if link is None:

--- a/backend/tests/test_member_coach.py
+++ b/backend/tests/test_member_coach.py
@@ -99,3 +99,19 @@ def test_trainer_token_rejected_on_member_coach(client):
     # 회원 전용 API — 트레이너 토큰은 403(CurrentUser 가 트레이너 차단)
     assert client.get("/v1/me/coach", headers=_h(tt)).status_code == 403
     assert client.get("/v1/me/coach/routines", headers=_h(tt)).status_code == 403
+
+
+def test_inactive_link_member_has_no_current_coach(client):
+    """비활성(휴면) 링크만 가진 회원은 현재 담당 코치가 없다(리뷰 재-#3).
+
+    user-sungho 는 시드가 active=False 로 생성한다(트레이너 로스터엔 휴면으로 보이지만,
+    회원측 '내 코치'로는 선택되지 않아야 한다).
+    """
+    tok = client.post(
+        "/v1/auth/login", data={"username": "sungho@oncare.com", "password": "oncare123"}
+    ).json()["access_token"]
+    assert client.get("/v1/me/coach", headers=_h(tok)).status_code == 404
+    assert client.get("/v1/me/coach/routines", headers=_h(tok)).json() == []
+    assert client.post(
+        "/v1/me/coach/chat", json={"text": "안녕하세요"}, headers=_h(tok)
+    ).status_code == 404

--- a/backend/tests/test_member_coach.py
+++ b/backend/tests/test_member_coach.py
@@ -1,0 +1,101 @@
+"""회원측 트레이너 미러(#253) — 내 코치/받은 루틴/세션/양방향 채팅. DB 필요."""
+from __future__ import annotations
+
+from uuid import uuid4
+
+
+def _h(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _member_tok(client) -> str:
+    # user-jisu 는 시드가 demo_login_password(oncare123)로 생성 + 트레이너 링크 보유
+    return client.post(
+        "/v1/auth/login", data={"username": "jisu@oncare.com", "password": "oncare123"}
+    ).json()["access_token"]
+
+
+def _trainer_tok(client) -> str:
+    return client.post(
+        "/v1/auth/login", data={"username": "trainer@oncare.com", "password": "oncare123"}
+    ).json()["access_token"]
+
+
+def test_my_coach(client):
+    t = _member_tok(client)
+    r = client.get("/v1/me/coach", headers=_h(t))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["name"] == "김트레이너"
+    assert body["career"] == "7년"
+    assert body["gym"]["name"] == "온케어짐 신촌점"
+    assert body["goal"] == "체력 강화 · 다이어트"
+
+
+def test_my_routines_and_sessions(client):
+    t = _member_tok(client)
+    routines = client.get("/v1/me/coach/routines", headers=_h(t)).json()
+    assert len(routines) >= 3
+    assert all(rt["type"] in ("유산소", "근력", "스트레칭") for rt in routines)
+
+    sessions = client.get("/v1/me/coach/sessions", headers=_h(t)).json()
+    # 시드 스케줄에 이지수(user-jisu) 12:00 완료 세션이 있다
+    assert any(s["status"] == "완료" for s in sessions)
+
+
+def test_member_send_reflects_in_trainer_roster(client):
+    mt = _member_tok(client)
+    r = client.post(
+        "/v1/me/coach/chat", json={"text": "코치님 오늘 운동 힘들었어요"}, headers=_h(mt)
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["sender"] == "me"
+
+    # 회원 스레드 마지막이 내 메시지(관점 me)
+    thread = client.get("/v1/me/coach/chat", headers=_h(mt)).json()
+    assert thread[-1]["sender"] == "me"
+    assert thread[-1]["body"] == "코치님 오늘 운동 힘들었어요"
+
+    # 트레이너 로스터 last_message 에 회원 발신이 반영(양방향)
+    tt = _trainer_tok(client)
+    roster = client.get("/v1/trainer/clients", headers=_h(tt)).json()
+    jisu = next(c for c in roster if c["id"] == "user-jisu")
+    assert jisu["last_message"] == "코치님 오늘 운동 힘들었어요"
+
+
+def test_member_unread_and_read(client):
+    tt = _trainer_tok(client)
+    client.post(
+        "/v1/trainer/clients/user-jisu/chat",
+        json={"text": "내일 PT 잊지마세요"}, headers=_h(tt),
+    )
+    mt = _member_tok(client)
+    u = client.get("/v1/me/coach/chat/unread", headers=_h(mt)).json()
+    assert u["unread"] >= 1
+
+    rd = client.post("/v1/me/coach/chat/read", headers=_h(mt))
+    assert rd.status_code == 200
+    u2 = client.get("/v1/me/coach/chat/unread", headers=_h(mt)).json()
+    assert u2["unread"] == 0
+
+
+def test_member_without_coach_404(client):
+    email = f"m-{uuid4().hex[:8]}@oncare.com"
+    client.post("/v1/auth/register", json={"email": email, "password": "pw!", "name": "u"})
+    tok = client.post(
+        "/v1/auth/login", data={"username": email, "password": "pw!"}
+    ).json()["access_token"]
+    # 담당 트레이너가 없는 회원
+    assert client.get("/v1/me/coach", headers=_h(tok)).status_code == 404
+    assert client.post(
+        "/v1/me/coach/chat", json={"text": "hi"}, headers=_h(tok)
+    ).status_code == 404
+    # 받은 루틴은 빈 목록(에러 아님)
+    assert client.get("/v1/me/coach/routines", headers=_h(tok)).json() == []
+
+
+def test_trainer_token_rejected_on_member_coach(client):
+    tt = _trainer_tok(client)
+    # 회원 전용 API — 트레이너 토큰은 403(CurrentUser 가 트레이너 차단)
+    assert client.get("/v1/me/coach", headers=_h(tt)).status_code == 403
+    assert client.get("/v1/me/coach/routines", headers=_h(tt)).status_code == 403


### PR DESCRIPTION
## Summary
* 회원 앱의 "내 담당 코치" 화면을 위한 회원측 미러 API 추가 — 트레이너가 배정/기록한
  데이터를 **회원 관점**으로 되비추고, 코치와의 양방향 채팅을 완성.
* 담당 코치는 **active 링크만** 인정(휴면 링크만 있으면 404/빈 목록).

## Changes
### ✨ Features
* `GET /me/coach` — 내 담당 코치 요약(활성 담당 없으면 404).
* `GET /me/coach/routines` — 받은 루틴, `GET /me/coach/sessions` — 내 PT 세션.
* `GET /me/coach/chat`·`/chat/unread`, `POST /me/coach/chat`·`/chat/read` — 회원→코치 양방향.

### 🔧 Improvements
* `get_member_trainer_id`가 `active.is_(True)`만 선택, 채팅은 트레이너측과 동일한 복합 커서 페이지네이션.

## Commits
1. `e3e374b` feat(member-api): add member-side coach mirror (coach, routines, chat, sessions)
2. `96d38bd` fix(member-api): active-only coach selection and chat cursor pagination

## Notes
* 회원↔트레이너 채팅은 같은 `chat_messages`를 공유 — 한쪽이 보내면 상대에게 즉시 보임.
* `/me/coach/sessions` 응답 상한은 리뷰 후속(#261)에서 LIMIT 100 적용.

## Related Issues
Closes #254

## Checklist
* [ ] 코드 리뷰 준비 완료
* [ ] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인