### PR TITLE
feat(schedule,notifications): calendar event detail CRUD and notification actions

### DIFF
--- a/backend/app/api/v1/notifications.py
+++ b/backend/app/api/v1/notifications.py
@@ -10,15 +10,26 @@ from datetime import datetime, timezone
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
+from sqlalchemy import func, select, update
 from sqlalchemy.orm import Session
 
 from app.api.deps import CurrentUser
 from app.db.session import get_db
 from app.models.models import Notification
-from app.schemas.misc_api import NotificationOut
+from app.schemas.misc_api import NotificationAction, NotificationOut
 
 router = APIRouter(tags=["notifications"])
+
+# 알림 카테고리 → 바로가기 액션(프론트 라우트 힌트). system 은 액션 없음.
+_ACTION_BY_CATEGORY: dict[str, NotificationAction] = {
+    "reminder": NotificationAction(label="기록하러 가기", target="vitals"),
+    "health_check": NotificationAction(label="일정 보기", target="schedule"),
+    "achievement": NotificationAction(label="대시보드 보기", target="dashboard"),
+}
+
+
+def _action_for(category: str) -> NotificationAction | None:
+    return _ACTION_BY_CATEGORY.get(category)
 
 
 def _time_ago(dt: datetime) -> str:
@@ -49,9 +60,39 @@ def list_notifications(
         NotificationOut(
             id=r.id, title=r.title, body=r.body, category=r.category,
             read=r.read, created_at=r.created_at, time_ago=_time_ago(r.created_at),
+            action=_action_for(r.category),
         )
         for r in rows
     ]
