### PR TITLE
feat(deploy): containerized App Runner deploy (migrations on start) + CI

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -53,6 +53,17 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
 
+      - name: Assert single Alembic head (no branched migrations)
+        run: |
+          set -euo pipefail
+          HEADS=$(alembic heads | grep -c '(head)' || true)
+          echo "alembic heads count: $HEADS"
+          if [ "$HEADS" -ne 1 ]; then
+            echo "::error::Alembic 마이그레이션 head 가 1개가 아닙니다($HEADS). down_revision 선형화 필요."
+            alembic heads
+            exit 1
+          fi
+
       - name: Run migrations (validates baseline)
         run: alembic upgrade head
 

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -56,11 +56,15 @@ jobs:
       - name: Assert single Alembic head (no branched migrations)
         run: |
           set -euo pipefail
-          HEADS=$(alembic heads | grep -c '(head)' || true)
+          # alembic 실행 자체가 실패하면(분기/설정 오류 등) set -e 로 여기서 즉시 실패시킨다.
+          # (이전엔 `alembic heads | grep -c … || true` 라 alembic 실패도 head=... 로 넘어가는
+          #  fail-open 이었다.) 성공한 출력에서만 head 개수를 센다.
+          alembic heads > alembic_heads.txt
+          HEADS=$(grep -c '(head)' alembic_heads.txt || true)
           echo "alembic heads count: $HEADS"
+          cat alembic_heads.txt
           if [ "$HEADS" -ne 1 ]; then
             echo "::error::Alembic 마이그레이션 head 가 1개가 아닙니다($HEADS). down_revision 선형화 필요."
-            alembic heads
             exit 1
           fi
 

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -6,12 +6,13 @@ name: Backend Deploy (ECR + App Runner)
 #   APPRUNNER_SERVICE_ARN 배포 대상 App Runner 서비스 ARN
 # 리전/리포명은 아래 env 에서 조정.
 
+# 배포는 "Backend CI"(test + alembic heads 검사)가 main 에서 성공했을 때만 실행한다.
+# 이렇게 하면 실패한 커밋이 운영에 배포되지 않는다(테스트 통과 게이팅).
 on:
-  push:
+  workflow_run:
+    workflows: ["Backend CI"]
+    types: [completed]
     branches: [main]
-    paths:
-      - "backend/**"
-      - ".github/workflows/backend-deploy.yml"
   workflow_dispatch:
 
 permissions:
@@ -25,8 +26,15 @@ env:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    # workflow_run 은 성공했을 때만(수동 실행은 무조건 허용).
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' ||
+          github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # CI 를 통과한 정확한 커밋을 배포(workflow_dispatch 는 현재 ref).
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
@@ -42,9 +50,10 @@ jobs:
         working-directory: backend
         env:
           REGISTRY: ${{ steps.ecr.outputs.registry }}
+          SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
         run: |
           set -euo pipefail
-          IMAGE="$REGISTRY/$ECR_REPOSITORY:${{ github.sha }}"
+          IMAGE="$REGISTRY/$ECR_REPOSITORY:$SHA"
           LATEST="$REGISTRY/$ECR_REPOSITORY:latest"
           docker build -t "$IMAGE" -t "$LATEST" .
           docker push "$IMAGE"

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -1,0 +1,56 @@
+name: Backend Deploy (ECR + App Runner)
+
+# main 에 backend 변경이 push 되면 이미지를 빌드→ECR push→App Runner 재배포.
+# 필요한 GitHub Secrets:
+#   AWS_DEPLOY_ROLE_ARN   OIDC 로 assume 할 IAM 역할 ARN(ECR push + App Runner 배포 권한)
+#   APPRUNNER_SERVICE_ARN 배포 대상 App Runner 서비스 ARN
+# 리전/리포명은 아래 env 에서 조정.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-deploy.yml"
+  workflow_dispatch:
+
+permissions:
+  id-token: write   # OIDC 로 AWS 자격 취득
+  contents: read
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECR_REPOSITORY: oncare-backend
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push image
+        working-directory: backend
+        env:
+          REGISTRY: ${{ steps.ecr.outputs.registry }}
+        run: |
+          set -euo pipefail
+          IMAGE="$REGISTRY/$ECR_REPOSITORY:${{ github.sha }}"
+          LATEST="$REGISTRY/$ECR_REPOSITORY:latest"
+          docker build -t "$IMAGE" -t "$LATEST" .
+          docker push "$IMAGE"
+          docker push "$LATEST"
+
+      - name: Trigger App Runner deployment
+        run: |
+          aws apprunner start-deployment \
+            --service-arn "${{ secrets.APPRUNNER_SERVICE_ARN }}"

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -35,7 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       ${{ (github.event_name == 'workflow_run' &&
-           github.event.workflow_run.conclusion == 'success') ||
+           github.event.workflow_run.conclusion == 'success' &&
+           github.event.workflow_run.event == 'push' &&
+           github.event.workflow_run.head_branch == 'main' &&
+           github.event.workflow_run.head_repository.full_name == github.repository) ||
           (github.event_name == 'workflow_dispatch' &&
            github.ref == 'refs/heads/main') }}
     steps:
