### PR TITLE
feat(backend): prod hardening

### DIFF
--- a/backend/app/api/v1/system.py
+++ b/backend/app/api/v1/system.py
@@ -41,9 +41,12 @@ def readyz(db: Annotated[Session, Depends(get_db)]) -> dict[str, str]:
     배포 검증/로드밸런서가 '트래픽 받을 준비'를 판정하는 데 쓴다(liveness 와 분리).
     """
     try:
+        # established-but-slow 커넥션에서도 프로브가 무한 대기하지 않게 짧은 statement_timeout
+        # 을 트랜잭션 로컬로 건다(connect_timeout 은 연결 수립만 커버 — 리뷰 #291).
+        db.execute(text("SET LOCAL statement_timeout = '3s'"))
         db.execute(text("SELECT 1"))
     except Exception:
-        # 실패한 트랜잭션 상태를 롤백해 정리한다 — 같은 세션/커넥션이 이후 재사용될 때
+        # 실패/타임아웃 트랜잭션 상태를 롤백해 정리한다 — 같은 세션/커넥션이 이후 재사용될 때
         # 'aborted transaction' 이 남지 않도록(리뷰 #291).
         db.rollback()
         # 원인(접속 문자열 등)은 서버 로그에만. 클라이언트엔 일반화된 503.

--- a/backend/app/api/v1/system.py
+++ b/backend/app/api/v1/system.py
@@ -43,6 +43,9 @@ def readyz(db: Annotated[Session, Depends(get_db)]) -> dict[str, str]:
     try:
         db.execute(text("SELECT 1"))
     except Exception:
+        # 실패한 트랜잭션 상태를 롤백해 정리한다 — 같은 세션/커넥션이 이후 재사용될 때
+        # 'aborted transaction' 이 남지 않도록(리뷰 #291).
+        db.rollback()
         # 원인(접속 문자열 등)은 서버 로그에만. 클라이언트엔 일반화된 503.
         logger.exception("readiness check failed — DB unavailable")
         raise HTTPException(status_code=503, detail="서비스가 아직 준비되지 않았습니다.")

--- a/backend/app/api/v1/system.py
+++ b/backend/app/api/v1/system.py
@@ -8,12 +8,19 @@
 """
 from __future__ import annotations
 
-from fastapi import APIRouter
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import text
+from sqlalchemy.orm import Session
 
 from app.core.config import get_settings
+from app.db.session import get_db
 
 router = APIRouter(tags=["system"])
 settings = get_settings()
+logger = logging.getLogger("app.system")
 
 
 @router.get("/ping")
@@ -23,7 +30,23 @@ def ping() -> dict[str, str]:
 
 @router.get("/healthz")
 def healthz() -> dict[str, str]:
+    """Liveness — 프로세스 생존만 확인(DB 무관). App Runner liveness 용."""
     return {"status": "ok", "backend": "fastapi"}
+
+
+@router.get("/readyz")
+def readyz(db: Annotated[Session, Depends(get_db)]) -> dict[str, str]:
+    """Readiness — DB 연결 가능 여부까지 확인. 실패 시 내부 상세를 숨긴 503.
+
+    배포 검증/로드밸런서가 '트래픽 받을 준비'를 판정하는 데 쓴다(liveness 와 분리).
+    """
+    try:
+        db.execute(text("SELECT 1"))
+    except Exception:
+        # 원인(접속 문자열 등)은 서버 로그에만. 클라이언트엔 일반화된 503.
+        logger.exception("readiness check failed — DB unavailable")
+        raise HTTPException(status_code=503, detail="서비스가 아직 준비되지 않았습니다.")
+    return {"status": "ready"}
 
 
 @router.get("/version")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -93,6 +93,8 @@ class Settings(BaseSettings):
     # --- 운영 배포 하드닝 ---
     force_https: bool = False       # HTTP→HTTPS 리다이렉트(프록시 뒤면 X-Forwarded-Proto 신뢰)
     security_headers: bool = True   # 보안 응답 헤더(HSTS·nosniff·frame deny 등)
+    # 루트 로거 레벨. 허용값만(임의 문자열 금지 — 오타로 로깅이 조용히 죽는 것 방지).
+    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
 
     # --- Rate limit (인증 엔드포인트 브루트포스 방어) ---
     rate_limit_enabled: bool = True
