### PR TITLE
feat(places): add Kakao Local O2O search with seed fallback

### DIFF
--- a/backend/app/api/v1/places.py
+++ b/backend/app/api/v1/places.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy import select
@@ -52,9 +52,11 @@ def _haversine_m(lat1, lng1, lat2, lng2) -> int:
 async def places_nearby(
     current_user: CurrentUser,
     db: Annotated[Session, Depends(get_db)],
-    lat: float = Query(37.5665, description="기준 위도(기본: 서울시청)"),
-    lng: float = Query(126.9780, description="기준 경도"),
-    category: str | None = Query(None, description="medical|fitness|healthy_food|pharmacy"),
+    lat: float = Query(37.5665, ge=-90, le=90, description="기준 위도(기본: 서울시청)"),
+    lng: float = Query(126.9780, ge=-180, le=180, description="기준 경도"),
+    category: Literal["medical", "fitness", "healthy_food", "pharmacy"] | None = Query(
+        None, description="medical|fitness|healthy_food|pharmacy"
+    ),
     radius_m: int = Query(3000, ge=100, le=20000),
 ) -> list[PlaceOut]:
     """주변 장소(거리순). 카카오 키가 있으면 실검색, 없거나 실패하면 시드 폴백.

--- a/backend/app/api/v1/places.py
+++ b/backend/app/api/v1/places.py
@@ -9,6 +9,7 @@
 """
 from __future__ import annotations
 
+import logging
 import math
 from typing import Annotated
 
@@ -17,11 +18,24 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.deps import CurrentUser
+from app.core.config import get_settings
 from app.db.session import get_db
 from app.models.models import Place
 from app.schemas.misc_api import PlaceOut
+from app.services.places import kakao
 
 router = APIRouter(tags=["places"])
+logger = logging.getLogger(__name__)
+
+
+def _use_kakao(settings) -> bool:
+    """카카오 실검색을 쓸지: provider=kakao 강제거나, auto+키 보유."""
+    provider = settings.places_provider
+    if provider == "seed":
+        return False
+    if provider == "kakao":
+        return True
+    return bool(settings.kakao_rest_api_key)  # auto
 
 
 def _haversine_m(lat1, lng1, lat2, lng2) -> int:
@@ -35,7 +49,7 @@ def _haversine_m(lat1, lng1, lat2, lng2) -> int:
 
 
 @router.get("/places/nearby", response_model=list[PlaceOut])