+
+
+@router.get("/notifications/unread-count", response_model=dict)
+def unread_count(
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> dict:
+    """미확인 알림 수(배지용)."""
+    n = db.scalar(
+        select(func.count())
+        .select_from(Notification)
+        .where(Notification.user_id == current_user.id, Notification.read.is_(False))
+    ) or 0
+    return {"unread": n}
+
+
+@router.post("/notifications/read-all")
+def mark_all_read(
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> dict:
+    """내 미확인 알림을 모두 읽음 처리."""
+    result = db.execute(
+        update(Notification)
+        .where(Notification.user_id == current_user.id, Notification.read.is_(False))
+        .values(read=True)
+    )
+    db.commit()
+    return {"marked_read": result.rowcount or 0}
 
 
 @router.post("/notifications/{notification_id}/read", status_code=200)
@@ -66,3 +107,18 @@ def mark_read(
     row.read = True
     db.commit()
     return {"id": notification_id, "read": True}
+
+
+@router.delete("/notifications/{notification_id}")
+def delete_notification(
+    notification_id: str,
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> dict:
+    """알림 삭제(본인 소유만)."""
+    row = db.scalar(select(Notification).where(Notification.id == notification_id))
+    if row is None or row.user_id != current_user.id:
+        raise HTTPException(status_code=404, detail="알림을 찾을 수 없습니다.")
+    db.delete(row)
+    db.commit()
+    return {"status": "deleted"}

--- a/backend/app/api/v1/schedule.py
+++ b/backend/app/api/v1/schedule.py
@@ -10,16 +10,24 @@ import uuid
 from datetime import datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.deps import CurrentUser
 from app.db.session import get_db
 from app.models.models import ScheduleEvent
-from app.schemas.misc_api import ScheduleEventCreate, ScheduleEventOut
+from app.schemas.misc_api import ScheduleEventCreate, ScheduleEventOut, ScheduleEventUpdate
 
 router = APIRouter(tags=["schedule"])
+
+
+def _owned_event(db: Session, user_id: str, event_id: str) -> ScheduleEvent:
+    """본인 소유 일정을 가져오거나 404."""
+    row = db.scalar(select(ScheduleEvent).where(ScheduleEvent.id == event_id))
+    if row is None or row.user_id != user_id:
+        raise HTTPException(status_code=404, detail="일정을 찾을 수 없습니다.")
+    return row
 
 
 @router.get("/schedule/events", response_model=list[ScheduleEventOut])
@@ -61,3 +69,43 @@ def create_event(
     db.commit()
     db.refresh(row)
     return row
+
+
+@router.get("/schedule/events/{event_id}", response_model=ScheduleEventOut)
+def get_event(
+    event_id: str,
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> ScheduleEvent:
+    """일정 상세(본인 소유만)."""
+    return _owned_event(db, current_user.id, event_id)
+
+
+@router.put("/schedule/events/{event_id}", response_model=ScheduleEventOut)
+def update_event(
+    event_id: str,
+    payload: ScheduleEventUpdate,
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> ScheduleEvent:
+    """일정 상세 수정(제공된 필드만)."""
+    row = _owned_event(db, current_user.id, event_id)
+    for field, value in payload.model_dump(exclude_unset=True).items():
+        if value is not None:
+            setattr(row, field, value)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.delete("/schedule/events/{event_id}")
+def delete_event(
+    event_id: str,
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> dict:
+    """일정 삭제(본인 소유만)."""
+    row = _owned_event(db, current_user.id, event_id)
+    db.delete(row)
+    db.commit()
+    return {"status": "deleted"}

--- a/backend/app/schemas/misc_api.py
+++ b/backend/app/schemas/misc_api.py
@@ -29,7 +29,23 @@ class ScheduleEventCreate(BaseModel):
     color_hex: str = "#E0F2F7"
 
 
+class ScheduleEventUpdate(BaseModel):
+    """일정 상세 수정(부분). 제공된 필드만 반영."""
+    date: str | None = None
+    time: str | None = None
+    title: str | None = None
+    category: str | None = None
+    emoji: str | None = None
+    color_hex: str | None = None
+
+
 # ---- 알림 ----
+class NotificationAction(BaseModel):
+    """알림에서 바로 갈 수 있는 액션(카테고리에서 파생). 프론트가 target 으로 이동."""
+    label: str         # "기록하러 가기"
+    target: str        # 프론트 라우트 힌트: vitals|schedule|dashboard
+
+
 class NotificationOut(BaseModel):
     id: str
     title: str
@@ -38,6 +54,7 @@ class NotificationOut(BaseModel):
     read: bool
     created_at: datetime
     time_ago: str
+    action: NotificationAction | None = None
 
 
 # ---- 장소 ----

--- a/backend/app/schemas/misc_api.py
+++ b/backend/app/schemas/misc_api.py
@@ -4,9 +4,31 @@ STEP 6 스키마 — 일정 / 알림 / 장소 / AI 코치.
 """
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Optional
-from pydantic import BaseModel
+from datetime import date as _date, datetime
+from typing import Literal, Optional
+from pydantic import BaseModel, Field, field_validator
+
+# 회원 일정 카테고리 허용값(프론트 계약).
+ScheduleCategory = Literal["hospital", "exercise", "meal", "medication", "other"]
+_HEX_COLOR = r"^#[0-9A-Fa-f]{3}([0-9A-Fa-f]{3})?$"
+
+
+def _valid_ymd(v: str) -> str:
+    try:
+        _date.fromisoformat(v)  # 2026-99-99 등 달력상 불가능한 값 거부
+    except ValueError as e:
+        raise ValueError("유효한 날짜(YYYY-MM-DD)가 아닙니다.") from e
+    return v
+
+
+def _valid_hhmm_or_empty(v: str) -> str:
+    if v == "":
+        return v  # 시간 미지정(종일) 허용
+    try:
+        datetime.strptime(v, "%H:%M")  # 25:99 등 거부
+    except ValueError as e:
+        raise ValueError("유효한 시간(HH:MM)이 아닙니다.") from e
+    return v
 
 
 # ---- 일정 ----
@@ -21,22 +43,35 @@ class ScheduleEventOut(BaseModel):
 
 
 class ScheduleEventCreate(BaseModel):
-    date: str
-    time: str = ""
-    title: str
-    category: str = "other"
-    emoji: str = ""
-    color_hex: str = "#E0F2F7"
+    date: str = Field(max_length=10)
+    time: str = Field(default="", max_length=10)
+    title: str = Field(min_length=1, max_length=200)
+    category: ScheduleCategory = "other"
+    emoji: str = Field(default="", max_length=10)
+    color_hex: str = Field(default="#E0F2F7", max_length=10, pattern=_HEX_COLOR)
+
+    _v_date = field_validator("date")(_valid_ymd)
+    _v_time = field_validator("time")(_valid_hhmm_or_empty)
 
 
 class ScheduleEventUpdate(BaseModel):
-    """일정 상세 수정(부분). 제공된 필드만 반영."""
-    date: str | None = None
-    time: str | None = None
-    title: str | None = None
-    category: str | None = None
-    emoji: str | None = None
-    color_hex: str | None = None
+    """일정 상세 수정(부분). 제공된 필드만 반영. 잘못된 값은 422."""
+    date: str | None = Field(default=None, max_length=10)
+    time: str | None = Field(default=None, max_length=10)
+    title: str | None = Field(default=None, min_length=1, max_length=200)
+    category: ScheduleCategory | None = None
+    emoji: str | None = Field(default=None, max_length=10)
+    color_hex: str | None = Field(default=None, max_length=10, pattern=_HEX_COLOR)
+
+    @field_validator("date")
+    @classmethod
+    def _vd(cls, v: str | None) -> str | None:
+        return _valid_ymd(v) if v is not None else v
+
+    @field_validator("time")
+    @classmethod
+    def _vt(cls, v: str | None) -> str | None:
+        return _valid_hhmm_or_empty(v) if v is not None else v
 
 
 # ---- 알림 ----

--- a/backend/tests/test_calendar_noti.py
+++ b/backend/tests/test_calendar_noti.py
@@ -46,6 +46,26 @@ def test_schedule_event_detail_not_found(client):
     assert client.delete("/v1/schedule/events/nope").status_code == 404
 
 
+def test_schedule_event_input_validation(client):
+    """잘못된 날짜·시간·카테고리·색상은 DB 500 이 아니라 422(리뷰 재-#4)."""
+    base = {"date": _today(), "title": "검진"}
+    url = "/v1/schedule/events"
+    assert client.post(url, json={**base, "date": "2026-99-99"}).status_code == 422
+    assert client.post(url, json={**base, "date": "2026-02-31"}).status_code == 422
+    assert client.post(url, json={**base, "time": "25:99"}).status_code == 422
+    assert client.post(url, json={**base, "category": "invalid"}).status_code == 422
+    assert client.post(url, json={**base, "color_hex": "red"}).status_code == 422
+    assert client.post(url, json={**base, "title": ""}).status_code == 422
+    # 유효 입력은 201 (time 은 빈 값=종일 허용)
+    ok = client.post(url, json={**base, "time": "", "category": "hospital", "color_hex": "#E0F2F7"})
+    assert ok.status_code == 201
+    eid = ok.json()["id"]
+    # 수정도 잘못된 값 422
+    assert client.put(f"{url}/{eid}", json={"time": "99:99"}).status_code == 422
+    assert client.put(f"{url}/{eid}", json={"category": "nope"}).status_code == 422
+    client.delete(f"{url}/{eid}")
+
+
 # ---- 알림 액션 ----
 
 def test_notification_action_derived(client):

--- a/backend/tests/test_calendar_noti.py
+++ b/backend/tests/test_calendar_noti.py
@@ -1,0 +1,122 @@
+"""캘린더 상세 + 알림 액션(#256). DB 필요(로컬 skip, CI 실행).
+
+인증은 데모 폴백(토큰 없음 → user-demo 회원)을 사용한다.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+
+def _today() -> str:
+    return date.today().isoformat()
+
+
+# ---- 캘린더 상세(일정 CRUD) ----
+
+def test_schedule_event_detail_crud(client):
+    # 생성
+    c = client.post(
+        "/v1/schedule/events",
+        json={"date": _today(), "time": "09:00", "title": "혈압 측정", "category": "medication"},
+    )
+    assert c.status_code == 201, c.text
+    eid = c.json()["id"]
+
+    # 상세 조회
+    g = client.get(f"/v1/schedule/events/{eid}")
+    assert g.status_code == 200
+    assert g.json()["title"] == "혈압 측정"
+
+    # 수정(부분)
+    u = client.put(f"/v1/schedule/events/{eid}", json={"time": "10:30", "title": "혈압 재측정"})
+    assert u.status_code == 200
+    assert u.json()["time"] == "10:30"
+    assert u.json()["title"] == "혈압 재측정"
+    assert u.json()["category"] == "medication"  # 미변경 필드 유지
+
+    # 삭제 → 이후 조회 404
+    d = client.delete(f"/v1/schedule/events/{eid}")
+    assert d.status_code == 200
+    assert client.get(f"/v1/schedule/events/{eid}").status_code == 404
+
+
+def test_schedule_event_detail_not_found(client):
+    assert client.get("/v1/schedule/events/nope").status_code == 404
+    assert client.put("/v1/schedule/events/nope", json={"title": "x"}).status_code == 404
+    assert client.delete("/v1/schedule/events/nope").status_code == 404
+
+
+# ---- 알림 액션 ----
+
+def test_notification_action_derived(client):
+    rows = client.get("/v1/notifications").json()
+    assert len(rows) >= 1
+    by_cat = {r["category"]: r for r in rows}
+    # 시드: reminder / achievement / health_check → 파생 액션 존재
+    if "reminder" in by_cat:
+        assert by_cat["reminder"]["action"]["label"] == "기록하러 가기"
+        assert by_cat["reminder"]["action"]["target"] == "vitals"
+    if "health_check" in by_cat:
+        assert by_cat["health_check"]["action"]["target"] == "schedule"
+
+
+def test_notification_read_all_and_unread_count(client, db_session):
+    from app.models.models import Notification
+
+    db_session.add(Notification(
+        id="noti-test-unread", user_id="user-demo", title="테스트 알림",
+        body="본문", category="reminder", read=False,
+    ))
+    db_session.commit()
+    try:
+        assert client.get("/v1/notifications/unread-count").json()["unread"] >= 1
+        marked = client.post("/v1/notifications/read-all").json()["marked_read"]
+        assert marked >= 1
+        assert client.get("/v1/notifications/unread-count").json()["unread"] == 0
+    finally:
+        db_session.query(Notification).filter(
+            Notification.id == "noti-test-unread"
+        ).delete()
+        db_session.commit()
+
+
+def test_notification_delete(client, db_session):
+    from app.models.models import Notification
+
+    db_session.add(Notification(
+        id="noti-test-del", user_id="user-demo", title="삭제용", body="b",
+        category="system", read=False,
+    ))
+    db_session.commit()
+    # system 카테고리는 액션 없음(None)
+    rows = client.get("/v1/notifications").json()
+    target = next((r for r in rows if r["id"] == "noti-test-del"), None)
+    assert target is not None
+    assert target["action"] is None
+
+    d = client.delete("/v1/notifications/noti-test-del")
+    assert d.status_code == 200
+    assert client.delete("/v1/notifications/noti-test-del").status_code == 404
+
+
+def test_notification_action_and_delete_ownership(client, db_session):
+    from uuid import uuid4
+
+    # 다른 사용자 소유 알림은 삭제 불가(404)
+    from app.models.models import Notification, User
+
+    other = f"other-{uuid4().hex[:6]}"
+    db_session.add(User(id=other, email=f"{other}@oncare.com", name="타인", role="member"))
+    db_session.flush()
+    db_session.add(Notification(
+        id="noti-other", user_id=other, title="남의 알림", body="b",
+        category="system", read=False,
+    ))
+    db_session.commit()
+    try:
+        # 데모(user-demo)로 남의 알림 삭제 시도 → 404
+        assert client.delete("/v1/notifications/noti-other").status_code == 404
+    finally:
+        db_session.query(Notification).filter(Notification.id == "noti-other").delete()
+        db_session.query(User).filter(User.id == other).delete()
+        db_session.commit()


### PR DESCRIPTION
## Summary
* 회원 캘린더 **일정 상세**(조회/수정/삭제)와 **알림 액션**(모두 읽음·미확인수·삭제) 추가.
* 알림마다 카테고리 파생 **바로가기 액션(label+target)** 제공. 새 마이그레이션 없음.

## Changes
### ✨ Features
* `GET/PUT/DELETE /schedule/events/{id}`(본인 소유 404), `GET /schedule/events?month=` 월간 조회.
* `GET /notifications/unread-count`, `POST /notifications/read-all`, `DELETE /notifications/{id}`.
* `NotificationOut.action` — reminder→vitals, health_check→schedule, achievement→dashboard.

## Commits
1. `2c89c6b` feat(schedule,notifications): calendar event detail CRUD and notification actions
2. `be735b0` fix(schedule): validate calendar event date/time/category/color (422)

## Notes
* 소유권 404 가드, 트레이너 토큰 403. action.target은 프론트 라우트 힌트.
* (date/month의 basic-ISO·와일드카드 차단 강화는 리뷰 후속 #261.)

## Related Issues
Closes #256

## Checklist
* [ ] 코드 리뷰 준비 완료
* [ ] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인