@@ -44,12 +47,21 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event }}
+          WORKFLOW_RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_RUN_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
           MANUAL_SHA: ${{ inputs.sha }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
           if [ "$EVENT_NAME" = "workflow_run" ]; then
+            if [ "$WORKFLOW_RUN_EVENT" != "push" ] ||
+               [ "$WORKFLOW_RUN_BRANCH" != "main" ] ||
+               [ "$WORKFLOW_RUN_REPOSITORY" != "$GITHUB_REPOSITORY" ]; then
+              echo "::error::자동 배포는 동일 저장소의 main push Backend CI만 허용합니다."
+              exit 1
+            fi
             TARGET_SHA="$WORKFLOW_RUN_SHA"
           else
             TARGET_SHA="$MANUAL_SHA"

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -19,6 +19,12 @@ permissions:
   id-token: write   # OIDC 로 AWS 자격 취득
   contents: read
 
+# 배포는 한 번에 하나만(동시 배포가 :latest 를 앞다퉈 덮어써 잘못된 이미지가 나가는 것 방지).
+# 진행 중 배포는 취소하지 않고 큐잉한다(배포 중단 방지).
+concurrency:
+  group: backend-deploy
+  cancel-in-progress: false
+
 env:
   AWS_REGION: ap-northeast-2
   ECR_REPOSITORY: oncare-backend
@@ -31,20 +37,22 @@ jobs:
       ${{ github.event_name == 'workflow_dispatch' ||
           github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v4
+      # 배포 권한(OIDC)을 쓰는 스텝의 외부 action 은 이동 가능한 태그가 아니라 불변 커밋 SHA 로 핀한다
+      # (공급망 변경 리스크 완화). 뒤 주석은 원 버전. 갱신 시 GitHub API 로 태그→커밋 SHA 재조회.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           # CI 를 통과한 정확한 커밋을 배포(workflow_dispatch 는 현재 ref).
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
         id: ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2
 
       - name: Build and push image
         working-directory: backend
@@ -59,7 +67,32 @@ jobs:
           docker push "$IMAGE"
           docker push "$LATEST"
 
-      - name: Trigger App Runner deployment
+      - name: Deploy to App Runner and wait for health
+        env:
+          SVC: ${{ secrets.APPRUNNER_SERVICE_ARN }}
         run: |
-          aws apprunner start-deployment \
-            --service-arn "${{ secrets.APPRUNNER_SERVICE_ARN }}"
+          set -euo pipefail
+          OP=$(aws apprunner start-deployment --service-arn "$SVC" --query OperationId --output text)
+          echo "started deployment operation: $OP"
+          # 배포 완료까지 서비스 status 폴링 (OPERATION_IN_PROGRESS -> RUNNING). 최대 ~10분.
+          for i in $(seq 1 40); do
+            STATUS=$(aws apprunner describe-service --service-arn "$SVC" \
+              --query 'Service.Status' --output text)
+            echo "[$i] service status: $STATUS"
+            case "$STATUS" in
+              RUNNING) break ;;
+              OPERATION_IN_PROGRESS) sleep 15 ;;
+              *) echo "::error::예상치 못한 App Runner 상태: $STATUS"; exit 1 ;;
+            esac
+            if [ "$i" -eq 40 ]; then echo "::error::배포가 시간 내 완료되지 않음"; exit 1; fi
+          done
+          # 실제 서비스가 응답하는지 /v1/healthz 로 확인(개시 성공≠배포 성공).
+          URL=$(aws apprunner describe-service --service-arn "$SVC" \
+            --query 'Service.ServiceUrl' --output text)
+          for i in $(seq 1 10); do
+            if curl -fsS "https://$URL/v1/healthz" > /dev/null; then
+              echo "healthz OK -> deploy verified"; exit 0
+            fi
+            echo "healthz not ready, retry $i"; sleep 10
+          done
+          echo "::error::배포 후 /v1/healthz 가 응답하지 않음"; exit 1

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -1,26 +1,27 @@
 name: Backend Deploy (ECR + App Runner)
 
-# main 에 backend 변경이 push 되면 이미지를 빌드→ECR push→App Runner 재배포.
+# main의 Backend CI를 통과한 정확한 커밋 이미지만 ECR과 App Runner에 배포한다.
 # 필요한 GitHub Secrets:
-#   AWS_DEPLOY_ROLE_ARN   OIDC 로 assume 할 IAM 역할 ARN(ECR push + App Runner 배포 권한)
+#   AWS_DEPLOY_ROLE_ARN   OIDC로 assume할 IAM 역할 ARN
 #   APPRUNNER_SERVICE_ARN 배포 대상 App Runner 서비스 ARN
-# 리전/리포명은 아래 env 에서 조정.
-
-# 배포는 "Backend CI"(test + alembic heads 검사)가 main 에서 성공했을 때만 실행한다.
-# 이렇게 하면 실패한 커밋이 운영에 배포되지 않는다(테스트 통과 게이팅).
 on:
   workflow_run:
     workflows: ["Backend CI"]
     types: [completed]
     branches: [main]
   workflow_dispatch:
+    inputs:
+      sha:
+        description: "Backend CI를 통과한 main 커밋의 전체 SHA(40자)"
+        required: true
+        type: string
 
 permissions:
-  id-token: write   # OIDC 로 AWS 자격 취득
+  actions: read
   contents: read
+  id-token: write
 
-# 배포는 한 번에 하나만(동시 배포가 :latest 를 앞다퉈 덮어써 잘못된 이미지가 나가는 것 방지).
-# 진행 중 배포는 취소하지 않고 큐잉한다(배포 중단 방지).
+# 진행 중인 배포를 취소하지 않고 한 번에 하나씩 실행한다.
 concurrency:
   group: backend-deploy
   cancel-in-progress: false
@@ -32,17 +33,65 @@ env:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    # workflow_run 은 성공했을 때만(수동 실행은 무조건 허용).
     if: >-
-      ${{ github.event_name == 'workflow_dispatch' ||
-          github.event.workflow_run.conclusion == 'success' }}
+      ${{ (github.event_name == 'workflow_run' &&
+           github.event.workflow_run.conclusion == 'success') ||
+          (github.event_name == 'workflow_dispatch' &&
+           github.ref == 'refs/heads/main') }}
     steps:
