### PR TITLE
fix(member): 계정 전환 시 상담 요청 상태 초기화

### DIFF
--- a/frontend/flutter/lib/features/auth/presentation/controllers/session_controller.dart
+++ b/frontend/flutter/lib/features/auth/presentation/controllers/session_controller.dart
@@ -60,6 +60,7 @@ class SessionController extends StateNotifier<SessionState> {
     } catch (_) {
       // secure storage 저장 실패해도 세션 메모리 토큰으로 진행
     }
+    _ref.invalidate(consultationRequestControllerProvider);
     _setToken(access);
     state = const SessionState(status: SessionStatus.authenticated);
   }

--- a/frontend/flutter/lib/features/auth/presentation/controllers/session_controller.dart
+++ b/frontend/flutter/lib/features/auth/presentation/controllers/session_controller.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:oncare/core/network/auth_token.dart';
 import 'package:oncare/core/network/dio_client.dart';
 import 'package:oncare/core/storage/secure_token_store.dart';
+import 'package:oncare/features/exercise/presentation/controllers/consultation_request_controller.dart';
 
 enum SessionStatus { unknown, signedOut, demo, authenticated }
 
@@ -111,6 +112,7 @@ class SessionController extends StateNotifier<SessionState> {
   /// Skip auth — demo mode. No token; the backend demo-fallback serves data.
   void enterDemo() {
     _setToken(null);
+    _ref.invalidate(consultationRequestControllerProvider);
     state = const SessionState(status: SessionStatus.demo);
   }
 
@@ -119,6 +121,7 @@ class SessionController extends StateNotifier<SessionState> {
       await _ref.read(secureTokenStoreProvider).clear();
     } catch (_) {}
     _setToken(null);
+    _ref.invalidate(consultationRequestControllerProvider);
     state = const SessionState(status: SessionStatus.signedOut);
   }
 }

--- a/frontend/flutter/test/features/auth/session_controller_test.dart
+++ b/frontend/flutter/test/features/auth/session_controller_test.dart
@@ -54,16 +54,28 @@ void main() {
     );
   });
 
-  test('enterDemo clears consultation requests from an existing session', () {
+  test('enterDemo clears existing consultation requests', () {
     final ProviderContainer container = ProviderContainer();
     addTearDown(container.dispose);
 
-    container
-        .read(consultationRequestControllerProvider.notifier)
-        .add(_pendingRequest);
+    expect(
+      container
+          .read(consultationRequestControllerProvider.notifier)
+          .add(_pendingRequest),
+      isTrue,
+    );
 
     container.read(sessionControllerProvider.notifier).enterDemo();
 
     expect(container.read(consultationRequestControllerProvider), isEmpty);
+    expect(
+      container
+          .read(consultationRequestControllerProvider.notifier)
+          .hasPending(
+            targetType: _pendingRequest.targetType,
+            gymId: _pendingRequest.gymId,
+          ),
+      isFalse,
+    );
   });
 }

--- a/frontend/flutter/test/features/auth/session_controller_test.dart
+++ b/frontend/flutter/test/features/auth/session_controller_test.dart
@@ -1,7 +1,9 @@
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:oncare/core/network/dio_client.dart';
 import 'package:oncare/features/auth/presentation/controllers/session_controller.dart';
 import 'package:oncare/features/exercise/domain/entities/consultation_request.dart';
 import 'package:oncare/features/exercise/presentation/controllers/consultation_request_controller.dart';
@@ -78,4 +80,120 @@ void main() {
       isFalse,
     );
   });