@@ -142,6 +144,14 @@ class Settings(BaseSettings):
                         f"DEMO_LOGIN_PASSWORD 를 기본값이 아닌 {MIN_DEMO_PASSWORD_LEN}자 이상의 "
                         "안전한 값으로 설정해야 합니다(또는 SEED_DEMO_DATA=false)."
                     )
+            # 운영은 Alembic 을 스키마의 유일한 변경 경로로 삼는다. create_all 이 켜져 있으면
+            # ORM 정의만으로 테이블이 생겨 Alembic 이력과 어긋날 수 있으므로, 조용히 무시하지 않고
+            # 기동을 거부한다(AUTO_CREATE_TABLES=false 를 명시하도록 강제).
+            if self.auto_create_tables:
+                raise ValueError(
+                    "운영(env=prod)에서는 AUTO_CREATE_TABLES=false 로 두고 Alembic 을 스키마의 "
+                    "유일한 소스로 삼아야 합니다."
+                )
         return self
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -28,6 +28,8 @@ class Settings(BaseSettings):
 
     # --- Database ---
     database_url: str = "postgresql+psycopg://oncare:oncare@localhost:5432/oncare"
+    # DB 커넥션 인출(연결 수립) 상한(초) — 네트워크 파티션/무응답 시 스레드 무한 점유 방지.
+    db_connect_timeout_seconds: int = 5
     # 앱 기동 시 create_all() 로 테이블 생성 여부(개발 편의). 운영은 Alembic 을 정답으로 → false 권장.
     auto_create_tables: bool = True
 

--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -98,7 +98,10 @@ def install(app: FastAPI) -> None:
             return response
         except Exception:
             duration_ms = (time.monotonic() - start) * 1000
-            logger.info("%s %r -> 500 (%.1fms)", request.method, request.url.path, duration_ms)
+            # 성공 경로와 동일하게 헬스 폴링 경로는 로그 제외 — 헬스 핸들러의 미처리 예외가
+            # 폴링 빈도만큼 로그를 도배하지 않도록(리뷰 일관성).
+            if not request.url.path.endswith(_ACCESS_LOG_SKIP_SUFFIXES):
+                logger.info("%s %r -> 500 (%.1fms)", request.method, request.url.path, duration_ms)
             raise
         finally:
             request_id_ctx.reset(token)