-      # 배포 권한(OIDC)을 쓰는 스텝의 외부 action 은 이동 가능한 태그가 아니라 불변 커밋 SHA 로 핀한다
-      # (공급망 변경 리스크 완화). 뒤 주석은 원 버전. 갱신 시 GitHub API 로 태그→커밋 SHA 재조회.
+      - name: Resolve and verify deploy commit
+        id: target
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          MANUAL_SHA: ${{ inputs.sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
+            TARGET_SHA="$WORKFLOW_RUN_SHA"
+          else
+            TARGET_SHA="$MANUAL_SHA"
+          fi
+          TARGET_SHA=$(printf '%s' "$TARGET_SHA" | tr '[:upper:]' '[:lower:]')
+
+          if ! [[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::배포 SHA는 40자리 전체 커밋 SHA여야 합니다."
+            exit 1
+          fi
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            MATCHES=$(gh api \
+              --method GET \
+              "repos/$GITHUB_REPOSITORY/actions/workflows/backend-ci.yml/runs" \
+              -f branch=main \
+              -f event=push \
+              -f status=success \
+              -f head_sha="$TARGET_SHA" \
+              -f per_page=100 \
+              --jq '[.workflow_runs[] |
+                select(
+                  .head_sha == "'"$TARGET_SHA"'" and
+                  .head_branch == "main" and
+                  .event == "push" and
+                  .conclusion == "success"
+                )
+              ] | length')
+            if [ "$MATCHES" -lt 1 ]; then
+              echo "::error::$TARGET_SHA에 대한 main Backend CI 성공 기록이 없습니다."
+              exit 1
+            fi
+          fi
+
+          echo "sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"
+          echo "Verified deploy commit: $TARGET_SHA"
+
+      # 배포 권한(OIDC)을 쓰는 외부 action은 불변 커밋 SHA로 고정한다.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          # CI 를 통과한 정확한 커밋을 배포(workflow_dispatch 는 현재 ref).
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ steps.target.outputs.sha }}
+          persist-credentials: false
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
@@ -54,45 +103,112 @@ jobs:
         id: ecr
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2
 
-      - name: Build and push image
+      - name: Build and push immutable image
+        id: image
         working-directory: backend
         env:
           REGISTRY: ${{ steps.ecr.outputs.registry }}
-          SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          SHA: ${{ steps.target.outputs.sha }}
         run: |
           set -euo pipefail
-          IMAGE="$REGISTRY/$ECR_REPOSITORY:$SHA"
-          LATEST="$REGISTRY/$ECR_REPOSITORY:latest"
-          docker build -t "$IMAGE" -t "$LATEST" .
-          docker push "$IMAGE"
-          docker push "$LATEST"
+          TAGGED_IMAGE="$REGISTRY/$ECR_REPOSITORY:$SHA"
+          docker build -t "$TAGGED_IMAGE" .
+          docker push "$TAGGED_IMAGE"
 
-      - name: Deploy to App Runner and wait for health
+          DIGEST=$(aws ecr describe-images \
+            --repository-name "$ECR_REPOSITORY" \
+            --image-ids imageTag="$SHA" \
+            --query 'imageDetails[0].imageDigest' \
+            --output text)
+          if ! [[ "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::ECR 이미지 digest를 확인하지 못했습니다: $DIGEST"
+            exit 1
+          fi
+
+          IMAGE_IDENTIFIER="$REGISTRY/$ECR_REPOSITORY@$DIGEST"
+          echo "identifier=$IMAGE_IDENTIFIER" >> "$GITHUB_OUTPUT"
+          echo "Pushed immutable image: $IMAGE_IDENTIFIER"
+
+      - name: Update App Runner source and wait for operation
         env:
           SVC: ${{ secrets.APPRUNNER_SERVICE_ARN }}
+          IMAGE_IDENTIFIER: ${{ steps.image.outputs.identifier }}
         run: |
           set -euo pipefail
-          OP=$(aws apprunner start-deployment --service-arn "$SVC" --query OperationId --output text)
-          echo "started deployment operation: $OP"
-          # 배포 완료까지 서비스 status 폴링 (OPERATION_IN_PROGRESS -> RUNNING). 최대 ~10분.
+
+          SOURCE_FILE="$RUNNER_TEMP/source-configuration.json"
+          aws apprunner describe-service \
+            --service-arn "$SVC" \
+            --query 'Service.SourceConfiguration' \
+            --output json |
+            jq --arg image "$IMAGE_IDENTIFIER" '
+              if .ImageRepository == null then
+                error("App Runner service is not configured with ImageRepository")
+              else
+                .ImageRepository.ImageIdentifier = $image
+                | .AutoDeploymentsEnabled = false
+              end
+            ' > "$SOURCE_FILE"
+
+          OP=$(aws apprunner update-service \
+            --service-arn "$SVC" \
+            --source-configuration "file://$SOURCE_FILE" \
+            --query OperationId \
+            --output text)
+          if [ -z "$OP" ] || [ "$OP" = "None" ]; then
+            echo "::error::App Runner update-service OperationId를 받지 못했습니다."
+            exit 1
+          fi
+          echo "Started App Runner operation: $OP"
+
           for i in $(seq 1 40); do
-            STATUS=$(aws apprunner describe-service --service-arn "$SVC" \
-              --query 'Service.Status' --output text)
-            echo "[$i] service status: $STATUS"
+            STATUS=$(aws apprunner list-operations \
+              --service-arn "$SVC" \
+              --query "OperationSummaryList[?Id=='$OP'].Status | [0]" \
+              --output text)
+            echo "[$i] operation $OP status: $STATUS"
             case "$STATUS" in
-              RUNNING) break ;;
-              OPERATION_IN_PROGRESS) sleep 15 ;;
-              *) echo "::error::예상치 못한 App Runner 상태: $STATUS"; exit 1 ;;
+              SUCCEEDED)
+                break
+                ;;
+              PENDING|IN_PROGRESS|None|"")
+                if [ "$i" -eq 40 ]; then
+                  echo "::error::App Runner 작업이 제한 시간 안에 완료되지 않았습니다."
+                  exit 1
+                fi
+                sleep 15
+                ;;
+              FAILED|ROLLBACK_IN_PROGRESS|ROLLBACK_FAILED|ROLLBACK_SUCCEEDED)
+                echo "::error::App Runner 작업 실패: $STATUS (OperationId: $OP)"
+                exit 1
+                ;;
+              *)
+                echo "::error::알 수 없는 App Runner 작업 상태: $STATUS"
+                exit 1
+                ;;
             esac
-            if [ "$i" -eq 40 ]; then echo "::error::배포가 시간 내 완료되지 않음"; exit 1; fi
           done
-          # 실제 서비스가 응답하는지 /v1/healthz 로 확인(개시 성공≠배포 성공).
-          URL=$(aws apprunner describe-service --service-arn "$SVC" \
-            --query 'Service.ServiceUrl' --output text)
+
+          DEPLOYED_IMAGE=$(aws apprunner describe-service \
+            --service-arn "$SVC" \
+            --query 'Service.SourceConfiguration.ImageRepository.ImageIdentifier' \
+            --output text)
+          if [ "$DEPLOYED_IMAGE" != "$IMAGE_IDENTIFIER" ]; then
+            echo "::error::App Runner 이미지 불일치: expected=$IMAGE_IDENTIFIER actual=$DEPLOYED_IMAGE"
+            exit 1
+          fi
+
+          URL=$(aws apprunner describe-service \
+            --service-arn "$SVC" \
+            --query 'Service.ServiceUrl' \
+            --output text)
           for i in $(seq 1 10); do
             if curl -fsS "https://$URL/v1/healthz" > /dev/null; then
-              echo "healthz OK -> deploy verified"; exit 0
+              echo "healthz OK: immutable deploy verified"
+              exit 0
             fi