+
+  test('login clears consultation requests created in demo mode', () async {
+    final Dio dio = _authDio(<String, Object?>{
+      'access_token': 'login-access-token',
+      'refresh_token': 'login-refresh-token',
+    });
+    addTearDown(dio.close);
+    final ProviderContainer container = ProviderContainer(
+      overrides: <Override>[dioProvider.overrideWithValue(dio)],
+    );
+    addTearDown(container.dispose);
+    final SessionController controller = container.read(
+      sessionControllerProvider.notifier,
+    );
+    await _waitForSessionStatus(container, SessionStatus.signedOut);
+    controller.enterDemo();
+
+    expect(
+      container
+          .read(consultationRequestControllerProvider.notifier)
+          .add(_pendingRequest),
+      isTrue,
+    );
+
+    await controller.login(email: 'member@example.com', password: 'password');
+
+    expect(
+      container.read(sessionControllerProvider).status,
+      SessionStatus.authenticated,
+    );
+    expect(container.read(consultationRequestControllerProvider), isEmpty);
+    expect(
+      container
+          .read(consultationRequestControllerProvider.notifier)
+          .hasPending(
+            targetType: _pendingRequest.targetType,
+            gymId: _pendingRequest.gymId,
+          ),
+      isFalse,
+    );
+  });
+
+  test('login without an access token keeps consultation requests', () async {
+    final Dio dio = _authDio(<String, Object?>{
+      'refresh_token': 'refresh-token-only',
+    });
+    addTearDown(dio.close);
+    final ProviderContainer container = ProviderContainer(
+      overrides: <Override>[dioProvider.overrideWithValue(dio)],
+    );
+    addTearDown(container.dispose);
+    final SessionController controller = container.read(
+      sessionControllerProvider.notifier,
+    );
+    await _waitForSessionStatus(container, SessionStatus.signedOut);
+    controller.enterDemo();
+
+    expect(
+      container
+          .read(consultationRequestControllerProvider.notifier)
+          .add(_pendingRequest),
+      isTrue,
+    );
+
+    await expectLater(
+      controller.login(email: 'member@example.com', password: 'password'),
+      throwsException,
+    );
+
+    expect(
+      container.read(sessionControllerProvider).status,
+      SessionStatus.demo,
+    );
+    expect(
+      container.read(consultationRequestControllerProvider),
+      <ConsultationRequest>[_pendingRequest],
+    );
+    expect(
+      container
+          .read(consultationRequestControllerProvider.notifier)
+          .hasPending(
+            targetType: _pendingRequest.targetType,
+            gymId: _pendingRequest.gymId,
+          ),
+      isTrue,
+    );
+  });
+}
+
+Dio _authDio(Map<String, Object?> response) {
+  final Dio dio = Dio(BaseOptions(baseUrl: 'https://example.test'));
+  dio.interceptors.add(
+    InterceptorsWrapper(
+      onRequest: (RequestOptions options, RequestInterceptorHandler handler) {
+        handler.resolve(
+          Response<Map<String, Object?>>(
+            requestOptions: options,
+            statusCode: 200,
+            data: response,
+          ),
+        );
+      },
+    ),
+  );
+  return dio;
+}
+
+Future<void> _waitForSessionStatus(
+  ProviderContainer container,
+  SessionStatus expected,
+) async {
+  for (var attempt = 0; attempt < 20; attempt++) {
+    if (container.read(sessionControllerProvider).status == expected) return;
+    await Future<void>.delayed(Duration.zero);
+  }
+  fail('Session did not reach $expected');
 }