--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -1,0 +1,107 @@
+"""
+관측성(운영 장애 추적) — 요청 ID · 구조화 액세스 로그 · 전역 예외 처리 · 로깅 설정.
+
+- 요청마다 request ID 를 부여한다. 외부 `X-Request-ID` 는 **형식 검증**을 통과한 값만
+  재사용하고(로그 인젝션 방지), 아니면 새 UUID 를 생성한다.
+- 모든 응답에 `X-Request-ID` 헤더를 실어 클라이언트↔서버 로그를 상관지을 수 있게 한다.
+- 액세스 로그는 method·path·status·duration·request_id 만 남긴다(쿼리/바디/Authorization
+  등 민감정보는 남기지 않는다).
+- 처리되지 않은 예외는 서버 로그에 stack trace 를 **한 번** 남기고, 클라이언트에는 내부
+  상세를 감춘 공통 500 응답(request_id 포함)만 반환한다.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import time
+import uuid
+from contextvars import ContextVar
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+# 로그·헤더에 그대로 싣기 안전한 request ID 형식(영숫자 . _ -, 1~64자). 그 외 입력은 신뢰하지 않는다.
+_REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+_REQUEST_ID_HEADER = "X-Request-ID"
+
+# 현재 요청의 ID. 로그 필터가 여기서 읽어 모든 로그 레코드에 붙인다.
+request_id_ctx: ContextVar[str] = ContextVar("request_id", default="-")
+
+logger = logging.getLogger("app.access")
+
+
+def new_request_id() -> str:
+    return uuid.uuid4().hex
+
+
+def _resolve_request_id(raw: str | None) -> str:
+    """외부 헤더 값은 형식 검증을 통과할 때만 재사용하고, 아니면 새로 생성한다."""
+    if raw and _REQUEST_ID_RE.match(raw):
+        return raw
+    return new_request_id()
+
+
+class RequestIdLogFilter(logging.Filter):
+    """모든 로그 레코드에 현재 request_id 를 주입한다(포맷 문자열에서 %(request_id)s 사용)."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = request_id_ctx.get()
+        return True
+
+
+def setup_logging(level: str = "INFO") -> None:
+    """루트 로거를 request_id 포함 포맷으로 설정한다(호출당 핸들러 1개로 재설정)."""
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(
+        "%(asctime)s %(levelname)s [%(request_id)s] %(name)s: %(message)s"
+    ))
+    handler.addFilter(RequestIdLogFilter())
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(level)
+
+
+def install(app: FastAPI) -> None:
+    """request-id 미들웨어 + 액세스 로그 + 전역 예외 핸들러를 앱에 설치한다."""
+
+    @app.middleware("http")
+    async def _request_context(request: Request, call_next):
+        rid = _resolve_request_id(request.headers.get(_REQUEST_ID_HEADER))
+        # request.state 에도 실어 둔다 — 전역 예외 핸들러는 이 미들웨어 바깥에서 실행되어
+        # contextvar 가 이미 리셋됐을 수 있으므로, 핸들러는 request.state 에서 rid 를 읽는다.
+        request.state.request_id = rid
+        token = request_id_ctx.set(rid)
+        start = time.monotonic()
+        try:
+            response = await call_next(request)
+        except Exception:
+            duration_ms = (time.monotonic() - start) * 1000
+            # 민감정보(쿼리/바디/헤더)는 남기지 않는다 — method·path·소요시간만.
+            logger.info("%s %s -> 500 (%.1fms)", request.method, request.url.path, duration_ms)
+            raise
+        finally:
+            request_id_ctx.reset(token)
+        duration_ms = (time.monotonic() - start) * 1000
+        logger.info(
+            "%s %s -> %d (%.1fms)",
+            request.method, request.url.path, response.status_code, duration_ms,
+        )
+        response.headers[_REQUEST_ID_HEADER] = rid
+        return response
+
+    @app.exception_handler(Exception)
+    async def _unhandled_exception(request: Request, exc: Exception):
+        rid = getattr(request.state, "request_id", "-")
+        token = request_id_ctx.set(rid)  # 핸들러 로깅에도 rid 가 찍히도록
+        try:
+            # stack trace 는 서버 로그에만 한 번. 클라이언트엔 내부 상세를 노출하지 않는다.
+            logging.getLogger("app.error").exception(
+                "unhandled error: %s %s", request.method, request.url.path
+            )
+        finally:
+            request_id_ctx.reset(token)
+        return JSONResponse(
+            status_code=500,
+            content={"detail": "내부 서버 오류가 발생했습니다.", "request_id": rid},
+            headers={_REQUEST_ID_HEADER: rid},
+        )

--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -65,6 +65,11 @@ def setup_logging(level: str = "INFO") -> None:
     root.setLevel(level)
 
 
+# LB/오케스트레이터가 자주 폴링하는 헬스 경로는 액세스 로그에서 제외(로그 도배 방지).
+# readiness 실패의 원인은 system.readyz 가 별도로 logger.exception 으로 남긴다.
+_ACCESS_LOG_SKIP_SUFFIXES = ("/ping", "/healthz", "/readyz")
+
+
 def install(app: FastAPI) -> None:
     """request-id 미들웨어 + 액세스 로그 + 전역 예외 핸들러를 앱에 설치한다."""
 
@@ -83,10 +88,12 @@ def install(app: FastAPI) -> None:
             response = await call_next(request)
             duration_ms = (time.monotonic() - start) * 1000
             # 민감정보(쿼리/바디/헤더)는 남기지 않는다 — method·path·상태·소요시간만.
-            logger.info(
-                "%s %r -> %d (%.1fms)",
-                request.method, request.url.path, response.status_code, duration_ms,
-            )
+            # 헬스 폴링 경로는 로그에서 제외한다.
+            if not request.url.path.endswith(_ACCESS_LOG_SKIP_SUFFIXES):
+                logger.info(
+                    "%s %r -> %d (%.1fms)",
+                    request.method, request.url.path, response.status_code, duration_ms,
+                )
             response.headers[_REQUEST_ID_HEADER] = rid
             return response
         except Exception:

--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -35,8 +35,12 @@ def new_request_id() -> str:
 
 
 def _resolve_request_id(raw: str | None) -> str:
-    """외부 헤더 값은 형식 검증을 통과할 때만 재사용하고, 아니면 새로 생성한다."""
-    if raw and _REQUEST_ID_RE.match(raw):
+    """외부 헤더 값은 형식 검증을 통과할 때만 재사용하고, 아니면 새로 생성한다.
+
+    fullmatch 로 문자열 전체를 검사한다 — match+$ 는 'abc\\n' 처럼 끝의 개행 직전까지만
+    매치될 수 있어(로그 인젝션 여지) 안전하지 않다.
+    """
+    if raw and _REQUEST_ID_RE.fullmatch(raw):
         return raw
     return new_request_id()
 
@@ -72,22 +76,25 @@ def install(app: FastAPI) -> None:
         request.state.request_id = rid
         token = request_id_ctx.set(rid)
         start = time.monotonic()
+        # 액세스 로그·응답 헤더는 반드시 reset 이전에 처리한다 — reset 뒤에 로그하면
+        # contextvar 가 이미 '-' 라 로그의 request_id 가 비어 상관관계가 끊긴다.
+        # path 는 %r 로 남긴다 — 인코딩된 CR/LF 등이 로그 행을 깨거나 위조하지 못하게.
         try:
             response = await call_next(request)
+            duration_ms = (time.monotonic() - start) * 1000
+            # 민감정보(쿼리/바디/헤더)는 남기지 않는다 — method·path·상태·소요시간만.
+            logger.info(
+                "%s %r -> %d (%.1fms)",
+                request.method, request.url.path, response.status_code, duration_ms,
+            )
+            response.headers[_REQUEST_ID_HEADER] = rid
+            return response
         except Exception:
             duration_ms = (time.monotonic() - start) * 1000
-            # 민감정보(쿼리/바디/헤더)는 남기지 않는다 — method·path·소요시간만.
-            logger.info("%s %s -> 500 (%.1fms)", request.method, request.url.path, duration_ms)
+            logger.info("%s %r -> 500 (%.1fms)", request.method, request.url.path, duration_ms)
             raise
         finally:
             request_id_ctx.reset(token)
-        duration_ms = (time.monotonic() - start) * 1000
-        logger.info(
-            "%s %s -> %d (%.1fms)",
-            request.method, request.url.path, response.status_code, duration_ms,
-        )
-        response.headers[_REQUEST_ID_HEADER] = rid
-        return response
 
     @app.exception_handler(Exception)
     async def _unhandled_exception(request: Request, exc: Exception):
@@ -96,7 +103,7 @@ def install(app: FastAPI) -> None:
         try:
             # stack trace 는 서버 로그에만 한 번. 클라이언트엔 내부 상세를 노출하지 않는다.
             logging.getLogger("app.error").exception(
-                "unhandled error: %s %s", request.method, request.url.path
+                "unhandled error: %s %r", request.method, request.url.path
             )
         finally:
             request_id_ctx.reset(token)

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -10,7 +10,14 @@ from app.core.config import get_settings
 
 settings = get_settings()
 
-engine = create_engine(settings.database_url, pool_pre_ping=True, echo=False)
+# connect_timeout: 네트워크 파티션/DB 무응답 시 커넥션 인출이 스레드를 무한 점유하지 않게
+# 상한을 둔다(특히 /readyz 폴링). libpq 파라미터라 psycopg 로 전달된다.
+engine = create_engine(
+    settings.database_url,
+    pool_pre_ping=True,
+    echo=False,
+    connect_args={"connect_timeout": settings.db_connect_timeout_seconds},
+)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,10 +15,13 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.api.v1 import (
     ai_coach, coach_docs, dashboard, diet, exercise, member_coach, notifications, places, schedule, social, system, trainer, users, vitals,
 )
+from app.core import observability
 from app.core.config import get_settings
 from app.db.init_db import init_db
 
 settings = get_settings()