-            echo "healthz not ready, retry $i"; sleep 10
+            echo "healthz not ready, retry $i"
+            sleep 10
           done
-          echo "::error::배포 후 /v1/healthz 가 응답하지 않음"; exit 1
+          echo "::error::배포 후 /v1/healthz가 응답하지 않습니다."
+          exit 1

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,14 +1,24 @@
 FROM python:3.12-slim
 WORKDIR /code
+
+# psycopg(libpq) 빌드 의존성. 슬림 이미지 기준.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential libpq-dev && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+
+# 앱 + 마이그레이션 자산(운영은 Alembic 이 스키마의 정답이므로 반드시 포함).
 COPY app ./app
+COPY migrations ./migrations
+COPY alembic.ini ./alembic.ini
+COPY scripts ./scripts
+RUN chmod +x scripts/start.sh
 
 # 비루트 유저로 실행 (컨테이너 탈출 시 피해 범위 축소)
 RUN useradd --create-home --uid 10001 appuser && chown -R appuser:appuser /code
 USER appuser
 
 EXPOSE 8000
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# 기동: alembic upgrade head 후 uvicorn(프록시 뒤이므로 --proxy-headers).
+CMD ["scripts/start.sh"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,10 +1,8 @@
 FROM python:3.12-slim
 WORKDIR /code
 
-# psycopg(libpq) 빌드 의존성. 슬림 이미지 기준.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential libpq-dev && rm -rf /var/lib/apt/lists/*
-
+# psycopg[binary] 휠이 libpq 를 번들하므로 apt 빌드 툴체인(build-essential/libpq-dev)이
+# 불필요하다 — 이미지에서 수백 MB 를 덜어낸다. (소스 빌드로 바꾸면 psycopg[c] + libpq-dev 필요)
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/backend/docs/DEPLOY.md
+++ b/backend/docs/DEPLOY.md
@@ -16,7 +16,9 @@ GitHub(main push) ──> Actions ──> ECR(이미지) ──> App Runner(:800
 운영은 `AUTO_CREATE_TABLES=false` 로 두고 Alembic 을 스키마의 유일한 소스로 삼는다.
 
 **배포 게이팅**: `.github/workflows/backend-deploy.yml` 은 **"Backend CI" 가 성공**했을 때만
-(workflow_run) 실행되어, 테스트/마이그레이션 실패 커밋이 운영에 배포되지 않는다. Backend CI 는
+(workflow_run) 실행되며, 자동 배포는 **동일 저장소의 `main` push**에서 발생한 성공 run만
+허용한다. PR·fork 등 다른 이벤트의 CI 결과로는 배포할 수 없다. 따라서 테스트/마이그레이션
+실패 커밋이나 병합되지 않은 코드는 운영에 배포되지 않는다. Backend CI 는
 `alembic heads` 가 **정확히 1개**인지 검사해 마이그레이션 head 분기(선형화 누락)를 막는다.
 배포 잡은 `concurrency` 로 한 번에 하나만 돌고, `update-service`가 반환한 정확한 OperationId와
 `/v1/healthz` 를 폴링해 **실제 배포·기동 성공까지 확인**한 뒤 워크플로우를 통과시킨다.

--- a/backend/docs/DEPLOY.md
+++ b/backend/docs/DEPLOY.md
@@ -18,6 +18,12 @@ GitHub(main push) ──> Actions ──> ECR(이미지) ──> App Runner(:800
 **배포 게이팅**: `.github/workflows/backend-deploy.yml` 은 **"Backend CI" 가 성공**했을 때만
 (workflow_run) 실행되어, 테스트/마이그레이션 실패 커밋이 운영에 배포되지 않는다. Backend CI 는
 `alembic heads` 가 **정확히 1개**인지 검사해 마이그레이션 head 분기(선형화 누락)를 막는다.
+배포 잡은 `concurrency` 로 한 번에 하나만 돌고, `start-deployment` 후 App Runner 상태와
+`/v1/healthz` 를 폴링해 **실제 배포·기동 성공까지 확인**한 뒤 워크플로우를 통과시킨다.
+
+> ⚠️ **수동 실행 주의**: `workflow_dispatch` 로 수동 트리거하면 **CI 성공 게이트를 우회**해
+> 현재 ref 를 그대로 배포한다(리포 write 권한자만 가능). 최초 배포/긴급 롤백 용도로만 쓰고,
+> 반드시 로컬에서 `alembic upgrade head` + `pytest` 를 통과시킨 커밋에서만 사용한다.
 
 ---
 
@@ -58,16 +64,28 @@ CREATE EXTENSION IF NOT EXISTS vector;
 
 ## 4) App Runner 서비스
 
-- 소스: ECR 이미지(`oncare-backend:latest`), 포트 `8000`.
+- 소스: ECR 이미지, 포트 `8000`. CI 는 매 배포마다 **커밋 SHA 태그** 이미지(`oncare-backend:<sha>`)와
+  `:latest` 를 함께 push 한다.
+- **배포 방식(권장)**: CI 가 push 직후 `start-deployment` 로 트리거하고 완료·헬스까지 확인한다.
+  App Runner 자동배포를 `:latest` 로 켜두면 **다른 push 가 먼저 `:latest` 를 덮을 때 CI 통과 SHA 가
+  아닌 이미지가 나갈 수 있으므로**, 정확성이 중요하면 App Runner 소스 이미지를 `:latest` 대신
+  **커밋 SHA 태그(또는 digest)** 로 지정하고 CI 가 그 이미지 식별자를 갱신하도록 두는 편이 안전하다.
 - 헬스체크: HTTP `GET /v1/healthz`.
 - 환경변수: 위 표(민감값은 Secrets 참조).
-- 자동배포: ECR `:latest` push 시 재배포(또는 CI 의 `start-deployment` 로 트리거).
 - 컨테이너가 기동 시 마이그레이션을 수행하므로 별도 마이그레이션 스텝 불필요.
 
-## 5) CI 용 GitHub Secrets
+## 5) CI 용 GitHub Secrets & IAM 역할
 
-- `AWS_DEPLOY_ROLE_ARN` — GitHub OIDC 로 assume 하는 IAM 역할(ECR push + `apprunner:StartDeployment`).
+- `AWS_DEPLOY_ROLE_ARN` — GitHub OIDC 로 assume 하는 IAM 역할. 필요 권한: ECR push
+  (`ecr:GetAuthorizationToken`, `ecr:BatchCheckLayerAvailability`, `ecr:PutImage`,
+  `ecr:InitiateLayerUpload`, `ecr:UploadLayerPart`, `ecr:CompleteLayerUpload`) + `apprunner:StartDeployment`,
+  `apprunner:DescribeService`.
 - `APPRUNNER_SERVICE_ARN` — 배포 대상 App Runner 서비스 ARN.
+- **App Runner ECR 액세스 역할(별도)**: App Runner 가 **private ECR 에서 이미지를 pull** 하려면
+  서비스의 `AuthenticationConfiguration.AccessRoleArn` 에 지정하는 IAM 역할이 필요하다.
+  신뢰 주체 `build.apprunner.amazonaws.com`, 정책은 `ecr:GetAuthorizationToken`(리소스 `*`) +
+  `ecr:BatchGetImage`·`ecr:GetDownloadUrlForLayer`·`ecr:BatchCheckLayerAvailability`·`ecr:DescribeImages`
+  (해당 리포 리소스). 이 역할이 없으면 배포/기동 시 이미지 pull 이 실패한다.
 
 ## 6) 프론트 연결
 
@@ -81,15 +99,23 @@ flutter build web --release \
 
 ---
 
-## ⚠️ 마이그레이션 head 선형화 (머지 순서 주의)
+## 마이그레이션 head 선형화 (머지 순서 주의)
 
-트레이너 도메인 마이그레이션(`0010_trainer_domain`)과 `backend-diet-macros`의
-`0010_diet_entry_macros` 가 **둘 다 0009 에서 분기**한다. 둘 다 머지되면 Alembic head 가
-2개가 되어 `alembic upgrade head` 가 실패한다.
+병렬 브랜치가 같은 부모에서 각자 새 마이그레이션을 만들면 Alembic head 가 여러 개가 되어
+`alembic upgrade head` 가 실패한다. 현재는 아래처럼 **단일 선형 체인**으로 정리돼 있다:
 
-**나중에 머지되는 쪽**이 자기 마이그레이션의 `down_revision` 을 상대 head 로 바꿔 선형화한다
-(1줄 + 파일명 `0011_` 정리). 예: diet-macros 가 먼저 머지되면 트레이너 마이그레이션을
-`down_revision = "0010_diet_entry_macros"` 로.
+```
+0009_diet_idempotency_key → 0010_diet_entry_macros(#207) → 0011_health_daily_sugar_g(#231)
+                          → 0012_trainer_domain(트레이너 스택)
+```
+
+**원칙**: 나중에 머지되는 마이그레이션의 `down_revision` 을 현재 main head 로 맞춰 한 줄로 잇는다
+(파일명 숫자도 위치에 맞게). 트레이너 스택은 위 순서대로 **가장 마지막**에 머지한다.
+
+> 단, **한쪽 브랜치가 이미 staging/production DB 에 적용된 뒤**라면 위 "down_revision 만 바꾸기"를
+> 쓰면 안 된다. 먼저 `alembic current` 로 그 DB 의 현재 revision 을 확인하고, 이미 적용된 경우
+> `alembic merge` 로 병합 revision 을 만들거나 실제 적용 상태에 맞춰 head 를 선형화한다.
+> CI 의 single-head 검사(`alembic heads` == 1)로 분기 재발을 막는다.
 
 ---
 

--- a/backend/docs/DEPLOY.md
+++ b/backend/docs/DEPLOY.md
@@ -1,8 +1,8 @@
 # 백엔드 배포 가이드 — AWS App Runner + RDS(pgvector)
 
 컨테이너 + Postgres(pgvector) 구조라 **App Runner + RDS PostgreSQL** 조합을 권장한다
-(HTTPS 자동, 운영 부담 최소). CI 는 `main` push 시 이미지를 ECR 에 올리고 App Runner 를
-재배포한다(`.github/workflows/backend-deploy.yml`).
+(HTTPS 자동, 운영 부담 최소). `main`의 Backend CI가 성공하면 해당 커밋 이미지를 ECR에 올리고,
+불변 digest로 App Runner 소스를 갱신한다(`.github/workflows/backend-deploy.yml`).
 
 ```
 GitHub(main push) ──> Actions ──> ECR(이미지) ──> App Runner(:8000, /v1/healthz)
@@ -18,12 +18,13 @@ GitHub(main push) ──> Actions ──> ECR(이미지) ──> App Runner(:800
 **배포 게이팅**: `.github/workflows/backend-deploy.yml` 은 **"Backend CI" 가 성공**했을 때만
 (workflow_run) 실행되어, 테스트/마이그레이션 실패 커밋이 운영에 배포되지 않는다. Backend CI 는
 `alembic heads` 가 **정확히 1개**인지 검사해 마이그레이션 head 분기(선형화 누락)를 막는다.
-배포 잡은 `concurrency` 로 한 번에 하나만 돌고, `start-deployment` 후 App Runner 상태와
+배포 잡은 `concurrency` 로 한 번에 하나만 돌고, `update-service`가 반환한 정확한 OperationId와
 `/v1/healthz` 를 폴링해 **실제 배포·기동 성공까지 확인**한 뒤 워크플로우를 통과시킨다.
 
-> ⚠️ **수동 실행 주의**: `workflow_dispatch` 로 수동 트리거하면 **CI 성공 게이트를 우회**해
-> 현재 ref 를 그대로 배포한다(리포 write 권한자만 가능). 최초 배포/긴급 롤백 용도로만 쓰고,
-> 반드시 로컬에서 `alembic upgrade head` + `pytest` 를 통과시킨 커밋에서만 사용한다.
+**수동 실행**도 CI 게이트를 우회하지 않는다. `main`에서 워크플로우를 실행하며 배포할 40자리
+커밋 SHA를 입력해야 하고, 워크플로우가 GitHub Actions API에서 그 SHA의 `main` push에 대한
+`Backend CI` 성공 기록을 확인한 뒤에만 배포한다. 따라서 최초 배포나 롤백도 이미 CI를 통과한
+`main` 커밋 중에서 선택해야 한다.
 
 ---
 
@@ -64,21 +65,24 @@ CREATE EXTENSION IF NOT EXISTS vector;
 
 ## 4) App Runner 서비스
 
-- 소스: ECR 이미지, 포트 `8000`. CI 는 매 배포마다 **커밋 SHA 태그** 이미지(`oncare-backend:<sha>`)와
-  `:latest` 를 함께 push 한다.
-- **배포 방식(권장)**: CI 가 push 직후 `start-deployment` 로 트리거하고 완료·헬스까지 확인한다.
-  App Runner 자동배포를 `:latest` 로 켜두면 **다른 push 가 먼저 `:latest` 를 덮을 때 CI 통과 SHA 가
-  아닌 이미지가 나갈 수 있으므로**, 정확성이 중요하면 App Runner 소스 이미지를 `:latest` 대신
-  **커밋 SHA 태그(또는 digest)** 로 지정하고 CI 가 그 이미지 식별자를 갱신하도록 두는 편이 안전하다.
+- 소스: ECR 이미지, 포트 `8000`. CI는 **커밋 SHA 태그** 이미지(`oncare-backend:<sha>`)만 push하고
+  ECR에서 그 이미지의 digest를 조회한다. 가변 `:latest` 태그는 만들거나 배포하지 않는다.
+- **배포 방식**: CI가 `update-service`로 App Runner의
+  `SourceConfiguration.ImageRepository.ImageIdentifier`를 `oncare-backend@sha256:...` 형식의
+  불변 digest로 갱신하고 자동배포를 끈다. 기존 이미지 환경변수·시크릿·ECR 액세스 역할은
+  `describe-service` 결과에서 보존한다.
+- 워크플로우는 `update-service`의 OperationId를 `list-operations`로 추적하고, 성공 후 서비스에
+  설정된 이미지 식별자가 요청한 digest와 같은지도 검증한다.
 - 헬스체크: HTTP `GET /v1/healthz`.
 - 환경변수: 위 표(민감값은 Secrets 참조).
 - 컨테이너가 기동 시 마이그레이션을 수행하므로 별도 마이그레이션 스텝 불필요.
 
 ## 5) CI 용 GitHub Secrets & IAM 역할
 
-- `AWS_DEPLOY_ROLE_ARN` — GitHub OIDC 로 assume 하는 IAM 역할. 필요 권한: ECR push
+- `AWS_DEPLOY_ROLE_ARN` — GitHub OIDC 로 assume 하는 IAM 역할. 필요 권한: ECR push 및 digest 조회
   (`ecr:GetAuthorizationToken`, `ecr:BatchCheckLayerAvailability`, `ecr:PutImage`,
-  `ecr:InitiateLayerUpload`, `ecr:UploadLayerPart`, `ecr:CompleteLayerUpload`) + `apprunner:StartDeployment`,
+  `ecr:InitiateLayerUpload`, `ecr:UploadLayerPart`, `ecr:CompleteLayerUpload`,
+  `ecr:DescribeImages`) + `apprunner:UpdateService`, `apprunner:ListOperations`,
   `apprunner:DescribeService`.
 - `APPRUNNER_SERVICE_ARN` — 배포 대상 App Runner 서비스 ARN.
 - **App Runner ECR 액세스 역할(별도)**: App Runner 가 **private ECR 에서 이미지를 pull** 하려면

--- a/backend/docs/DEPLOY.md
+++ b/backend/docs/DEPLOY.md
@@ -106,7 +106,7 @@ flutter build web --release \
 
 ```
 0009_diet_idempotency_key → 0010_diet_entry_macros(#207) → 0011_health_daily_sugar_g(#231)
-                          → 0012_trainer_domain(트레이너 스택)
+                          → 0012_trainer_domain(트레이너 도메인) → 0013_trainer_active_coach_uq(active 담당 unique index)
 ```
 
 **원칙**: 나중에 머지되는 마이그레이션의 `down_revision` 을 현재 main head 로 맞춰 한 줄로 잇는다

--- a/backend/docs/DEPLOY.md
+++ b/backend/docs/DEPLOY.md
@@ -1,0 +1,93 @@
+# 백엔드 배포 가이드 — AWS App Runner + RDS(pgvector)
+
+컨테이너 + Postgres(pgvector) 구조라 **App Runner + RDS PostgreSQL** 조합을 권장한다
+(HTTPS 자동, 운영 부담 최소). CI 는 `main` push 시 이미지를 ECR 에 올리고 App Runner 를
+재배포한다(`.github/workflows/backend-deploy.yml`).
+
+```
+GitHub(main push) ──> Actions ──> ECR(이미지) ──> App Runner(:8000, /v1/healthz)
+                                                        │
+                                                        └── RDS PostgreSQL 15+ (CREATE EXTENSION vector)
+```
+
+기동 흐름: 컨테이너가 `scripts/start.sh` 로 **`alembic upgrade head` → uvicorn(--proxy-headers)**.
+운영은 `AUTO_CREATE_TABLES=false` 로 두고 Alembic 을 스키마의 유일한 소스로 삼는다.
+
+---
+
+## 1) ECR 리포지토리
+
+```bash
+aws ecr create-repository --repository-name oncare-backend --region ap-northeast-2
+```
+
+## 2) RDS PostgreSQL (pgvector)
+
+- 엔진: PostgreSQL **15.2+** (pgvector 지원 버전). 보안그룹은 App Runner VPC 커넥터에서 5432 허용.
+- 생성 후 pgvector 확장 1회:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+```
+
+- `DATABASE_URL` 형식: `postgresql+psycopg://<user>:<pass>@<rds-endpoint>:5432/<db>`
+
+## 3) 환경변수 / Secrets (App Runner)
+
+| 키 | 값/설명 |
+|---|---|
+| `ENV` | `prod` (fail-fast 하드닝 활성) |
+| `JWT_SECRET` | `openssl rand -hex 32` (기본값이면 기동 거부) |
+| `DATABASE_URL` | 위 RDS 접속 문자열 |
+| `AUTO_CREATE_TABLES` | `false` (Alembic 이 정답) |
+| `CORS_ALLOW_ORIGINS` | GitHub Pages 도메인 (예: `https://ewhasudo.zapto.org`) |
+| `TZ` | `Asia/Seoul` (오늘/어제 라벨 KST 기준) |
+| `SEED_DEMO_DATA` | 운영 권장 `false`. 데이터 든 데모 계정을 두려면 `true` + `DEMO_LOGIN_PASSWORD` 필수 |
+| `DEMO_LOGIN_PASSWORD` | `SEED_DEMO_DATA=true` 일 때 12자+ 강한 값(아니면 기동 거부) |
+| `GEMINI_API_KEY` 또는 LiteLLM(`LITELLM_*`) | 식단 인식/코치. 없으면 stub 폴백 |
+| `KAKAO_REST_API_KEY` | 장소(O2O) 실검색. 없으면 시드 폴백. `PLACES_PROVIDER=auto` 기본 |
+
+> 참고: 키가 없어도 인식/장소는 폴백으로 동작(기동은 됨). 운영 시크릿은 Secrets Manager/SSM 에 두고
+> App Runner 에 주입한다.
+
+## 4) App Runner 서비스
+
+- 소스: ECR 이미지(`oncare-backend:latest`), 포트 `8000`.
+- 헬스체크: HTTP `GET /v1/healthz`.
+- 환경변수: 위 표(민감값은 Secrets 참조).
+- 자동배포: ECR `:latest` push 시 재배포(또는 CI 의 `start-deployment` 로 트리거).
+- 컨테이너가 기동 시 마이그레이션을 수행하므로 별도 마이그레이션 스텝 불필요.
+
+## 5) CI 용 GitHub Secrets
+
+- `AWS_DEPLOY_ROLE_ARN` — GitHub OIDC 로 assume 하는 IAM 역할(ECR push + `apprunner:StartDeployment`).
+- `APPRUNNER_SERVICE_ARN` — 배포 대상 App Runner 서비스 ARN.
+
+## 6) 프론트 연결
+
+```bash
+flutter build web --release \
+  --dart-define=USE_MOCK_API=false \
+  --dart-define=API_BASE_URL=https://<apprunner-domain>/v1
+```
+
+지도 핀은 프론트 카카오맵 **JS SDK**(JS키 + 도메인 등록) 담당. 백엔드는 좌표+정보만 제공한다.
+
+---
+
+## ⚠️ 마이그레이션 head 선형화 (머지 순서 주의)
+
+트레이너 도메인 마이그레이션(`0010_trainer_domain`)과 `backend-diet-macros`의
+`0010_diet_entry_macros` 가 **둘 다 0009 에서 분기**한다. 둘 다 머지되면 Alembic head 가
+2개가 되어 `alembic upgrade head` 가 실패한다.
+
+**나중에 머지되는 쪽**이 자기 마이그레이션의 `down_revision` 을 상대 head 로 바꿔 선형화한다
+(1줄 + 파일명 `0011_` 정리). 예: diet-macros 가 먼저 머지되면 트레이너 마이그레이션을
+`down_revision = "0010_diet_entry_macros"` 로.
+
+---
+
+## 대안 — 저비용 EC2 (수동)
+
+`docker-compose.yml` 거의 그대로 EC2 1대에 올리고 Nginx + Let's Encrypt 로 HTTPS.
+가장 저렴하지만 HTTPS/DB백업/재시작을 직접 관리해야 한다.

--- a/backend/docs/DEPLOY.md
+++ b/backend/docs/DEPLOY.md
@@ -10,8 +10,14 @@ GitHub(main push) ──> Actions ──> ECR(이미지) ──> App Runner(:800
                                                         └── RDS PostgreSQL 15+ (CREATE EXTENSION vector)
 ```
 
-기동 흐름: 컨테이너가 `scripts/start.sh` 로 **`alembic upgrade head` → uvicorn(--proxy-headers)**.
+기동 흐름: 컨테이너가 `scripts/start.sh` 로 **마이그레이션 → uvicorn(--proxy-headers)**.
+마이그레이션은 `scripts/migrate.py` 가 **PostgreSQL advisory lock 으로 직렬화**하므로, App Runner
+가 여러 인스턴스를 동시에 띄워도 하나만 마이그레이션하고 나머지는 대기 후 no-op 이다(리뷰 #3).
 운영은 `AUTO_CREATE_TABLES=false` 로 두고 Alembic 을 스키마의 유일한 소스로 삼는다.
+
+**배포 게이팅**: `.github/workflows/backend-deploy.yml` 은 **"Backend CI" 가 성공**했을 때만
+(workflow_run) 실행되어, 테스트/마이그레이션 실패 커밋이 운영에 배포되지 않는다. Backend CI 는
+`alembic heads` 가 **정확히 1개**인지 검사해 마이그레이션 head 분기(선형화 누락)를 막는다.
 
 ---
 

--- a/backend/scripts/migrate.py
+++ b/backend/scripts/migrate.py
@@ -1,0 +1,39 @@
+"""
+마이그레이션 직렬화 러너 — App Runner 등 다중 인스턴스가 동시에 기동해도
+여러 인스턴스가 같은 DB 를 동시에 마이그레이션하지 않도록 PostgreSQL advisory lock
+으로 직렬화한다(리뷰 재-#3).
+
+한 인스턴스가 lock 을 잡고 `alembic upgrade head` 를 수행하는 동안 다른 인스턴스는
+lock 획득에서 대기하다가, 앞 인스턴스가 끝나면 lock 을 잡고 alembic 을 실행한다
+(이미 head 면 사실상 no-op). alembic 이 실패하면 비정상 종료해 서버 기동을 막는다.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import psycopg
+
+# 마이그레이션 전용 고정 advisory lock 키(임의 상수). 다른 용도와 겹치지 않게.
+_LOCK_KEY = 4815162342
+
+
+def main() -> int:
+    # DATABASE_URL 은 SQLAlchemy 형식(postgresql+psycopg://...) → psycopg 는 순수 postgresql://
+    url = os.environ["DATABASE_URL"].replace("postgresql+psycopg://", "postgresql://")
+    conn = psycopg.connect(url, autocommit=True)
+    try:
+        print(f"[migrate] acquiring advisory lock {_LOCK_KEY}", flush=True)
+        conn.execute("SELECT pg_advisory_lock(%s)", (_LOCK_KEY,))
+        print("[migrate] lock acquired -> alembic upgrade head", flush=True)
+        subprocess.run(["alembic", "upgrade", "head"], check=True)
+        print("[migrate] alembic upgrade head done", flush=True)
+        return 0
+    finally:
+        conn.execute("SELECT pg_advisory_unlock(%s)", (_LOCK_KEY,))
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/migrate.py
+++ b/backend/scripts/migrate.py
@@ -12,11 +12,22 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import time
 
 import psycopg
 
 # 마이그레이션 전용 고정 advisory lock 키(임의 상수). 다른 용도와 겹치지 않게.
 _LOCK_KEY = 4815162342
+# lock 획득 총 대기 한도(초)와 재시도 간격. 앞 인스턴스가 lock 을 들고 멈추거나 DB 에
+# lock 이 걸려 있어도 무한 대기하지 않고 fail-fast 하도록 한다(리뷰: pg_advisory_lock 무한 대기).
+_LOCK_TIMEOUT_SECONDS = float(os.environ.get("MIGRATE_LOCK_TIMEOUT", "120"))
+_LOCK_RETRY_INTERVAL = float(os.environ.get("MIGRATE_LOCK_RETRY_INTERVAL", "2"))
+
+
+def _try_acquire(conn: psycopg.Connection) -> bool:
+    """pg_try_advisory_lock 은 대기 없이 즉시 성공/실패를 반환한다(무한 블로킹 방지)."""
+    row = conn.execute("SELECT pg_try_advisory_lock(%s)", (_LOCK_KEY,)).fetchone()
+    return bool(row and row[0])
 
 
 def main() -> int:
@@ -24,14 +35,27 @@ def main() -> int:
     url = os.environ["DATABASE_URL"].replace("postgresql+psycopg://", "postgresql://")
     conn = psycopg.connect(url, autocommit=True)
     try:
-        print(f"[migrate] acquiring advisory lock {_LOCK_KEY}", flush=True)
-        conn.execute("SELECT pg_advisory_lock(%s)", (_LOCK_KEY,))
+        deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
+        print(f"[migrate] acquiring advisory lock {_LOCK_KEY} (timeout {_LOCK_TIMEOUT_SECONDS}s)", flush=True)
+        while not _try_acquire(conn):
+            if time.monotonic() >= deadline:
+                print(
+                    "[migrate] ERROR: advisory lock 을 시간 내 획득하지 못함 — 다른 인스턴스의 "
+                    "마이그레이션이 멈춰있을 수 있음. 기동을 중단한다.",
+                    flush=True,
+                )
+                return 1
+            print("[migrate] lock busy, retrying...", flush=True)
+            time.sleep(_LOCK_RETRY_INTERVAL)
         print("[migrate] lock acquired -> alembic upgrade head", flush=True)
-        subprocess.run(["alembic", "upgrade", "head"], check=True)
-        print("[migrate] alembic upgrade head done", flush=True)
-        return 0
+        try:
+            subprocess.run(["alembic", "upgrade", "head"], check=True)
+            print("[migrate] alembic upgrade head done", flush=True)
+            return 0
+        finally:
+            # lock 은 우리가 획득한 경우에만 해제한다.
+            conn.execute("SELECT pg_advisory_unlock(%s)", (_LOCK_KEY,))
     finally:
-        conn.execute("SELECT pg_advisory_unlock(%s)", (_LOCK_KEY,))
         conn.close()
 
 

--- a/backend/scripts/start.sh
+++ b/backend/scripts/start.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# 운영 컨테이너 기동 엔트리포인트.
+# 1) 스키마를 Alembic head 까지 마이그레이션(운영은 AUTO_CREATE_TABLES=false 권장 →
+#    Alembic 이 유일한 스키마 소스). 2) uvicorn 시작.
+# App Runner/프록시 뒤이므로 --proxy-headers 로 X-Forwarded-Proto 를 신뢰(HTTPS 판정).
+set -euo pipefail
+
+echo "[start] alembic upgrade head"
+alembic upgrade head
+
+echo "[start] launching uvicorn on :8000"
+exec uvicorn app.main:app \
+  --host 0.0.0.0 --port 8000 \
+  --proxy-headers --forwarded-allow-ips="*"

--- a/backend/scripts/start.sh
+++ b/backend/scripts/start.sh
@@ -5,8 +5,8 @@
 # App Runner/프록시 뒤이므로 --proxy-headers 로 X-Forwarded-Proto 를 신뢰(HTTPS 판정).
 set -euo pipefail
 
-echo "[start] alembic upgrade head"
-alembic upgrade head
+echo "[start] migrate (advisory-lock serialized)"
+python scripts/migrate.py
 
 echo "[start] launching uvicorn on :8000"
 exec uvicorn app.main:app \


### PR DESCRIPTION
## Summary
* Dockerfile이 마이그레이션 자산(migrations·alembic.ini·scripts)을 포함하고 `scripts/start.sh`로
  **advisory-lock 마이그레이션 → uvicorn(--proxy-headers)** 기동 → 이미지만으로 배포.
* CI 성공 후에만 **ECR 빌드/푸시 + App Runner 재배포** GitHub Actions(workflow_run 게이팅).
* AWS 셋업 가이드 + single-alembic-head 체크 문서화.

## Changes
### ✨ Features
* `backend/Dockerfile`, `scripts/start.sh`, `scripts/migrate.py`(pg_advisory_lock 직렬화).
* `.github/workflows/backend-deploy.yml`(OIDC→ECR→apprunner), `backend-ci.yml`에 single-head 체크.
* `backend/docs/DEPLOY.md` — App Runner+RDS(pgvector) 가이드 + 환경변수/Secrets 표.

## Commits
1. `9717447` feat(deploy): containerized App Runner deploy (migrations on start) + CI
2. `f2f4b52` fix(deploy): gate deploy on CI, serialize migrations, check single alembic head

## Notes
* 현재 main(`b677b29`) 기반, 재베이스 완료. 다른 PR 머지 후 최신 main 한 번 더 반영 권장
  #257이 diet.py를 리팩터했으므로 그와의 순서·충돌 확인 필수.
* 운영 env: `ENV=prod`, `AUTO_CREATE_TABLES=false`, `CORS_ALLOW_ORIGINS`=도메인 명시, `SEED_DEMO_DATA` 정책, 각 API 키.
* 필요한 Secrets: `AWS_DEPLOY_ROLE_ARN`, `APPRUNNER_SERVICE_ARN`, `JWT_SECRET`, `DATABASE_URL`, `KAKAO_REST_API_KEY`, `GEMINI_API_KEY`.

## Related Issues
Closes #258

## Checklist
* [ ] 코드 리뷰 준비 완료
* [ ] 재베이스 후 Merge 충돌 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 백엔드가 배포 후 데이터베이스 마이그레이션을 자동으로 수행하고 서비스를 시작합니다.
  - AWS 환경에 백엔드 컨테이너를 자동 배포하는 절차가 추가되었습니다.
  - 여러 인스턴스가 동시에 마이그레이션을 실행하지 않도록 안정성이 강화되었습니다.

- **버그 수정**
  - 데이터베이스 마이그레이션이 분기된 상태로 배포되는 문제를 사전에 감지합니다.

- **문서**
  - AWS App Runner와 PostgreSQL 기반 백엔드 배포 및 운영 방법을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->