-def places_nearby(
+async def places_nearby(
     current_user: CurrentUser,
     db: Annotated[Session, Depends(get_db)],
     lat: float = Query(37.5665, description="기준 위도(기본: 서울시청)"),
@@ -43,8 +57,28 @@ def places_nearby(
     category: str | None = Query(None, description="medical|fitness|healthy_food|pharmacy"),
     radius_m: int = Query(3000, ge=100, le=20000),
 ) -> list[PlaceOut]:
-    # TODO(카카오맵): 실연동 시 여기서 _search_kakao(lat,lng,category) 호출 후
-    #                 결과를 PlaceOut 으로 변환. 현재는 DB 시드 데이터 사용.
+    """주변 장소(거리순). 카카오 키가 있으면 실검색, 없거나 실패하면 시드 폴백.
+    응답 형식(PlaceOut)은 두 경로 동일하므로 프론트는 영향 없음."""
+    settings = get_settings()
+    if _use_kakao(settings) and settings.kakao_rest_api_key:
+        try:
+            places = await kakao.search_nearby(
+                lat, lng, category, radius_m,
+                api_key=settings.kakao_rest_api_key,
+                timeout=settings.kakao_timeout_seconds,
+            )
+            if places:
+                return places
+            # 결과 0건이면 시드로 폴백(데모가 비지 않도록)
+        except Exception:  # noqa: BLE001 — 외부 API 실패가 요청을 깨지 않도록 폴백
+            logger.warning("카카오 장소검색 실패 — 시드 데이터로 폴백", exc_info=True)
+    return _seed_nearby(db, lat, lng, category, radius_m)
+
+
+def _seed_nearby(
+    db: Session, lat: float, lng: float, category: str | None, radius_m: int
+) -> list[PlaceOut]:
+    """DB 시드 장소를 거리 계산해 반환(카카오 미연동/실패 시 폴백)."""
     q = select(Place)
     if category:
         q = q.where(Place.category == category)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -38,6 +38,13 @@ class Settings(BaseSettings):
     # 토큰 없이 접근 시 데모 사용자로 폴백(개발 편의). 운영(prod)에서는 항상 비활성.
     allow_demo_fallback: bool = True
 
+    # --- 장소(O2O) ---
+    # 카카오 Local REST 키. 있으면 실검색, 없으면 시드 폴백(recognizer 팩토리와 같은 철학).
+    kakao_rest_api_key: str = ""
+    # auto: 키 있으면 kakao, 없으면 seed. 강제하려면 kakao|seed.
+    places_provider: str = "auto"     # auto | kakao | seed
+    kakao_timeout_seconds: float = 3.0
+
     # --- AI 엔진 ---
     recognizer: str = "gemini"        # gemini | claude(litellm) | yolo
     # 인식 후 공공 식품영양성분 DB 로 영양 수치 보강(정확도↑). 순수 LLM 비교실험 시 false.

--- a/backend/app/services/places/kakao.py
+++ b/backend/app/services/places/kakao.py
@@ -11,11 +11,24 @@
 """
 from __future__ import annotations
 
+import time
+
 import httpx
 
 from app.schemas.misc_api import PlaceOut
 
 _KAKAO_KEYWORD_URL = "https://dapi.kakao.com/v2/local/search/keyword.json"
+
+# 간단한 인메모리 TTL 캐시 — 동일 위치·카테고리 반복 조회 시 카카오 호출을 줄여
+# 요청 폭주/요금을 완화한다(운영은 인스턴스별 캐시라 근사적 완화). 좌표는 소수 3자리
+# (~110m) 버킷으로 묶는다.
+_CACHE_TTL_SECONDS = 60.0
+_CACHE_MAX = 500
+_cache: dict[tuple, tuple[float, list[PlaceOut]]] = {}
+
+
+def _cache_key(lat: float, lng: float, category: str | None, radius_m: int) -> tuple:
+    return (round(lat, 3), round(lng, 3), category or "", radius_m)
 
 # 계약 카테고리 → 카카오 키워드
 _CATEGORY_QUERY = {
@@ -61,7 +74,14 @@ async def search_nearby(
     lat: float, lng: float, category: str | None, radius_m: int,
     api_key: str, timeout: float = 3.0,
 ) -> list[PlaceOut]:
-    """카카오 Local 키워드 검색으로 주변 장소를 거리순 조회. 실패 시 예외(라우터가 폴백)."""
+    """카카오 Local 키워드 검색으로 주변 장소를 거리순 조회. 실패 시 예외(라우터가 폴백).
+    TTL 캐시 히트 시 호출을 건너뛴다."""
+    key = _cache_key(lat, lng, category, radius_m)
+    now = time.monotonic()
+    hit = _cache.get(key)
+    if hit is not None and hit[0] > now:
+        return hit[1]
+
     params = {
         "query": _query_for(category),
         "x": str(lng),      # 카카오는 x=경도, y=위도
@@ -75,4 +95,9 @@ async def search_nearby(
         resp = await client.get(_KAKAO_KEYWORD_URL, params=params, headers=headers)
         resp.raise_for_status()
         docs = resp.json().get("documents", [])
-    return docs_to_places(docs, category)
+    result = docs_to_places(docs, category)
+
+    if len(_cache) >= _CACHE_MAX:
+        _cache.clear()  # 단순 상한 — 무한 증식 방지
+    _cache[key] = (now + _CACHE_TTL_SECONDS, result)
+    return result

--- a/backend/app/services/places/kakao.py
+++ b/backend/app/services/places/kakao.py
@@ -1,0 +1,78 @@
+"""
+카카오 Local(장소) 검색 프록시.
+
+카카오 Local REST(키워드 검색)를 서버가 대신 호출해 결과를 PlaceOut 으로 변환한다.
+키는 서버(설정/Secrets)에만 두므로 프론트로 노출되지 않고, 응답 형식은 기존 계약
+(PlaceOut)과 동일해 프론트는 영향이 없다. 키가 없거나 호출이 실패하면 라우터가
+시드 데이터로 폴백한다(recognizer 팩토리의 stub 폴백과 같은 철학).
+
+카테고리→검색어 매핑: 카카오 카테고리 코드는 병원(HP8)·약국(PM9)만 있고 헬스장/건강식은
+없으므로, 계약 카테고리 전부를 키워드 검색으로 일관 처리한다.
+"""
+from __future__ import annotations
+
+import httpx
+
+from app.schemas.misc_api import PlaceOut
+
+_KAKAO_KEYWORD_URL = "https://dapi.kakao.com/v2/local/search/keyword.json"
+
+# 계약 카테고리 → 카카오 키워드
+_CATEGORY_QUERY = {
+    "medical": "병원",
+    "fitness": "헬스장",
+    "healthy_food": "샐러드",
+    "pharmacy": "약국",
+}
+
+
+def _query_for(category: str | None) -> str:
+    if not category:
+        return "병원"
+    return _CATEGORY_QUERY.get(category, category)
+
+
+def docs_to_places(docs: list[dict], category: str | None) -> list[PlaceOut]:
+    """카카오 documents → PlaceOut 목록(좌표 없는 항목은 스킵). 순수 함수(테스트 용이)."""
+    out: list[PlaceOut] = []
+    for d in docs:
+        try:
+            lat = float(d["y"])
+            lng = float(d["x"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        try:
+            dist = int(d.get("distance") or 0)
+        except (TypeError, ValueError):
+            dist = 0
+        out.append(PlaceOut(
+            id=str(d.get("id", "")),
+            name=d.get("place_name", ""),
+            category=category or "",
+            address=d.get("road_address_name") or d.get("address_name") or "",
+            distance_meters=dist,
+            lat=lat,
+            lng=lng,
+        ))
+    return out
+
+
+async def search_nearby(
+    lat: float, lng: float, category: str | None, radius_m: int,
+    api_key: str, timeout: float = 3.0,
+) -> list[PlaceOut]:
+    """카카오 Local 키워드 검색으로 주변 장소를 거리순 조회. 실패 시 예외(라우터가 폴백)."""
+    params = {
+        "query": _query_for(category),
+        "x": str(lng),      # 카카오는 x=경도, y=위도
+        "y": str(lat),
+        "radius": min(max(radius_m, 1), 20000),
+        "sort": "distance",
+        "size": 15,
+    }
+    headers = {"Authorization": f"KakaoAK {api_key}"}
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        resp = await client.get(_KAKAO_KEYWORD_URL, params=params, headers=headers)
+        resp.raise_for_status()
+        docs = resp.json().get("documents", [])
+    return docs_to_places(docs, category)

--- a/backend/tests/test_places.py
+++ b/backend/tests/test_places.py
@@ -1,0 +1,100 @@
+"""장소(O2O) — 카카오 실검색 + 시드 폴백(#255).
+
+- docs_to_places 파싱 / _use_kakao 해석은 순수(로컬 실행).
+- 엔드포인트(폴백·카카오 경로)는 DB 필요(로컬 skip, CI 실행).
+"""
+from __future__ import annotations
+
+
+def test_kakao_docs_to_places_parsing():
+    from app.services.places.kakao import docs_to_places
+
+    docs = [
+        {
+            "id": "1", "place_name": "온케어짐", "x": "127.0", "y": "37.5",
+            "distance": "120", "road_address_name": "서울 서대문구 신촌로 120",
+        },
+        {"id": "2", "place_name": "좌표없음"},  # x/y 없음 → 스킵
+        {"id": "3", "place_name": "거리없음", "x": "127.1", "y": "37.6"},  # distance 없음 → 0
+    ]
+    out = docs_to_places(docs, "fitness")
+    assert len(out) == 2
+    assert out[0].name == "온케어짐"
+    assert out[0].category == "fitness"
+    assert out[0].distance_meters == 120
+    assert out[0].lat == 37.5 and out[0].lng == 127.0
+    assert out[1].distance_meters == 0
+
+
+def test_use_kakao_resolution():
+    from app.api.v1.places import _use_kakao
+    from app.core.config import Settings
+
+    seed_forced = Settings(_env_file=None, places_provider="seed", kakao_rest_api_key="k")
+    kakao_forced = Settings(_env_file=None, places_provider="kakao")
+    auto_with_key = Settings(_env_file=None, places_provider="auto", kakao_rest_api_key="k")
+    auto_no_key = Settings(_env_file=None, places_provider="auto", kakao_rest_api_key="")
+    assert _use_kakao(seed_forced) is False
+    assert _use_kakao(kakao_forced) is True
+    assert _use_kakao(auto_with_key) is True
+    assert _use_kakao(auto_no_key) is False
+
+
+def test_places_fallback_to_seed_without_key(client):
+    # 기본 설정(키 없음, auto) → 시드 폴백
+    r = client.get("/v1/places/nearby")
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert len(data) >= 1
+    assert all("category" in p and "distance_meters" in p for p in data)
+    # 거리순 정렬
+    dists = [p["distance_meters"] for p in data]
+    assert dists == sorted(dists)
+
+
+def test_places_category_filter_seed(client):
+    r = client.get("/v1/places/nearby", params={"category": "fitness"})
+    assert r.status_code == 200, r.text
+    assert all(p["category"] == "fitness" for p in r.json())
+
+
+def test_places_uses_kakao_when_configured(client, monkeypatch):
+    """카카오 경로: search_nearby 를 가짜로 대체해 네트워크 없이 검증."""
+    import app.api.v1.places as places_mod
+    from app.core.config import get_settings
+    from app.schemas.misc_api import PlaceOut
+
+    async def fake_search(lat, lng, category, radius_m, api_key, timeout):
+        assert api_key == "test-key"
+        return [PlaceOut(
+            id="kk1", name="카카오헬스장", category=category or "",
+            address="서울 어딘가", distance_meters=50, lat=lat, lng=lng,
+        )]
+
+    monkeypatch.setattr(places_mod.kakao, "search_nearby", fake_search)
+    s = get_settings()
+    monkeypatch.setattr(s, "kakao_rest_api_key", "test-key")
+    monkeypatch.setattr(s, "places_provider", "kakao")
+
+    r = client.get("/v1/places/nearby", params={"category": "fitness", "lat": 37.5, "lng": 127.0})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body[0]["id"] == "kk1"
+    assert body[0]["name"] == "카카오헬스장"
+
+
+def test_places_falls_back_when_kakao_raises(client, monkeypatch):
+    """카카오 호출이 실패해도 요청은 시드로 폴백해 성공한다."""
+    import app.api.v1.places as places_mod
+    from app.core.config import get_settings
+
+    async def boom(*a, **k):
+        raise RuntimeError("kakao down")
+
+    monkeypatch.setattr(places_mod.kakao, "search_nearby", boom)
+    s = get_settings()
+    monkeypatch.setattr(s, "kakao_rest_api_key", "test-key")
+    monkeypatch.setattr(s, "places_provider", "kakao")
+
+    r = client.get("/v1/places/nearby")
+    assert r.status_code == 200, r.text  # 폴백으로 200

--- a/backend/tests/test_places.py
+++ b/backend/tests/test_places.py
@@ -83,6 +83,63 @@ def test_places_uses_kakao_when_configured(client, monkeypatch):
     assert body[0]["name"] == "카카오헬스장"
 
 
+def test_places_input_validation(client):
+    """좌표 범위·category 허용값 밖은 DB 500 이 아니라 422(리뷰 재-#5)."""
+    assert client.get("/v1/places/nearby", params={"lat": 100}).status_code == 422
+    assert client.get("/v1/places/nearby", params={"lat": -100}).status_code == 422
+    assert client.get("/v1/places/nearby", params={"lng": 200}).status_code == 422
+    assert client.get("/v1/places/nearby", params={"category": "gym"}).status_code == 422
+    # 유효 카테고리는 정상
+    assert client.get("/v1/places/nearby", params={"category": "fitness"}).status_code == 200
+
+
+def test_kakao_cache_reduces_calls(monkeypatch):
+    """동일 위치·카테고리 반복 조회는 TTL 캐시로 카카오 호출을 한 번만 한다."""
+    import asyncio
+
+    import app.services.places.kakao as kk
+
+    kk._cache.clear()
+    calls = {"n": 0}
+
+    class _FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"documents": [
+                {"id": "1", "place_name": "P", "x": "127.0", "y": "37.5", "distance": "10"}
+            ]}
+
+    class _FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, *a, **k):
+            calls["n"] += 1
+            return _FakeResp()
+
+    monkeypatch.setattr(kk.httpx, "AsyncClient", _FakeClient)
+
+    async def _run():
+        a = await kk.search_nearby(37.5, 127.0, "fitness", 3000, api_key="k")
+        b = await kk.search_nearby(37.5, 127.0, "fitness", 3000, api_key="k")
+        return a, b
+
+    try:
+        a, b = asyncio.run(_run())
+        assert calls["n"] == 1  # 두 번째는 캐시 히트
+        assert a[0].name == "P" and b[0].name == "P"
+    finally:
+        kk._cache.clear()
+
+
 def test_places_falls_back_when_kakao_raises(client, monkeypatch):
     """카카오 호출이 실패해도 요청은 시드로 폴백해 성공한다."""
     import app.api.v1.places as places_mod


### PR DESCRIPTION
## Summary
* `/places/nearby`를 카카오 Local 키워드 검색 **서버 프록시**로 실연동(키는 서버에만, 프론트 무영향).
* 키 없음/실패 시 **시드 폴백**(recognizer stub 폴백 철학) — 데모/CI 안전.

## Changes
### ✨ Features
* `services/places/kakao.py` — 카카오 검색 + `docs_to_places` 파싱 + TTL 캐시.
* `places.py` — async 프록시 + provider 해석(auto|kakao|seed) + 시드 폴백 + 좌표/카테고리 422 검증.
* config: `KAKAO_REST_API_KEY`, `PLACES_PROVIDER`, `KAKAO_TIMEOUT_SECONDS`.

## Commits
1. `2a43833` feat(places): add Kakao Local O2O search with seed fallback
2. `838a101` fix(places): validate coordinates/category and cache Kakao results

## Notes
* 지도 핀 렌더링은 프론트 카카오맵 JS SDK 담당 — 백엔드는 좌표+정보만 제공.
* 배포 시 `KAKAO_REST_API_KEY`를 Secrets에 주입하면 auto가 실검색으로 전환.
* (무카테고리 시 4개 카테고리 병합은 리뷰 후속 #261에서 보강.)

## Related Issues
Closes #255

## Checklist
* [ ] 코드 리뷰 준비 완료
* [ ] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인