### PR TITLE
ci(trainer): add PR/main CI for trainer Flutter app

### DIFF
--- a/.github/workflows/trainer-ci.yml
+++ b/.github/workflows/trainer-ci.yml
@@ -1,0 +1,86 @@
+name: Trainer CI
+
+# 트레이너 Flutter 앱(frontend/flutter_trainer) 전용 PR/main CI.
+# 배포(GitHub Pages, /trainer/)는 deploy.yml(#233)이 담당하고, 이 워크플로우는
+# PR 단계에서 analyze/test + Drift WASM 포함 웹 빌드를 검증한다(#185 잔여 작업).
+on:
+  pull_request:
+    paths:
+      - "frontend/flutter_trainer/**"
+      - ".github/workflows/trainer-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "frontend/flutter_trainer/**"
+      - ".github/workflows/trainer-ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: trainer-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze-and-test:
+    name: Analyze and test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend/flutter_trainer
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Test
+        run: flutter test
+
+  web-build:
+    name: Build trainer web with Drift WASM
+    runs-on: ubuntu-latest
+    needs: analyze-and-test
+    defaults:
+      run:
+        working-directory: frontend/flutter_trainer
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      # 웹 빌드 전에 반드시 Drift 런타임(sqlite3.wasm + drift_worker.js)을 web/ 로 받아야 한다.
+      - name: Download Drift WASM runtime
+        run: bash tool/fetch_drift_wasm.sh
+
+      - name: Verify Drift runtime files (source web/)
+        run: |
+          test -s web/sqlite3.wasm
+          test -s web/drift_worker.js
+
+      - name: Build trainer web
+        run: flutter build web --release --base-href "/trainer/"
+
+      # 다운로드뿐 아니라 최종 산출물에도 두 파일이 포함됐는지 확인(배포 시 404 방지).
+      - name: Verify built Drift runtime files (build/web/)
+        run: |
+          test -s build/web/sqlite3.wasm
+          test -s build/web/drift_worker.js

--- a/.github/workflows/trainer-ci.yml
+++ b/.github/workflows/trainer-ci.yml
@@ -30,10 +30,12 @@ jobs:
         working-directory: frontend/flutter_trainer
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: stable
           cache: true
@@ -56,10 +58,12 @@ jobs:
         working-directory: frontend/flutter_trainer
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: stable
           cache: true


### PR DESCRIPTION
## Summary
트레이너 Flutter 앱 전용 CI 추가(#185 잔여 — 배포 /trainer/ 는 #233에서 완료).
- PR/main 변경 시 flutter analyze / flutter test
- Drift WASM 다운로드 후 트레이너 웹 빌드
- 최종 산출물의 sqlite3.wasm·drift_worker.js 검증

## Verification
- [ ] flutter analyze / test / build web 통과 (CI)
- [ ] build/web/sqlite3.wasm·drift_worker.js 존재 (CI)
- [ ] 배포 사이트에서 시드 고객 3명 렌더 확인

Closes #185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 트레이너 앱의 변경 사항에 대해 자동으로 정적 분석과 테스트를 수행합니다.
  * 웹 릴리스 빌드를 자동 검증하여 배포 전 오류를 조기에 확인합니다.
  * 웹 실행에 필요한 구성 파일이 빌드 결과물에 포함되었는지도 확인해 배포 후 리소스 누락 문제를 예방합니다.
  * 최신 변경 사항만 우선 처리하도록 중복 실행을 자동으로 정리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->