+# 로깅을 먼저 설정(요청 ID 포함 포맷). 이후 모듈 로거들이 이 설정을 따른다.
+observability.setup_logging(settings.log_level)
 
 
 @asynccontextmanager
@@ -65,6 +68,10 @@ if settings.security_headers:
                 "Strict-Transport-Security", "max-age=63072000; includeSubDomains"
             )
         return response
+
+# 관측성: request-id 미들웨어(가장 바깥 — 컨텍스트를 먼저 세팅) + 액세스 로그 + 전역 500 핸들러.
+# 보안 헤더 미들웨어 뒤에 설치해 request-id 미들웨어가 최외곽에서 감싸게 한다.
+observability.install(app)
 
 # /v1 prefix 로 마운트 (프론트 base URL 이 /v1 을 포함하는 계약)
 app.include_router(system.router, prefix=settings.api_v1_prefix)

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -21,25 +21,47 @@ def test_prod_blocks_default_secret():
         Settings(_env_file=None, env="prod", jwt_secret=DEFAULT_JWT_SECRET)
 
 
-def test_prod_ok_with_real_secret():
-    s = Settings(
+def _prod(**kw) -> Settings:
+    """운영 정상 설정 헬퍼 — Alembic 이 스키마 소스이므로 auto_create_tables=False 명시."""
+    base = dict(
         _env_file=None, env="prod",
         jwt_secret="a-strong-random-secret-value",
         cors_allow_origins="https://app.oncare.com",
-        seed_demo_data=False,  # 운영 권장: 데모 시드 끔(켜려면 DEMO_LOGIN_PASSWORD 강제)
+        seed_demo_data=False,       # 운영 권장: 데모 시드 끔(켜려면 DEMO_LOGIN_PASSWORD 강제)
+        auto_create_tables=False,   # 운영은 Alembic 이 스키마 소스
     )
+    base.update(kw)
+    return Settings(**base)
+
+
+def test_prod_ok_with_real_secret():
+    s = _prod()
     assert s.is_prod is True
+    assert s.auto_create_tables is False
+
+
+def test_prod_blocks_auto_create_tables():
+    """운영에서 AUTO_CREATE_TABLES=true 면 기동 거부(Alembic 만 스키마 소스)."""
+    with pytest.raises(ValidationError):
+        _prod(auto_create_tables=True)
+
+
+def test_dev_keeps_auto_create_tables():
+    """개발에서는 create_all 편의 유지(기본 True)."""
+    assert Settings(_env_file=None).auto_create_tables is True
+
+
+def test_log_level_rejects_invalid():
+    """LOG_LEVEL 은 허용값만(임의 문자열 금지)."""
+    with pytest.raises(ValidationError):
+        Settings(_env_file=None, log_level="LOUD")
+    assert Settings(_env_file=None, log_level="DEBUG").log_level == "DEBUG"
 
 
 def test_demo_fallback_gated_by_env():
     # 개발: 기본 허용
     assert Settings(_env_file=None).demo_fallback_enabled is True
-    # 운영: 설정과 무관하게 비활성
-    prod = Settings(
-        _env_file=None, env="prod", jwt_secret="strong",
-        cors_allow_origins="https://app.oncare.com", allow_demo_fallback=True,
-        seed_demo_data=False,
-    )
-    assert prod.demo_fallback_enabled is False
+    # 운영: 설정과 무관하게 비활성(_prod 헬퍼가 seed/auto_create 가드를 모두 만족)
+    assert _prod(allow_demo_fallback=True).demo_fallback_enabled is False
     # 명시적으로 끄면 개발에서도 비활성
     assert Settings(_env_file=None, allow_demo_fallback=False).demo_fallback_enabled is False

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -70,7 +70,8 @@ def test_access_log_carries_request_id_on_success(client):
     access.addHandler(handler)
     access.setLevel(logging.INFO)
     try:
-        client.get("/v1/healthz", headers={"X-Request-ID": "trace-log-1"})
+        # 헬스 경로(/healthz·/readyz·/ping)는 액세스 로그에서 제외되므로 비-헬스 경로로 검사한다.
+        client.get("/v1/version", headers={"X-Request-ID": "trace-log-1"})
     finally:
         access.removeHandler(handler)
     out = stream.getvalue()
@@ -88,9 +89,14 @@ def test_readyz_503_on_db_failure(client):
     from app.db.session import get_db
     from app.main import app
 
+    rolled_back = {"called": False}
+
     class _BoomSession:
         def execute(self, *a, **k):
             raise RuntimeError("connection refused to 10.0.0.5:5432")
+
+        def rollback(self):  # /readyz 가 실패 트랜잭션을 정리하는지(리뷰 #291) 확인용
+            rolled_back["called"] = True
 
     def _boom_db():
         yield _BoomSession()
@@ -100,6 +106,7 @@ def test_readyz_503_on_db_failure(client):
         r = client.get("/v1/readyz")
         assert r.status_code == 503
         assert "connection refused" not in r.text  # 원인 미노출
+        assert rolled_back["called"] is True        # 예외 시 rollback 호출됨
         # liveness 는 DB 와 무관하게 여전히 200
         assert client.get("/v1/healthz").status_code == 200
     finally:

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -51,6 +51,32 @@ def test_global_500_hides_detail_and_carries_request_id():
     assert r.headers.get("X-Request-ID") == "trace-abc"
 
 
+def test_access_log_carries_request_id_on_success(client):
+    """정상 200 응답의 액세스 로그에도 request_id 가 실려야 한다(reset 전에 로그).
+
+    로그·헤더가 request_id_ctx.reset() 이후에 실행되면 로그 request_id 가 '-' 가 되어
+    상관관계가 끊긴다 — 그 회귀를 막는다.
+    """
+    import io
+    import logging
+
+    from app.core.observability import RequestIdLogFilter
+
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter("[%(request_id)s] %(message)s"))
+    handler.addFilter(RequestIdLogFilter())  # contextvar 에서 request_id 주입
+    access = logging.getLogger("app.access")
+    access.addHandler(handler)
+    access.setLevel(logging.INFO)
+    try:
+        client.get("/v1/healthz", headers={"X-Request-ID": "trace-log-1"})
+    finally:
+        access.removeHandler(handler)
+    out = stream.getvalue()
+    assert "[trace-log-1]" in out  # reset 이전에 로그 → rid 가 '-' 가 아님
+
+
 def test_readyz_ok(client):
     r = client.get("/v1/readyz")
     assert r.status_code == 200

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -1,0 +1,80 @@
+"""관측성 하드닝(#288) — request-id 생성/검증/전달, 전역 500, DB readiness."""
+from __future__ import annotations
+
+import re
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core import observability
+
+_HEX32 = re.compile(r"^[0-9a-f]{32}$")
+
+
+def test_request_id_generated_when_absent(client):
+    r = client.get("/v1/healthz")
+    rid = r.headers.get("X-Request-ID")
+    assert rid and _HEX32.match(rid)  # 헤더 없으면 새 UUID 생성
+
+
+def test_request_id_passed_through_when_valid(client):
+    r = client.get("/v1/healthz", headers={"X-Request-ID": "abc-123_XYZ.v1"})
+    assert r.headers.get("X-Request-ID") == "abc-123_XYZ.v1"
+
+
+def test_request_id_replaced_when_invalid(client):
+    # 형식 위반(공백·특수문자) → 신뢰하지 않고 새로 생성(로그 인젝션 방지)
+    bad = "bad id; drop table\nX-Injected: 1"
+    r = client.get("/v1/healthz", headers={"X-Request-ID": bad})
+    rid = r.headers.get("X-Request-ID")
+    assert rid != bad and _HEX32.match(rid)
+    # 길이 초과(>64)도 거부
+    r2 = client.get("/v1/healthz", headers={"X-Request-ID": "a" * 65})
+    assert r2.headers.get("X-Request-ID") != "a" * 65
+
+
+def test_global_500_hides_detail_and_carries_request_id():
+    app = FastAPI()
+    observability.install(app)
+
+    @app.get("/boom")
+    def boom():
+        raise RuntimeError("SECRET: db password = hunter2")
+
+    c = TestClient(app, raise_server_exceptions=False)
+    r = c.get("/boom", headers={"X-Request-ID": "trace-abc"})
+    assert r.status_code == 500
+    assert "SECRET" not in r.text and "hunter2" not in r.text  # 내부 상세 미노출
+    body = r.json()
+    assert body["detail"] == "내부 서버 오류가 발생했습니다."
+    assert body["request_id"] == "trace-abc"
+    assert r.headers.get("X-Request-ID") == "trace-abc"
+
+
+def test_readyz_ok(client):
+    r = client.get("/v1/readyz")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ready"
+
+
+def test_readyz_503_on_db_failure(client):
+    """DB 장애 시 /readyz 는 내부 상세를 숨긴 503. (/healthz 는 liveness 라 영향 없음)"""
+    from app.db.session import get_db
+    from app.main import app
+
+    class _BoomSession:
+        def execute(self, *a, **k):
+            raise RuntimeError("connection refused to 10.0.0.5:5432")
+
+    def _boom_db():
+        yield _BoomSession()
+
+    app.dependency_overrides[get_db] = _boom_db
+    try:
+        r = client.get("/v1/readyz")
+        assert r.status_code == 503
+        assert "connection refused" not in r.text  # 원인 미노출
+        # liveness 는 DB 와 무관하게 여전히 200
+        assert client.get("/v1/healthz").status_code == 200
+    finally:
+        app.dependency_overrides.pop(get_db, None)

