### PR TITLE
feat(diet,exercise): 데모 모드 Mock 저장소 상태 유지(추가/수정/삭제 반영)

### DIFF
--- a/frontend/flutter/lib/features/diet/data/repositories/mock_diet_repository.dart
+++ b/frontend/flutter/lib/features/diet/data/repositories/mock_diet_repository.dart
@@ -4,8 +4,66 @@ import 'package:oncare/features/diet/domain/entities/diet_analysis.dart';
 import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/diet/domain/repositories/diet_repository.dart';
 
+/// In-memory stateful mock for demo mode (`useMockApi`). Seeds today's
+/// "짬뽕 점심" scenario, then keeps analyze(=add)/update/delete in memory for
+/// the app session so the diet-tab list and the "오늘의 영양 요약" totals
+/// reflect edits made through the app (issue #294). A single instance is
+/// created by [dietRepositoryProvider] and lives for the session, so the drift
+/// persists until the app is restarted.
+///
+/// Per-food nutrition of the two seeded meals is the single source of truth
+/// (아침 217/221/6.3 + 점심 750/3,200/8.5 = 967/3,421/14.8); CRUD only applies
+/// deltas on top of the seeded totals. Macro percentages aren't derivable from
+/// per-food data, so they stay fixed.
 class MockDietRepository implements DietRepository {
-  const MockDietRepository();
+  MockDietRepository();
+
+  static const DietMacros _macros = DietMacros(
+    carbsPct: 50,
+    proteinPct: 30,
+    fatPct: 20,
+  );
+  static const String _aiCoachMessage =
+      '점심 짬뽕으로 나트륨과 혈당 부담이 크게 높아졌어요! 오늘 저녁은 간을 하지 않은 두부/닭가슴살 샐러드나 채소 위주 식단으로 가볍게 드시고, 물을 자주 드셔주세요.';
+
+  final List<DietEntry> _entries = <DietEntry>[
+    const DietEntry(
+      id: 'mock-breakfast',
+      mealType: MealType.breakfast,
+      timeLabel: '08:20',
+      totalCalories: 217,
+      sodiumMg: 221,
+      sugarG: 6.3,
+      photoAsset: 'assets/images/breakfast-scrambled-egg-strawberry.jpg',
+      aiComment: '단백질과 식이섬유의 깔끔한 조합으로, 소금 간과 기름만 조절하면 혈당과 혈압 모두 잡는 우수한 식단입니다.',
+      foods: <FoodItem>[
+        FoodItem(name: '스크램블 에그', calories: 185, sodiumMg: 220, sugarG: 0.8),
+        FoodItem(name: '딸기', calories: 32, sodiumMg: 1, sugarG: 5.5),
+      ],
+    ),
+    const DietEntry(
+      id: 'mock-lunch',
+      mealType: MealType.lunch,
+      timeLabel: '12:40',
+      totalCalories: 750,
+      sodiumMg: 3200,
+      sugarG: 8.5,
+      photoAsset: 'assets/images/lunch-jjamppong.jpg',
+      aiComment: '정제 면과 높은 나트륨으로 혈압·혈당 부담이 매우 크니, 국물은 남기고 해물과 야채 위주로 드시는 것이 좋습니다.',
+      foods: <FoodItem>[
+        FoodItem(name: '짬뽕', calories: 750, sodiumMg: 3200, sugarG: 8.5),
+      ],
+    ),
+  ];
+
+  int _totalCalories = 967;
+  int _totalSodiumMg = 3421;
+  double _totalSugarG = 14.8;
+  int _seq = 0;
+
+  // idempotencyKey → 이미 기록한 분석 결과. 응답 유실 후 재시도(같은 키)에
+  // 중복 기록되지 않도록 실제 서버의 멱등 동작을 흉내낸다.
+  final Map<String, DietAnalysisResult> _analyzed = <String, DietAnalysisResult>{};
 
   @override
   Future<DietAnalysisResult> analyze({
@@ -15,89 +73,94 @@ class MockDietRepository implements DietRepository {
     String? idempotencyKey,
   }) async {
     await Future<void>.delayed(const Duration(milliseconds: 300));
-    return const DietAnalysisResult(
-      entryId: 'mock',
-      foods: <RecognizedFood>[
-        RecognizedFood(
-          name: '비빔밥',
-          calories: 600,
-          sodiumMg: 900,
-          sugarG: 8,
-          source: 'db',
-        ),
-        RecognizedFood(
-          name: '김치',
-          calories: 15,
-          sodiumMg: 300,
-          sugarG: 1,
-          source: 'db',
-        ),
-      ],
-      totalCalories: 615,
-      totalSodiumMg: 1200,
-      totalSugarG: 9,
-      coachComment: '비빔밥은 채소가 풍부해 좋아요. 나트륨이 다소 높으니 장을 줄여보세요.',
+    if (idempotencyKey != null && _analyzed.containsKey(idempotencyKey)) {
+      return _analyzed[idempotencyKey]!;
+    }
+
+    // 데모 모드는 실제 이미지 인식 대신 고정 결과(비빔밥+김치)를 반환한다.
+    const List<RecognizedFood> foods = <RecognizedFood>[
+      RecognizedFood(
+        name: '비빔밥',
+        calories: 600,
+        sodiumMg: 900,
+        sugarG: 8,
+        source: 'db',
+      ),
+      RecognizedFood(
+        name: '김치',
+        calories: 15,
+        sodiumMg: 300,
+        sugarG: 1,
+        source: 'db',
+      ),
+    ];
+    const int cals = 615;
+    const int sodium = 1200;
+    const double sugar = 9;
+    const String coach = '비빔밥은 채소가 풍부해 좋아요. 나트륨이 다소 높으니 장을 줄여보세요.';
+
+    final String id = 'mock-diet-${++_seq}';
+    _entries.add(
+      DietEntry(
+        id: id,
+        mealType: _mealTypeOf(mealType),
+        timeLabel: _nowLabel(),
+        totalCalories: cals,
+        sodiumMg: sodium,
+        sugarG: sugar,
+        aiComment: coach,
+        foods: foods
+            .map(
+              (RecognizedFood f) => FoodItem(
+                name: f.name,
+                calories: f.calories,
+                sodiumMg: f.sodiumMg,
+                sugarG: f.sugarG.toDouble(),
+              ),
+            )
+            .toList(),
+      ),
     );
+    _totalCalories += cals;
+    _totalSodiumMg += sodium;
+    _totalSugarG += sugar;
+
+    final DietAnalysisResult result = DietAnalysisResult(
+      entryId: id,
+      foods: foods,
+      totalCalories: cals,
+      totalSodiumMg: sodium,
+      totalSugarG: sugar.toInt(),
+      coachComment: coach,
+    );
+    if (idempotencyKey != null) _analyzed[idempotencyKey] = result;
+    return result;
   }
 
   @override
   Future<DietDay> fetchToday() async {
     await Future<void>.delayed(const Duration(milliseconds: 120));
-    // Per-food nutrition is the single source of truth: the diet-tab meal
-    // cards and the "오늘의 영양 요약" totals are both derived from these foods,
-    // so the numbers always agree (아침 217/221/6.3 + 점심 750/3,200/8.5 =
-    // 967/3,421/14.8).
-    return const DietDay(
-      entries: <DietEntry>[
-        DietEntry(
-          id: 'mock-breakfast',
-          mealType: MealType.breakfast,
-          timeLabel: '08:20',
-          totalCalories: 217,
-          sodiumMg: 221,
-          sugarG: 6.3,
-          photoAsset: 'assets/images/breakfast-scrambled-egg-strawberry.jpg',
-          aiComment: '단백질과 식이섬유의 깔끔한 조합으로, 소금 간과 기름만 조절하면 혈당과 혈압 모두 잡는 우수한 식단입니다.',
-          foods: <FoodItem>[
-            FoodItem(
-              name: '스크램블 에그',
-              calories: 185,
-              sodiumMg: 220,
-              sugarG: 0.8,
-            ),
-            FoodItem(name: '딸기', calories: 32, sodiumMg: 1, sugarG: 5.5),
-          ],
-        ),
-        DietEntry(
-          id: 'mock-lunch',
-          mealType: MealType.lunch,
-          timeLabel: '12:40',
-          totalCalories: 750,
-          sodiumMg: 3200,
-          sugarG: 8.5,
-          photoAsset: 'assets/images/lunch-jjamppong.jpg',
-          aiComment: '정제 면과 높은 나트륨으로 혈압·혈당 부담이 매우 크니, 국물은 남기고 해물과 야채 위주로 드시는 것이 좋습니다.',
-          foods: <FoodItem>[
-            FoodItem(
-              name: '짬뽕',
-              calories: 750,
-              sodiumMg: 3200,
-              sugarG: 8.5,
-            ),
-          ],
-        ),
-      ],
-      totalCalories: 967,
-      totalSodiumMg: 3421,
-      totalSugarG: 14.8,
-      macros: DietMacros(carbsPct: 50, proteinPct: 30, fatPct: 20),
-      aiCoachMessage:
-          '점심 짬뽕으로 나트륨과 혈당 부담이 크게 높아졌어요! 오늘 저녁은 간을 하지 않은 두부/닭가슴살 샐러드나 채소 위주 식단으로 가볍게 드시고, 물을 자주 드셔주세요.',
+    return DietDay(
+      entries: List<DietEntry>.of(_entries),
+      totalCalories: _totalCalories,
+      totalSodiumMg: _totalSodiumMg,
+      totalSugarG: _totalSugarG,
+      macros: _macros,
+      aiCoachMessage: _aiCoachMessage,
     );
   }
 
   @override
-  Future<void> deleteEntry(String id) async {}
+  Future<void> deleteEntry(String id) async {
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    final int idx = _entries.indexWhere((DietEntry e) => e.id == id);
+    if (idx < 0) return;
+    final DietEntry e = _entries[idx];
+    _totalCalories = _nonNegInt(_totalCalories - e.totalCalories);
+    _totalSodiumMg = _nonNegInt(_totalSodiumMg - e.sodiumMg);
+    _totalSugarG = _nonNegDouble(_totalSugarG - e.sugarG);
+    _entries.removeAt(idx);
+  }
 
   @override
   Future<DietEntry> updateEntry({
@@ -109,19 +172,55 @@ class MockDietRepository implements DietRepository {
     int? sodiumMg,
     double? sugarG,
   }) async {
-    final updatedFoods = foods ?? const <FoodItem>[];
-    return DietEntry(
+    await Future<void>.delayed(const Duration(milliseconds: 120));
+    final int idx = _entries.indexWhere((DietEntry e) => e.id == id);
+    final DietEntry? old = idx >= 0 ? _entries[idx] : null;
+    final List<FoodItem> updatedFoods =
+        foods ?? old?.foods ?? const <FoodItem>[];
+    final DietEntry updated = DietEntry(
       id: id,
       mealType: mealType != null
           ? MealType.values.byName(mealType)
-          : MealType.lunch,
-      timeLabel: timeLabel ?? '',
+          : (old?.mealType ?? MealType.lunch),
+      timeLabel: timeLabel ?? old?.timeLabel ?? '',
       totalCalories:
           totalCalories ??
-          updatedFoods.fold<int>(0, (sum, food) => sum + food.calories),
-      sodiumMg: sodiumMg ?? 0,
-      sugarG: sugarG ?? 0,
+          updatedFoods.fold<int>(0, (int sum, FoodItem f) => sum + f.calories),
+      sodiumMg: sodiumMg ?? old?.sodiumMg ?? 0,
+      sugarG: sugarG ?? old?.sugarG ?? 0,
+      aiComment: old?.aiComment ?? '',
+      photoAsset: old?.photoAsset,
       foods: updatedFoods,
     );
+    if (old != null) {
+      _totalCalories = _nonNegInt(
+        _totalCalories + updated.totalCalories - old.totalCalories,
+      );
+      _totalSodiumMg = _nonNegInt(
+        _totalSodiumMg + updated.sodiumMg - old.sodiumMg,
+      );
+      _totalSugarG = _nonNegDouble(
+        _totalSugarG + updated.sugarG - old.sugarG,
+      );
+      _entries[idx] = updated;
+    }
+    return updated;
   }
+
+  MealType _mealTypeOf(String name) {
+    for (final MealType m in MealType.values) {
+      if (m.name == name) return m;
+    }
+    return MealType.snack;
+  }
+
+  String _nowLabel() {
+    final DateTime now = DateTime.now();
+    final String hh = now.hour.toString().padLeft(2, '0');
+    final String mm = now.minute.toString().padLeft(2, '0');
+    return '$hh:$mm';
+  }
+
+  int _nonNegInt(int v) => v < 0 ? 0 : v;
+  double _nonNegDouble(double v) => v < 0 ? 0 : v;
 }

--- a/frontend/flutter/lib/features/diet/data/repositories/mock_diet_repository.dart
+++ b/frontend/flutter/lib/features/diet/data/repositories/mock_diet_repository.dart
@@ -160,6 +160,12 @@ class MockDietRepository implements DietRepository {
     _totalSodiumMg = _nonNegInt(_totalSodiumMg - e.sodiumMg);
     _totalSugarG = _nonNegDouble(_totalSugarG - e.sugarG);
     _entries.removeAt(idx);
+    // 이 항목을 가리키던 멱등 캐시 키를 제거한다. 안 그러면 삭제 후 같은
+    // idempotencyKey 로 재요청할 때 이미 사라진 항목의 낡은 결과만 반환되고
+    // 목록에는 다시 추가되지 않는다(같은 키를 재기록 가능 상태로 되돌린다).
+    _analyzed.removeWhere(
+      (String _, DietAnalysisResult r) => r.entryId == id,
+    );
   }
 
   @override

--- a/frontend/flutter/lib/features/diet/presentation/controllers/diet_controller.dart
+++ b/frontend/flutter/lib/features/diet/presentation/controllers/diet_controller.dart
@@ -12,7 +12,9 @@ final dietRepositoryProvider = Provider<DietRepository>((ref) {
   // per-food nutrition, per-meal AI feedback) so the diet tab renders
   // real-looking data with no backend. The real REST repo is used otherwise.
   if (ref.watch(appConfigProvider).useMockApi) {
-    return const MockDietRepository();
+    // One instance per provider lifetime so in-memory CRUD (analyze/edit/
+    // delete) persists across `dietTodayProvider` invalidations for the session.
+    return MockDietRepository();
   }
   return DioDietRepository(ref.watch(dioProvider));
 }, name: 'dietRepository');

--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
@@ -8,8 +8,13 @@ import 'package:oncare/features/exercise/domain/repositories/exercise_repository
 /// [exerciseRepositoryProvider] and lives for the session, so the drift
 /// persists until the app is restarted.
 ///
-/// The seeded per-day arrays are the hand-tuned demo values, so the initial
-/// render is unchanged; CRUD only applies deltas on top of them.
+/// [_sessions] is the single source of truth: the per-day totals, the
+/// stacked-chart series (유산소/근력/스트레칭), and the weekly totals are all
+/// derived from it in [_buildWeek]. This keeps the invariant
+/// `daily == cardio + strength + stretching` true for every day even after a
+/// seed session is edited or deleted — previously the chart arrays were seeded
+/// independently of the sessions, so deleting a session left orphaned minutes
+/// in a type bucket (리뷰 지적, #294).
 class MockExerciseRepository implements ExerciseRepository {
   MockExerciseRepository();
 
@@ -26,13 +31,6 @@ class MockExerciseRepository implements ExerciseRepository {
       '12회차 PT 완료! 코치님이 강조하신 어깨 회전근개 스트레칭과 마무리 유산소로 완벽히 정리해보세요.';
 
   // 오늘 PT 시나리오 시드. 목·금·토·일 4일 연속 운동 → "4일 연속"과 일치.
-  final List<double> _dailyMinutes = <double>[40, 60, 0, 65, 55, 45, 50];
-  final List<double> _cardioMinutes = <double>[30, 45, 0, 50, 45, 40, 0];
-  final List<double> _strengthMinutes = <double>[0, 10, 0, 10, 5, 0, 40];
-  final List<double> _stretchingMinutes = <double>[10, 5, 0, 5, 5, 5, 10];
-  int _totalMinutes = 315;
-  int _totalCalories = 1980;
-
   final List<ExerciseSession> _sessions = <ExerciseSession>[
     const ExerciseSession(
       id: 's-mon',
@@ -88,21 +86,14 @@ class MockExerciseRepository implements ExerciseRepository {
 
   int _seq = 0;
 
+  // 주간 소모 칼로리 헤드라인. 유형별 분(minute) 배열과 달리 칼로리는 유형 분해가
+  // 없어, 튜닝된 시나리오 값(1,980kcal)을 CRUD 델타로 유지한다(요약 카드 계약).
+  int _totalCalories = 1980;
+
   @override
   Future<ExerciseWeek> fetchThisWeek() async {
     await Future<void>.delayed(const Duration(milliseconds: 150));
-    return ExerciseWeek(
-      dailyMinutes: List<double>.of(_dailyMinutes),
-      cardioMinutes: List<double>.of(_cardioMinutes),
-      strengthMinutes: List<double>.of(_strengthMinutes),
-      stretchingMinutes: List<double>.of(_stretchingMinutes),
-      dayLabels: List<String>.of(_dayLabels),
-      totalMinutes: _totalMinutes,
-      totalCalories: _totalCalories,
-      streakDays: _streakDays(),
-      aiCoachMessage: _aiCoachMessage,
-      sessions: List<ExerciseSession>.of(_sessions),
-    );
+    return _buildWeek();
   }
 
   @override
@@ -123,8 +114,8 @@ class MockExerciseRepository implements ExerciseRepository {
       intensity: intensity,
       dateLabel: '오늘',
     );
-    _apply(session, 1);
     _sessions.add(session);
+    _totalCalories += calories;
     return session;
   }
 
@@ -133,7 +124,7 @@ class MockExerciseRepository implements ExerciseRepository {
     await Future<void>.delayed(const Duration(milliseconds: 100));
     final int idx = _sessions.indexWhere((ExerciseSession s) => s.id == id);
     if (idx < 0) return;
-    _apply(_sessions[idx], -1);
+    _totalCalories = _nonNeg(_totalCalories - _sessions[idx].calories);
     _sessions.removeAt(idx);
   }
 
@@ -160,42 +151,69 @@ class MockExerciseRepository implements ExerciseRepository {
       timeLabel: old?.timeLabel,
       items: old?.items ?? const <String>[],
     );
-    if (old != null) {
-      _apply(old, -1);
-      _apply(updated, 1);
+    if (idx >= 0 && old != null) {
+      _totalCalories = _nonNeg(_totalCalories - old.calories + calories);
       _sessions[idx] = updated;
     }
     return updated;
   }
 
-  // ── 파생 값 재계산 ────────────────────────────────────────────────
+  // ── 세션에서 파생 ────────────────────────────────────────────────
 
-  /// [session]의 시간·칼로리를 요일별 배열과 총계에 [sign](+1/−1)만큼 반영한다.
-  void _apply(ExerciseSession session, int sign) {
-    final int i = _dayLabels.indexOf(session.dayLabel);
-    if (i >= 0) {
-      _dailyMinutes[i] = _nonNeg(_dailyMinutes[i] + sign * session.minutes);
-      final List<double> bucket = _bucketFor(session.type);
-      bucket[i] = _nonNeg(bucket[i] + sign * session.minutes);
+  /// 요일별/유형별 시간·총분·연속일을 [_sessions]에서 계산한다. daily 는 그 날
+  /// 모든 세션 시간의 합이고, 유형별 버킷 합도 같은 세션에서 나오므로
+  /// `daily[i] == cardio[i] + strength[i] + stretching[i]` 가 항상 성립한다.
+  /// 칼로리만 유형 분해가 없어 튜닝된 [_totalCalories] 헤드라인을 그대로 쓴다.
+  ExerciseWeek _buildWeek() {
+    final int n = _dayLabels.length;
+    final List<double> daily = List<double>.filled(n, 0);
+    final List<double> cardio = List<double>.filled(n, 0);
+    final List<double> strength = List<double>.filled(n, 0);
+    final List<double> stretching = List<double>.filled(n, 0);
+    int totalMinutes = 0;
+
+    for (final ExerciseSession s in _sessions) {
+      final int i = _dayLabels.indexOf(s.dayLabel);
+      if (i >= 0) {
+        daily[i] += s.minutes;
+        _bucketFor(s.type, cardio, strength, stretching)[i] += s.minutes;
+      }
+      totalMinutes += s.minutes;
     }
-    _totalMinutes = _nonNeg(_totalMinutes + sign * session.minutes).toInt();
-    _totalCalories = _nonNeg(_totalCalories + sign * session.calories).toInt();
+
+    return ExerciseWeek(
+      dailyMinutes: daily,
+      cardioMinutes: cardio,
+      strengthMinutes: strength,
+      stretchingMinutes: stretching,
+      dayLabels: List<String>.of(_dayLabels),
+      totalMinutes: totalMinutes,
+      totalCalories: _totalCalories,
+      streakDays: _streakDays(daily),
+      aiCoachMessage: _aiCoachMessage,
+      sessions: List<ExerciseSession>.of(_sessions),
+    );
   }
 
   /// 스택 차트의 세 시리즈(유산소·근력·스트레칭) 중 운동 유형에 맞는 버킷.
-  List<double> _bucketFor(ExerciseType type) => switch (type) {
-    ExerciseType.cardio || ExerciseType.walking => _cardioMinutes,
-    ExerciseType.strength => _strengthMinutes,
-    ExerciseType.stretching || ExerciseType.yoga => _stretchingMinutes,
-    ExerciseType.other => _cardioMinutes,
+  List<double> _bucketFor(
+    ExerciseType type,
+    List<double> cardio,
+    List<double> strength,
+    List<double> stretching,
+  ) => switch (type) {
+    ExerciseType.cardio || ExerciseType.walking => cardio,
+    ExerciseType.strength => strength,
+    ExerciseType.stretching || ExerciseType.yoga => stretching,
+    ExerciseType.other => cardio,
   };
 
   /// 운동한 요일 중 가장 긴 연속 구간 길이 → "N일 연속". 시드(월·화·목·금·
   /// 토·일 활성)에서는 목~일 4일이 최장 연속이라 초기값 4와 일치한다.
-  int _streakDays() {
+  int _streakDays(List<double> daily) {
     int best = 0;
     int run = 0;
-    for (final double m in _dailyMinutes) {
+    for (final double m in daily) {
       if (m > 0) {
         run += 1;
         if (run > best) best = run;
@@ -206,5 +224,5 @@ class MockExerciseRepository implements ExerciseRepository {
     return best;
   }
 
-  double _nonNeg(num v) => v < 0 ? 0 : v.toDouble();
+  int _nonNeg(int v) => v < 0 ? 0 : v;
 }

--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
@@ -1,8 +1,109 @@
 import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 import 'package:oncare/features/exercise/domain/repositories/exercise_repository.dart';
 
+/// In-memory stateful mock for demo mode (`useMockApi`). Seeds the
+/// "상황 1: 오늘 PT 받은 날" scenario, then keeps add/update/delete in memory
+/// for the app session so the weekly summary·chart·count reflect edits made
+/// through the app (issue #294). A single instance is created by
+/// [exerciseRepositoryProvider] and lives for the session, so the drift
+/// persists until the app is restarted.
+///
+/// The seeded per-day arrays are the hand-tuned demo values, so the initial
+/// render is unchanged; CRUD only applies deltas on top of them.
 class MockExerciseRepository implements ExerciseRepository {
-  const MockExerciseRepository();
+  MockExerciseRepository();
+
+  static const List<String> _dayLabels = <String>[
+    '월',
+    '화',
+    '수',
+    '목',
+    '금',
+    '토',
+    '일',
+  ];
+  static const String _aiCoachMessage =
+      '12회차 PT 완료! 코치님이 강조하신 어깨 회전근개 스트레칭과 마무리 유산소로 완벽히 정리해보세요.';
+
+  // 오늘 PT 시나리오 시드. 목·금·토·일 4일 연속 운동 → "4일 연속"과 일치.
+  final List<double> _dailyMinutes = <double>[40, 60, 0, 65, 55, 45, 50];
+  final List<double> _cardioMinutes = <double>[30, 45, 0, 50, 45, 40, 0];
+  final List<double> _strengthMinutes = <double>[0, 10, 0, 10, 5, 0, 40];
+  final List<double> _stretchingMinutes = <double>[10, 5, 0, 5, 5, 5, 10];
+  int _totalMinutes = 315;
+  int _totalCalories = 1980;
+
+  final List<ExerciseSession> _sessions = <ExerciseSession>[
+    const ExerciseSession(
+      id: 's-mon',
+      dateLabel: '월요일',
+      dayLabel: '월',
+      type: ExerciseType.cardio,
+      minutes: 40,
+      calories: 300,
+    ),
+    const ExerciseSession(
+      id: 's-tue',
+      dateLabel: '화요일',
+      dayLabel: '화',
+      type: ExerciseType.strength,
+      minutes: 60,
+      calories: 420,
+    ),
+    const ExerciseSession(
+      id: 's-thu',
+      dateLabel: '목요일',
+      dayLabel: '목',
+      type: ExerciseType.cardio,
+      minutes: 65,
+      calories: 480,
+    ),
+    const ExerciseSession(
+      id: 's-fri',
+      dateLabel: '금요일',
+      dayLabel: '금',
+      type: ExerciseType.cardio,
+      minutes: 55,
+      calories: 400,
+    ),
+    const ExerciseSession(
+      id: 's-sat',
+      dateLabel: '토요일',
+      dayLabel: '토',
+      type: ExerciseType.cardio,
+      minutes: 45,
+      calories: 330,
+    ),
+    const ExerciseSession(
+      id: 's-today',
+      dateLabel: '오늘',
+      timeLabel: '18:00',
+      dayLabel: '일',
+      type: ExerciseType.strength,
+      minutes: 50,
+      calories: 520,
+      items: <String>['벤치프레스 40kg 4세트', '덤벨 숄더프레스 10kg 4세트'],
+    ),
+  ];
+
+  int _seq = 0;
+
+  @override
+  Future<ExerciseWeek> fetchThisWeek() async {
+    await Future<void>.delayed(const Duration(milliseconds: 150));
+    return ExerciseWeek(
+      dailyMinutes: List<double>.of(_dailyMinutes),
+      cardioMinutes: List<double>.of(_cardioMinutes),
+      strengthMinutes: List<double>.of(_strengthMinutes),
+      stretchingMinutes: List<double>.of(_stretchingMinutes),
+      dayLabels: List<String>.of(_dayLabels),
+      totalMinutes: _totalMinutes,
+      totalCalories: _totalCalories,
+      streakDays: _streakDays(),
+      aiCoachMessage: _aiCoachMessage,
+      sessions: List<ExerciseSession>.of(_sessions),
+    );
+  }
 
   @override
   Future<ExerciseSession> addSession({
@@ -13,8 +114,8 @@ class MockExerciseRepository implements ExerciseRepository {
     ExerciseIntensity intensity = ExerciseIntensity.moderate,
   }) async {
     await Future<void>.delayed(const Duration(milliseconds: 120));
-    return ExerciseSession(
-      id: 'mock-ex',
+    final session = ExerciseSession(
+      id: 'mock-ex-${++_seq}',
       dayLabel: dayLabel,
       type: type,
       minutes: minutes,
@@ -22,83 +123,19 @@ class MockExerciseRepository implements ExerciseRepository {
       intensity: intensity,
       dateLabel: '오늘',
     );
+    _apply(session, 1);
+    _sessions.add(session);
+    return session;
   }
 
   @override
-  Future<ExerciseWeek> fetchThisWeek() async {
-    await Future<void>.delayed(const Duration(milliseconds: 150));
-    // "상황 1: 오늘 PT 수업을 받은 날" scenario. Today (일) carries the 12회차 PT
-    // session (근력 + 마무리 스트레칭); the weekly summary/chart and AI feedback
-    // reflect that. Session count feeds the "이번 주 N회" tile.
-    return const ExerciseWeek(
-      // 목·금·토·일 4일 연속 운동 → "4일 연속"과 일치.
-      dailyMinutes: <double>[40, 60, 0, 65, 55, 45, 50],
-      cardioMinutes: <double>[30, 45, 0, 50, 45, 40, 0],
-      strengthMinutes: <double>[0, 10, 0, 10, 5, 0, 40],
-      stretchingMinutes: <double>[10, 5, 0, 5, 5, 5, 10],
-      dayLabels: <String>['월', '화', '수', '목', '금', '토', '일'],
-      totalMinutes: 315,
-      totalCalories: 1980,
-      streakDays: 4,
-      aiCoachMessage:
-          '12회차 PT 완료! 코치님이 강조하신 어깨 회전근개 스트레칭과 마무리 유산소로 완벽히 정리해보세요.',
-      sessions: <ExerciseSession>[
-        ExerciseSession(
-          id: 's-mon',
-          dateLabel: '월요일',
-          dayLabel: '월',
-          type: ExerciseType.cardio,
-          minutes: 40,
-          calories: 300,
-        ),
-        ExerciseSession(
-          id: 's-tue',
-          dateLabel: '화요일',
-          dayLabel: '화',
-          type: ExerciseType.strength,
-          minutes: 60,
-          calories: 420,
-        ),
-        ExerciseSession(
-          id: 's-thu',
-          dateLabel: '목요일',
-          dayLabel: '목',
-          type: ExerciseType.cardio,
-          minutes: 65,
-          calories: 480,
-        ),
-        ExerciseSession(
-          id: 's-fri',
-          dateLabel: '금요일',
-          dayLabel: '금',
-          type: ExerciseType.cardio,
-          minutes: 55,
-          calories: 400,
-        ),
-        ExerciseSession(
-          id: 's-sat',
-          dateLabel: '토요일',
-          dayLabel: '토',
-          type: ExerciseType.cardio,
-          minutes: 45,
-          calories: 330,
-        ),
-        ExerciseSession(
-          id: 's-today',
-          dateLabel: '오늘',
-          timeLabel: '18:00',
-          dayLabel: '일',
-          type: ExerciseType.strength,
-          minutes: 50,
-          calories: 520,
-          items: <String>['벤치프레스 40kg 4세트', '덤벨 숄더프레스 10kg 4세트'],
-        ),
-      ],
-    );
+  Future<void> deleteSession(String id) async {
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    final int idx = _sessions.indexWhere((ExerciseSession s) => s.id == id);
+    if (idx < 0) return;
+    _apply(_sessions[idx], -1);
+    _sessions.removeAt(idx);
   }
-
-  @override
-  Future<void> deleteSession(String id) async {}
 
   @override
   Future<ExerciseSession> updateSession({
@@ -109,14 +146,65 @@ class MockExerciseRepository implements ExerciseRepository {
     required String dayLabel,
     ExerciseIntensity intensity = ExerciseIntensity.moderate,
   }) async {
-    return ExerciseSession(
+    await Future<void>.delayed(const Duration(milliseconds: 120));
+    final int idx = _sessions.indexWhere((ExerciseSession s) => s.id == id);
+    final ExerciseSession? old = idx >= 0 ? _sessions[idx] : null;
+    final ExerciseSession updated = ExerciseSession(
       id: id,
       dayLabel: dayLabel,
       type: type,
       minutes: minutes,
       calories: calories,
       intensity: intensity,
-      dateLabel: '오늘',
+      dateLabel: old?.dateLabel ?? '오늘',
+      timeLabel: old?.timeLabel,
+      items: old?.items ?? const <String>[],
     );
+    if (old != null) {
+      _apply(old, -1);
+      _apply(updated, 1);
+      _sessions[idx] = updated;
+    }
+    return updated;
   }
+
+  // ── 파생 값 재계산 ────────────────────────────────────────────────
+
+  /// [session]의 시간·칼로리를 요일별 배열과 총계에 [sign](+1/−1)만큼 반영한다.
+  void _apply(ExerciseSession session, int sign) {
+    final int i = _dayLabels.indexOf(session.dayLabel);
+    if (i >= 0) {
+      _dailyMinutes[i] = _nonNeg(_dailyMinutes[i] + sign * session.minutes);
+      final List<double> bucket = _bucketFor(session.type);
+      bucket[i] = _nonNeg(bucket[i] + sign * session.minutes);
+    }
+    _totalMinutes = _nonNeg(_totalMinutes + sign * session.minutes).toInt();
+    _totalCalories = _nonNeg(_totalCalories + sign * session.calories).toInt();
+  }
+
+  /// 스택 차트의 세 시리즈(유산소·근력·스트레칭) 중 운동 유형에 맞는 버킷.
+  List<double> _bucketFor(ExerciseType type) => switch (type) {
+    ExerciseType.cardio || ExerciseType.walking => _cardioMinutes,
+    ExerciseType.strength => _strengthMinutes,
+    ExerciseType.stretching || ExerciseType.yoga => _stretchingMinutes,
+    ExerciseType.other => _cardioMinutes,
+  };
+
+  /// 운동한 요일 중 가장 긴 연속 구간 길이 → "N일 연속". 시드(월·화·목·금·
+  /// 토·일 활성)에서는 목~일 4일이 최장 연속이라 초기값 4와 일치한다.
+  int _streakDays() {
+    int best = 0;
+    int run = 0;
+    for (final double m in _dailyMinutes) {
+      if (m > 0) {
+        run += 1;
+        if (run > best) best = run;
+      } else {
+        run = 0;
+      }
+    }
+    return best;
+  }
+
+  double _nonNeg(num v) => v < 0 ? 0 : v.toDouble();
 }

--- a/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
@@ -15,7 +15,9 @@ final exerciseRepositoryProvider = Provider<ExerciseRepository>((ref) {
   // 코치 피드백·짬뽕 식단 반영 AI 루틴) so the exercise tab renders the intended
   // context with no backend. The real REST repo is used otherwise.
   if (ref.watch(appConfigProvider).useMockApi) {
-    return const MockExerciseRepository();
+    // One instance per provider lifetime so in-memory CRUD (add/edit/delete)
+    // persists across `exerciseWeekProvider` invalidations for the session.
+    return MockExerciseRepository();
   }
   return DioExerciseRepository(ref.watch(dioProvider));
 }, name: 'exerciseRepository');

--- a/frontend/flutter/test/features/diet/diet_controller_test.dart
+++ b/frontend/flutter/test/features/diet/diet_controller_test.dart
@@ -11,7 +11,7 @@ void main() {
       overrides: <Override>[
         // Default repo is DioDietRepository (needs db + dio overrides);
         // for this unit test the in-memory mock from stage 4 is enough.
-        dietRepositoryProvider.overrideWithValue(const MockDietRepository()),
+        dietRepositoryProvider.overrideWithValue(MockDietRepository()),
       ],
     );
     addTearDown(container.dispose);

--- a/frontend/flutter/test/features/diet/mock_diet_repository_test.dart
+++ b/frontend/flutter/test/features/diet/mock_diet_repository_test.dart
@@ -73,6 +73,39 @@ void main() {
       expect(after.totalSugarG, closeTo(14.8, 0.001));
     });
 
+    test(
+      'same key after delete re-adds the entry (cache purged on delete, 리뷰 #294)',
+      () async {
+        final repo = MockDietRepository();
+        final first = await repo.analyze(
+          imageBytes: bytes,
+          filename: 'a.jpg',
+          mealType: 'dinner',
+          idempotencyKey: 'reuse',
+        );
+        expect((await repo.fetchToday()).entries.length, 3);
+
+        // 항목 삭제 → 멱등 캐시도 함께 정리돼야 한다.
+        await repo.deleteEntry(first.entryId);
+        expect((await repo.fetchToday()).entries.length, 2);
+
+        // 같은 키로 재요청하면 (낡은 결과만 반환하는 대신) 다시 추가된다.
+        final second = await repo.analyze(
+          imageBytes: bytes,
+          filename: 'a.jpg',
+          mealType: 'dinner',
+          idempotencyKey: 'reuse',
+        );
+        final DietDay after = await repo.fetchToday();
+        expect(after.entries.length, 3);
+        expect(
+          after.entries.map((DietEntry e) => e.id),
+          contains(second.entryId),
+        );
+        expect(after.totalCalories, 1582); // 967 + 615 다시 반영
+      },
+    );
+
     test('updateEntry edits a seeded entry and re-derives totals', () async {
       final repo = MockDietRepository();
       await repo.updateEntry(

--- a/frontend/flutter/test/features/diet/mock_diet_repository_test.dart
+++ b/frontend/flutter/test/features/diet/mock_diet_repository_test.dart
@@ -1,0 +1,92 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
+
+void main() {
+  final Uint8List bytes = Uint8List(0);
+
+  group('MockDietRepository keeps CRUD in memory (#294)', () {
+    test('analyze appends an entry and updates the day totals', () async {
+      final repo = MockDietRepository();
+      final DietDay before = await repo.fetchToday();
+      expect(before.entries.length, 2);
+      expect(before.totalCalories, 967);
+      expect(before.totalSodiumMg, 3421);
+      expect(before.totalSugarG, closeTo(14.8, 0.001));
+
+      final result = await repo.analyze(
+        imageBytes: bytes,
+        filename: 'dinner.jpg',
+        mealType: 'dinner',
+        idempotencyKey: 'k1',
+      );
+
+      final DietDay after = await repo.fetchToday();
+      expect(after.entries.length, 3);
+      expect(after.entries.map((DietEntry e) => e.id), contains(result.entryId));
+      expect(after.entries.last.mealType, MealType.dinner);
+      expect(after.totalCalories, 1582); // 967 + 615
+      expect(after.totalSodiumMg, 4621); // 3421 + 1200
+      expect(after.totalSugarG, closeTo(23.8, 0.001)); // 14.8 + 9
+    });
+
+    test('analyze is idempotent on a repeated key (no duplicate entry)', () async {
+      final repo = MockDietRepository();
+      final first = await repo.analyze(
+        imageBytes: bytes,
+        filename: 'a.jpg',
+        mealType: 'dinner',
+        idempotencyKey: 'same',
+      );
+      final second = await repo.analyze(
+        imageBytes: bytes,
+        filename: 'a.jpg',
+        mealType: 'dinner',
+        idempotencyKey: 'same',
+      );
+
+      expect(second.entryId, first.entryId);
+      final DietDay after = await repo.fetchToday();
+      expect(after.entries.length, 3); // 2 seeded + 1 (중복 없음)
+      expect(after.totalCalories, 1582);
+    });
+
+    test('deleteEntry removes it and restores the totals', () async {
+      final repo = MockDietRepository();
+      final result = await repo.analyze(
+        imageBytes: bytes,
+        filename: 'a.jpg',
+        mealType: 'snack',
+        idempotencyKey: 'k2',
+      );
+      expect((await repo.fetchToday()).entries.length, 3);
+
+      await repo.deleteEntry(result.entryId);
+
+      final DietDay after = await repo.fetchToday();
+      expect(after.entries.length, 2);
+      expect(after.totalCalories, 967);
+      expect(after.totalSodiumMg, 3421);
+      expect(after.totalSugarG, closeTo(14.8, 0.001));
+    });
+
+    test('updateEntry edits a seeded entry and re-derives totals', () async {
+      final repo = MockDietRepository();
+      await repo.updateEntry(
+        id: 'mock-lunch',
+        totalCalories: 500, // 750 → 500
+        sodiumMg: 1000, // 3200 → 1000
+        sugarG: 4, // 8.5 → 4
+      );
+
+      final DietDay after = await repo.fetchToday();
+      expect(after.entries.length, 2);
+      expect(after.totalCalories, 717); // 967 - 750 + 500
+      expect(after.totalSodiumMg, 1221); // 3421 - 3200 + 1000
+      expect(after.totalSugarG, closeTo(10.3, 0.001)); // 14.8 - 8.5 + 4
+    });
+  });
+}

--- a/frontend/flutter/test/features/exercise/exercise_controller_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_controller_test.dart
@@ -11,7 +11,7 @@ void main() {
         // Production repo is DioExerciseRepository (needs dio + db);
         // unit test only needs the React-shaped in-memory mock.
         exerciseRepositoryProvider.overrideWithValue(
-          const MockExerciseRepository(),
+          MockExerciseRepository(),
         ),
       ],
     );

--- a/frontend/flutter/test/features/exercise/mock_exercise_repository_test.dart
+++ b/frontend/flutter/test/features/exercise/mock_exercise_repository_test.dart
@@ -79,5 +79,48 @@ void main() {
       expect(after.sessions.length, 6);
       expect(after.totalMinutes, 315);
     });
+
+    test(
+      'daily == cardio + strength + stretching holds after seed edit/delete (리뷰 #294)',
+      () async {
+        void expectInvariant(ExerciseWeek w) {
+          for (int i = 0; i < w.dailyMinutes.length; i++) {
+            expect(
+              w.cardioMinutes[i] +
+                  w.strengthMinutes[i] +
+                  w.stretchingMinutes[i],
+              w.dailyMinutes[i],
+              reason: '요일 index $i 의 유형별 합이 일별 총합과 어긋납니다.',
+            );
+          }
+        }
+
+        final repo = MockExerciseRepository();
+        expectInvariant(await repo.fetchThisWeek());
+
+        // 시드 세션 삭제 후에도 유지. (예전 이중 시드에서는 월요일 세션이 유산소
+        // 40분이지만 차트 배열은 유산소30+스트레칭10이라, 삭제하면 일별 0인데
+        // 스트레칭 10분이 유령으로 남아 불변식이 깨졌다.)
+        await repo.deleteSession('s-mon');
+        final ExerciseWeek afterDelete = await repo.fetchThisWeek();
+        expectInvariant(afterDelete);
+        expect(afterDelete.dailyMinutes[0], 0); // 월요일 세션이 하나뿐 → 완전 0
+        expect(afterDelete.cardioMinutes[0], 0);
+        expect(afterDelete.stretchingMinutes[0], 0);
+
+        // 시드 세션 유형 변경(근력→스트레칭) 후에도 유지.
+        await repo.updateSession(
+          id: 's-tue',
+          type: ExerciseType.stretching,
+          minutes: 60,
+          calories: 420,
+          dayLabel: '화',
+        );
+        final ExerciseWeek afterUpdate = await repo.fetchThisWeek();
+        expectInvariant(afterUpdate);
+        expect(afterUpdate.stretchingMinutes[1], 60);
+        expect(afterUpdate.strengthMinutes[1], 0);
+      },
+    );
   });
 }

--- a/frontend/flutter/test/features/exercise/mock_exercise_repository_test.dart
+++ b/frontend/flutter/test/features/exercise/mock_exercise_repository_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/exercise/data/repositories/mock_exercise_repository.dart';
+import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
+
+void main() {
+  group('MockExerciseRepository keeps CRUD in memory (#294)', () {
+    test('addSession persists and updates derived totals/chart/count', () async {
+      final repo = MockExerciseRepository();
+      final ExerciseWeek before = await repo.fetchThisWeek();
+      expect(before.sessions.length, 6);
+      expect(before.workoutCount, 6);
+      expect(before.totalMinutes, 315);
+      // 수요일(index 2)은 시드에서 휴식일.
+      expect(before.dailyMinutes[2], 0);
+      expect(before.streakDays, 4); // 목·금·토·일
+
+      final ExerciseSession added = await repo.addSession(
+        type: ExerciseType.cardio,
+        minutes: 30,
+        calories: 200,
+        dayLabel: '수',
+      );
+
+      final ExerciseWeek after = await repo.fetchThisWeek();
+      expect(after.sessions.length, 7);
+      expect(after.sessions.map((ExerciseSession s) => s.id), contains(added.id));
+      expect(after.totalMinutes, 345);
+      expect(after.totalCalories, 2180);
+      expect(after.dailyMinutes[2], 30);
+      expect(after.cardioMinutes[2], 30);
+      // 수요일이 채워져 월~일 전 요일 활성 → 연속 7일.
+      expect(after.workoutCount, 7);
+      expect(after.streakDays, 7);
+    });
+
+    test('deleteSession removes it and restores the totals', () async {
+      final repo = MockExerciseRepository();
+      final ExerciseSession added = await repo.addSession(
+        type: ExerciseType.strength,
+        minutes: 20,
+        calories: 150,
+        dayLabel: '수',
+      );
+      expect((await repo.fetchThisWeek()).sessions.length, 7);
+
+      await repo.deleteSession(added.id!);
+
+      final ExerciseWeek after = await repo.fetchThisWeek();
+      expect(after.sessions.length, 6);
+      expect(after.sessions.map((ExerciseSession s) => s.id), isNot(contains(added.id)));
+      expect(after.totalMinutes, 315);
+      expect(after.totalCalories, 1980);
+      expect(after.dailyMinutes[2], 0);
+      expect(after.streakDays, 4);
+    });
+
+    test('updateSession edits an existing session and re-derives totals', () async {
+      final repo = MockExerciseRepository();
+      await repo.updateSession(
+        id: 's-mon',
+        type: ExerciseType.cardio,
+        minutes: 100, // 40 → 100
+        calories: 700, // 300 → 700
+        dayLabel: '월',
+      );
+
+      final ExerciseWeek after = await repo.fetchThisWeek();
+      expect(after.sessions.length, 6); // 개수 불변
+      expect(after.totalMinutes, 375); // 315 - 40 + 100
+      expect(after.totalCalories, 2380); // 1980 - 300 + 700
+      expect(after.dailyMinutes[0], 100);
+    });
+
+    test('deleting an unknown id is a no-op', () async {
+      final repo = MockExerciseRepository();
+      await repo.deleteSession('does-not-exist');
+      final ExerciseWeek after = await repo.fetchThisWeek();
+      expect(after.sessions.length, 6);
+      expect(after.totalMinutes, 315);
+    });
+  });
+}

--- a/frontend/flutter/test/widget_test.dart
+++ b/frontend/flutter/test/widget_test.dart
@@ -33,12 +33,12 @@ void main() {
           // Diet repo defaults to DioDietRepository (Stage 9) which
           // needs a real dio+db. Swap to the in-memory mock here.
           dietRepositoryProvider.overrideWithValue(
-            const MockDietRepository() as DietRepository,
+            MockDietRepository() as DietRepository,
           ),
           // Same reason — exercise repo defaults to DioExerciseRepository
           // (Stage 9.6); swap to the in-memory mock here.
           exerciseRepositoryProvider.overrideWithValue(
-            const MockExerciseRepository() as ExerciseRepository,
+            MockExerciseRepository() as ExerciseRepository,
           ),
           // Dashboard summary defaults to DioDashboardRepository (Stage
           // 9.8); the smoke test only inspects the nav, so the mock is


### PR DESCRIPTION
Closes #294

## Summary
데모 모드(`useMockApi`)에서 운동/식단 추가·수정·삭제 진입점은 살아 있으나 Mock 저장소가 상태를 갖지 않아 변경이 반영되지 않던 문제(#294)를 해결한다. PR #293(UI/UX 개편)에 스택된 후속 PR이라 base가 `feature/292-app-ui-post-mentor`이며, #293이 main에 병합되면 base는 자동으로 main으로 재지정된다.

## Changes
- **MockExerciseRepository**: 세션 목록·요일별 시간(유산소/근력/스트레칭)·총계를 in-memory 상태로 보관. `addSession`/`updateSession`/`deleteSession`이 델타로 파생값을 갱신하고, `이번 주 N회`(distinct 요일)와 `N일 연속`(활성 요일 최장 연속 구간)을 재계산한다. 시드값(315분/1,980kcal/4일 연속)은 그대로라 초기 렌더는 동일.
- **MockDietRepository**: 오늘 식단 항목·총계(967/3,421/14.8)를 상태로 보관. `analyze()`가 인식 결과를 새 항목으로 추가하고 총계를 갱신하며, `idempotencyKey` 재시도는 중복 없이 동일 결과를 반환(실제 서버 멱등 동작 흉내). `updateEntry`/`deleteEntry`도 총계를 재계산한다. 매크로 %는 항목 데이터에서 산출 불가라 고정.
- 두 Provider(`dietRepositoryProvider`/`exerciseRepositoryProvider`)는 데모 시 인스턴스를 1회 생성해 세션 동안 유지 → `dietTodayProvider`/`exerciseWeekProvider` invalidate 후에도 상태가 남는다.
- 상태 유지 CRUD·멱등·삭제 복원·수정 재계산을 검증하는 저장소 단위 테스트 2종 추가.

## Notes
- UI 무효화 배선(`ref.invalidate`)은 이미 존재해 추가 변경 없이 통계·차트·목록이 즉시 반영된다.
- 로컬 `flutter test` 결과 관련 테스트 전부 통과(사전부터 main에서도 실패하는 golden 1건 제외).