--- a/frontend/flutter/test/features/auth/session_controller_test.dart
+++ b/frontend/flutter/test/features/auth/session_controller_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/auth/presentation/controllers/session_controller.dart';
+import 'package:oncare/features/exercise/domain/entities/consultation_request.dart';
+import 'package:oncare/features/exercise/presentation/controllers/consultation_request_controller.dart';
+
+final ConsultationRequest _pendingRequest = ConsultationRequest(
+  id: 'request-user-a',
+  targetType: ConsultationTargetType.gym,
+  gymId: 'gym-1',
+  gymName: 'A 사용자 상담 헬스장',
+  trainerName: null,
+  trainerRole: null,
+  exerciseGoal: '체중 감량',
+  healthPurpose: '혈압 관리',
+  preferredDate: DateTime(2026, 7, 30),
+  preferredTimeSlot: '오후',
+  message: 'A 사용자의 문의 내용',
+  status: ConsultationStatus.pending,
+  createdAt: DateTime(2026, 7, 29),
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    FlutterSecureStorage.setMockInitialValues(<String, String>{});
+  });
+
+  test('signOut clears consultation requests for the next user', () async {
+    final ProviderContainer container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    expect(
+      container
+          .read(consultationRequestControllerProvider.notifier)
+          .add(_pendingRequest),
+      isTrue,
+    );
+
+    await container.read(sessionControllerProvider.notifier).signOut();
+
+    expect(container.read(consultationRequestControllerProvider), isEmpty);
+    expect(
+      container
+          .read(consultationRequestControllerProvider.notifier)
+          .hasPending(
+            targetType: _pendingRequest.targetType,
+            gymId: _pendingRequest.gymId,
+          ),
+      isFalse,
+    );
+  });
+
+  test('enterDemo clears consultation requests from an existing session', () {
+    final ProviderContainer container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    container
+        .read(consultationRequestControllerProvider.notifier)
+        .add(_pendingRequest);
+
+    container.read(sessionControllerProvider.notifier).enterDemo();
+
+    expect(container.read(consultationRequestControllerProvider), isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary

- 로그아웃 시 `consultationRequestControllerProvider`를 invalidate해 이전 사용자의 메모리 상담 요청을 제거합니다.
- 기존 인증 세션에서 데모 모드로 전환할 때도 같은 상태를 초기화합니다.
- 계정 전환 시 이전 pending 요청과 상담 내용이 남지 않는 회귀 테스트를 추가합니다.

## Why

PR #262 머지 후 남아 있던 미해결 리뷰 피드백을 반영한 후속 수정입니다.

상담 요청 provider가 앱 전역 `StateNotifierProvider`로 유지되는 반면 기존 `SessionController.signOut()`은 토큰과 세션 상태만 초기화했습니다. 그 결과 같은 `ProviderScope`에서 A 사용자가 로그아웃하고 B 사용자가 로그인하면 A의 상담 내용이 노출되고, A의 pending 요청 때문에 B의 동일 대상 상담 버튼이 비활성화될 수 있었습니다.

## Changes

- `SessionController.signOut()`에서 상담 요청 provider invalidate
- 인증 상태에서 호출 가능한 `enterDemo()`에서도 상담 요청 provider invalidate
- `A 요청 생성 → 로그아웃 → 빈 요청 목록 → 동일 대상 pending 없음` 검증
- 기존 세션에서 데모 전환 시 요청 목록 초기화 검증

## Validation

- `dart format .` 실행 완료
  - 현재 Dart 포매터가 기존 파일 36개를 추가로 재포맷해 관련 없는 변경은 되돌렸으며, 수정 파일은 포맷된 상태입니다.
- `flutter test test/features/auth/session_controller_test.dart`: 2건 통과
- `flutter test test/golden/app_button_golden_test.dart test/features/exercise/consultation_request_flow_test.dart test/features/auth/session_controller_test.dart`
  - 관련 세션/상담 테스트 7건 통과
  - 기존 `AppButton variants (golden)` 1건은 기준 이미지 대비 0.37% (3,848px) 차이로 실패
- `flutter test`
  - 관련 테스트 포함 141건 통과
  - 위와 동일한 수정 범위 밖 골든 테스트 1건 실패
- `git diff --check`: 통과

## Scope

상담 요청 데이터의 메모리 저장 방식, provider family, 별도 세션 계층, 백엔드 연동, 트레이너 식별 방식은 변경하지 않았습니다.

## Related Issues

Closes #299

## Related PRs

- Follow-up for #262


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 로그아웃하거나 데모 세션으로 전환할 때 기존 상담 요청 정보가 자동으로 정리됩니다.
  * 세션 변경 후 이전 세션의 상담 요청이 남아 보이거나 잘못 표시되는 문제가 개선되었습니다.

* **테스트**
  * 로그아웃 및 데모 세션 전환 시 상담 요청 상태가 정상적으로 초기화되는지 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->