--- a/backend/tests/test_trainer.py
+++ b/backend/tests/test_trainer.py
@@ -109,6 +109,7 @@ def test_prod_demo_seed_requires_strong_password():
         _env_file=None, env="prod",
         jwt_secret="a-strong-enough-production-secret-value-01234567",
         cors_allow_origins="https://app.example.com",
+        auto_create_tables=False,  # 운영 스키마 가드(#288) 충족 — 이 테스트는 데모 비번 강도만 검증
     )
     # 기본값 + 데모 시드 → 기동 거부
     with pytest.raises(ValueError):


### PR DESCRIPTION
## 관련 이슈
- Closes #288
- Follow-up to #258, #286

## 변경 사항
- prod에서 AUTO_CREATE_TABLES=true fail-fast 거부(스키마 변경은 Alembic만)
- LOG_LEVEL 허용값(Literal) 검증
- request-id 미들웨어(검증된 X-Request-ID 재사용 or UUID 생성, 응답 헤더 반영)
- 구조화 액세스 로그(민감정보 제외)
- 전역 500 핸들러(서버 stack trace 1회, 클라엔 일반화 응답 + request_id)
- /v1/readyz(DB SELECT 1, 실패 시 상세 숨긴 503), /v1/healthz는 liveness 유지

## 안전성
- 요청 body/query/Authorization은 로그에 남기지 않음
- 외부 request-id는 허용 문자·길이 검증
- Alembic 마이그레이션 변경 없음 / 기존 성공 응답 계약 불변

## 테스트
- [x] prod AUTO_CREATE_TABLES=true 거부 / dev 자동생성 유지
- [x] LOG_LEVEL 잘못된 값 거부
- [x] request-id 생성·전달·잘못된 값 교체
- [x] 전역 500 상세 미노출 + request_id
- [x] /readyz 200 / DB 장애 503
- [x] 전체 backend pytest (123 passed)
- [ ] **배포 워크플로우·DEPLOY.md를 /readyz 기준으로 갱신 — #286·#288 둘 다 머지된 뒤 후속**

Closes #288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 서비스 준비 상태를 확인하는 `/readyz` 엔드포인트를 추가했습니다.
  * 모든 응답에 요청 ID를 포함해 장애 문의와 추적이 쉬워졌습니다.
  * 요청 처리 로그와 표준화된 서버 오류 응답을 제공합니다.

* **개선 사항**
  * 데이터베이스 장애 시 준비 상태가 503으로 반환되며 내부 오류 정보는 노출되지 않습니다.
  * 운영 환경의 테이블 자동 생성과 잘못된 로그 수준 설정을 차단합니다.
  * 헬스 체크는 데이터베이스 장애와 관계없이 정상적으로 동작합니다.

* **테스트**
  * 요청 ID, 오류 처리, 준비 상태 및 운영 설정 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->