### PR TITLE
feat(consultation): 회원 상담 요청 생성·조회 API 구현

### DIFF
--- a/backend/app/api/v1/consultations.py
+++ b/backend/app/api/v1/consultations.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import RequireMember
+from app.db.session import get_db
+from app.schemas.consultation_api import ConsultationCreate, ConsultationOut
+from app.services import consultation_service
+
+router = APIRouter(tags=["consultations"])
+
+
+@router.post(
+    "/consultations",
+    response_model=ConsultationOut,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_consultation(
+    payload: ConsultationCreate,
+    member: RequireMember,
+    db: Annotated[Session, Depends(get_db)],
+) -> ConsultationOut:
+    try:
+        return consultation_service.create_consultation(db, member.id, payload)
+    except consultation_service.InvalidConsultationRequest as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except consultation_service.ConsultationTargetNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except consultation_service.DuplicatePendingConsultation as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@router.get("/consultations/me", response_model=list[ConsultationOut])
+def list_my_consultations(
+    member: RequireMember,
+    db: Annotated[Session, Depends(get_db)],
+) -> list[ConsultationOut]:
+    return consultation_service.list_my_consultations(db, member.id)
+
+
+@router.get(
+    "/consultations/{consultation_id}",
+    response_model=ConsultationOut,
+)
+def get_my_consultation(
+    consultation_id: str,
+    member: RequireMember,
+    db: Annotated[Session, Depends(get_db)],
+) -> ConsultationOut:
+    consultation = consultation_service.get_my_consultation(
+        db, member.id, consultation_id
+    )
+    if consultation is None:
+        raise HTTPException(status_code=404, detail="상담 요청을 찾을 수 없습니다.")
+    return consultation

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,8 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.v1 import (
-    ai_coach, coach_docs, dashboard, diet, exercise, member_coach, notifications, places, schedule, social, system, trainer, users, vitals,
+    ai_coach, coach_docs, consultations, dashboard, diet, exercise, member_coach,
+    notifications, places, schedule, social, system, trainer, users, vitals,
 )
 from app.core.config import get_settings
 from app.db.init_db import init_db
@@ -81,3 +82,4 @@ app.include_router(ai_coach.router, prefix=settings.api_v1_prefix)
 app.include_router(coach_docs.router, prefix=settings.api_v1_prefix)
 app.include_router(trainer.router, prefix=settings.api_v1_prefix)
 app.include_router(member_coach.router, prefix=settings.api_v1_prefix)
+app.include_router(consultations.router, prefix=settings.api_v1_prefix)

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -262,10 +262,10 @@ class ConsultationRequest(Base):
     )
     target_type: Mapped[str] = mapped_column(String(20))
     gym_id: Mapped[str | None] = mapped_column(
-        ForeignKey("places.id", ondelete="CASCADE"), nullable=True
+        ForeignKey("places.id", ondelete="SET NULL"), nullable=True
     )
     trainer_id: Mapped[str | None] = mapped_column(
-        ForeignKey("users.id", ondelete="CASCADE"), nullable=True
+        ForeignKey("users.id", ondelete="SET NULL"), nullable=True
     )
     exercise_goal: Mapped[str] = mapped_column(String(30))
     health_purpose_type: Mapped[str] = mapped_column(String(30))

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -252,6 +252,60 @@ class Place(Base):
     kakao_place_id: Mapped[str] = mapped_column(String(50), default="")
 
 
+class ConsultationRequest(Base):
+    """회원의 헬스장·트레이너 상담 요청."""
+    __tablename__ = "consultation_requests"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    member_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    target_type: Mapped[str] = mapped_column(String(20))
+    gym_id: Mapped[str | None] = mapped_column(
+        ForeignKey("places.id", ondelete="CASCADE"), nullable=True
+    )
+    trainer_id: Mapped[str | None] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=True
+    )
+    exercise_goal: Mapped[str] = mapped_column(String(30))
+    health_purpose_type: Mapped[str] = mapped_column(String(30))
+    health_purpose_detail: Mapped[str | None] = mapped_column(Text, nullable=True)
+    preferred_date: Mapped[str] = mapped_column(String(10))
+    preferred_time_slot: Mapped[str] = mapped_column(String(20))
+    message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(
+        String(20), default="pending", server_default="pending"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        Index(
+            "uq_consultation_requests_pending_gym",
+            "member_id",
+            "gym_id",
+            unique=True,
+            postgresql_where=text("target_type = 'gym' AND status = 'pending'"),
+        ),
+        Index(
+            "uq_consultation_requests_pending_trainer",
+            "member_id",
+            "trainer_id",
+            unique=True,
+            postgresql_where=text("target_type = 'trainer' AND status = 'pending'"),
+        ),
+        Index(
+            "ix_consultation_requests_member_created_at",
+            "member_id",
+            "created_at",
+        ),
+    )
+
+
 #
 # ---------------------------------------------------------------------------
 # 트레이너 도메인 — 트레이너↔회원 데이터 공유의 뼈대.

--- a/backend/app/schemas/consultation_api.py
+++ b/backend/app/schemas/consultation_api.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+ConsultationTargetType = Literal["gym", "trainer"]
+ExerciseGoal = Literal[
+    "weight_loss", "strength", "fitness", "posture", "health", "other"
+]
+HealthPurposeType = Literal[
+    "weight", "chronic", "rehab", "general", "none", "other"
+]
+PreferredTimeSlot = Literal["morning", "afternoon", "evening", "flexible"]
+
+
+class ConsultationCreate(BaseModel):
+    target_type: ConsultationTargetType
+    gym_id: str | None = Field(default=None, max_length=64)
+    trainer_id: str | None = Field(default=None, max_length=64)
+    exercise_goal: ExerciseGoal
+    health_purpose_type: HealthPurposeType
+    health_purpose_detail: str | None = Field(default=None, max_length=500)
+    preferred_date: date
+    preferred_time_slot: PreferredTimeSlot
+    message: str | None = Field(default=None, max_length=2000)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_status(cls, data: Any) -> Any:
+        if isinstance(data, dict) and "status" in data:
+            raise ValueError("status는 서버에서 설정합니다.")
+        return data
+
+    @field_validator(
+        "gym_id", "trainer_id", "health_purpose_detail", "message", mode="before"
+    )
+    @classmethod
+    def _normalize_optional_text(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            value = value.strip()
+            return value or None
+        return value
+
+    @model_validator(mode="after")
+    def _validate_target(self) -> ConsultationCreate:
+        if self.target_type == "gym":
+            if self.gym_id is None:
+                raise ValueError("헬스장 상담에는 gym_id가 필요합니다.")
+            if self.trainer_id is not None:
+                raise ValueError("헬스장 상담에는 trainer_id를 사용할 수 없습니다.")
+        else:
+            if self.trainer_id is None:
+                raise ValueError("트레이너 상담에는 trainer_id가 필요합니다.")
+            if self.gym_id is not None:
+                raise ValueError("트레이너 상담에는 gym_id를 사용할 수 없습니다.")
+        if self.health_purpose_type == "other" and self.health_purpose_detail is None:
+            raise ValueError("기타 건강관리 목적에는 상세 내용이 필요합니다.")
+        return self
+
+
+class ConsultationOut(BaseModel):
+    id: str
+    member_id: str
+    target_type: ConsultationTargetType
+    gym_id: str | None
+    trainer_id: str | None
+    exercise_goal: ExerciseGoal
+    health_purpose_type: HealthPurposeType
+    health_purpose_detail: str | None
+    preferred_date: date
+    preferred_time_slot: PreferredTimeSlot
+    message: str | None
+    status: str
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/schemas/consultation_api.py
+++ b/backend/app/schemas/consultation_api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 ConsultationTargetType = Literal["gym", "trainer"]
 ExerciseGoal = Literal[
@@ -61,6 +61,8 @@ class ConsultationCreate(BaseModel):
 
 
 class ConsultationOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: str
     member_id: str
     target_type: ConsultationTargetType

--- a/backend/app/services/consultation_service.py
+++ b/backend/app/services/consultation_service.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.models import ConsultationRequest, Place, TrainerProfile, User
+from app.schemas.consultation_api import ConsultationCreate
+
+
+class InvalidConsultationRequest(Exception):
+    pass
+
+
+class ConsultationTargetNotFound(Exception):
+    pass
+
+
+class DuplicatePendingConsultation(Exception):
+    pass
+
+
+def _pending_query(member_id: str, payload: ConsultationCreate):
+    query = select(ConsultationRequest).where(
+        ConsultationRequest.member_id == member_id,
+        ConsultationRequest.target_type == payload.target_type,
+        ConsultationRequest.status == "pending",
+    )
+    if payload.target_type == "gym":
+        return query.where(ConsultationRequest.gym_id == payload.gym_id)
+    return query.where(ConsultationRequest.trainer_id == payload.trainer_id)
+
+
+def _validate_target(db: Session, payload: ConsultationCreate) -> None:
+    if payload.target_type == "gym":
+        gym = db.scalar(
+            select(Place).where(
+                Place.id == payload.gym_id,
+                Place.category == "fitness",
+            )
+        )
+        if gym is None:
+            raise ConsultationTargetNotFound(
+                "상담 가능한 헬스장을 찾을 수 없습니다."
+            )
+        return
+
+    trainer = db.scalar(
+        select(User)
+        .join(TrainerProfile, TrainerProfile.trainer_id == User.id)
+        .where(
+            User.id == payload.trainer_id,
+            User.role == "trainer",
+            User.is_active.is_(True),
+        )
+    )
+    if trainer is None:
+        raise ConsultationTargetNotFound(
+            "상담 가능한 트레이너를 찾을 수 없습니다."
+        )
+
+
+def create_consultation(
+    db: Session, member_id: str, payload: ConsultationCreate
+) -> ConsultationRequest:
+    if payload.preferred_date < date.today():
+        raise InvalidConsultationRequest("상담 희망일은 오늘 이후여야 합니다.")
+
+    _validate_target(db, payload)
+    if db.scalar(_pending_query(member_id, payload)) is not None:
+        raise DuplicatePendingConsultation("이미 대기 중인 상담 요청이 있습니다.")
+
+    consultation = ConsultationRequest(
+        id=f"consult-{uuid.uuid4().hex[:12]}",
+        member_id=member_id,
+        target_type=payload.target_type,
+        gym_id=payload.gym_id,
+        trainer_id=payload.trainer_id,
+        exercise_goal=payload.exercise_goal,
+        health_purpose_type=payload.health_purpose_type,
+        health_purpose_detail=payload.health_purpose_detail,
+        preferred_date=payload.preferred_date.isoformat(),
+        preferred_time_slot=payload.preferred_time_slot,
+        message=payload.message,
+        status="pending",
+    )
+    db.add(consultation)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        if db.scalar(_pending_query(member_id, payload)) is not None:
+            raise DuplicatePendingConsultation(
+                "이미 대기 중인 상담 요청이 있습니다."
+            ) from None
+        raise
+    db.refresh(consultation)
+    return consultation
+
+
+def list_my_consultations(db: Session, member_id: str) -> list[ConsultationRequest]:
+    return list(
+        db.scalars(
+            select(ConsultationRequest)
+            .where(ConsultationRequest.member_id == member_id)
+            .order_by(
+                ConsultationRequest.created_at.desc(),
+                ConsultationRequest.id.desc(),
+            )
+        ).all()
+    )
+
+
+def get_my_consultation(
+    db: Session, member_id: str, consultation_id: str
+) -> ConsultationRequest | None:
+    return db.scalar(
+        select(ConsultationRequest).where(
+            ConsultationRequest.id == consultation_id,
+            ConsultationRequest.member_id == member_id,
+        )
+    )

--- a/backend/migrations/versions/0014_consultation_requests.py
+++ b/backend/migrations/versions/0014_consultation_requests.py
@@ -1,0 +1,85 @@
+"""회원 상담 요청 테이블
+
+회원이 헬스장 또는 트레이너에게 보내는 상담 요청을 저장한다. 대상별 pending
+요청은 partial unique index 로 한 건만 허용해 동시 요청에서도 중복 생성을 막는다.
+
+Revision ID: 0014_consultation_requests
+Revises: 0013_trainer_active_coach_uq
+Create Date: 2026-07-29
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0014_consultation_requests"
+down_revision: str | Sequence[str] | None = "0013_trainer_active_coach_uq"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "consultation_requests",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column(
+            "member_id", sa.String(64),
+            sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column("target_type", sa.String(20), nullable=False),
+        sa.Column(
+            "gym_id", sa.String(64),
+            sa.ForeignKey("places.id", ondelete="CASCADE"), nullable=True,
+        ),
+        sa.Column(
+            "trainer_id", sa.String(64),
+            sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=True,
+        ),
+        sa.Column("exercise_goal", sa.String(30), nullable=False),
+        sa.Column("health_purpose_type", sa.String(30), nullable=False),
+        sa.Column("health_purpose_detail", sa.Text(), nullable=True),
+        sa.Column("preferred_date", sa.String(10), nullable=False),
+        sa.Column("preferred_time_slot", sa.String(20), nullable=False),
+        sa.Column("message", sa.Text(), nullable=True),
+        sa.Column(
+            "status", sa.String(20), nullable=False, server_default="pending",
+        ),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_consultation_requests_member_id",
+        "consultation_requests",
+        ["member_id"],
+    )
+    op.create_index(
+        "ix_consultation_requests_member_created_at",
+        "consultation_requests",
+        ["member_id", "created_at"],
+    )
+    op.create_index(
+        "uq_consultation_requests_pending_gym",
+        "consultation_requests",
+        ["member_id", "gym_id"],
+        unique=True,
+        postgresql_where=sa.text("target_type = 'gym' AND status = 'pending'"),
+    )
+    op.create_index(
+        "uq_consultation_requests_pending_trainer",
+        "consultation_requests",
+        ["member_id", "trainer_id"],
+        unique=True,
+        postgresql_where=sa.text("target_type = 'trainer' AND status = 'pending'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("consultation_requests")

--- a/backend/migrations/versions/0014_consultation_requests.py
+++ b/backend/migrations/versions/0014_consultation_requests.py
@@ -31,11 +31,11 @@ def upgrade() -> None:
         sa.Column("target_type", sa.String(20), nullable=False),
         sa.Column(
             "gym_id", sa.String(64),
-            sa.ForeignKey("places.id", ondelete="CASCADE"), nullable=True,
+            sa.ForeignKey("places.id", ondelete="SET NULL"), nullable=True,
         ),
         sa.Column(
             "trainer_id", sa.String(64),
-            sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=True,
+            sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True,
         ),
         sa.Column("exercise_goal", sa.String(30), nullable=False),
         sa.Column("health_purpose_type", sa.String(30), nullable=False),

--- a/backend/tests/test_consultations.py
+++ b/backend/tests/test_consultations.py
@@ -1,0 +1,529 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+from app.models.models import ConsultationRequest, Place, TrainerProfile, User
+
+TEST_EMAIL_PREFIX = "consult-test-"
+TEST_PLACE_PREFIX = "consult-place-"
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_consultation_data(db_session):
+    yield
+    db_session.rollback()
+    user_ids = [
+        row[0]
+        for row in db_session.query(User.id)
+        .filter(User.email.like(f"{TEST_EMAIL_PREFIX}%"))
+        .all()
+    ]
+    if user_ids:
+        db_session.query(ConsultationRequest).filter(
+            (ConsultationRequest.member_id.in_(user_ids))
+            | (ConsultationRequest.trainer_id.in_(user_ids))
+        ).delete(synchronize_session=False)
+        db_session.query(TrainerProfile).filter(
+            TrainerProfile.trainer_id.in_(user_ids)
+        ).delete(synchronize_session=False)
+        db_session.query(User).filter(User.id.in_(user_ids)).delete(
+            synchronize_session=False
+        )
+    db_session.query(ConsultationRequest).filter(
+        ConsultationRequest.gym_id.like(f"{TEST_PLACE_PREFIX}%")
+    ).delete(synchronize_session=False)
+    db_session.query(Place).filter(
+        Place.id.like(f"{TEST_PLACE_PREFIX}%")
+    ).delete(synchronize_session=False)
+    db_session.commit()
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _register_member(client) -> tuple[str, str]:
+    suffix = uuid4().hex[:10]
+    email = f"{TEST_EMAIL_PREFIX}{suffix}@oncare.com"
+    response = client.post(
+        "/v1/auth/register",
+        json={"email": email, "password": "pw!", "name": "상담 테스트 회원"},
+    )
+    assert response.status_code == 201, response.text
+    token_response = client.post(
+        "/v1/auth/login",
+        data={"username": email, "password": "pw!"},
+    )
+    assert token_response.status_code == 200, token_response.text
+    return response.json()["id"], token_response.json()["access_token"]
+
+
+def _create_place(db_session, *, category: str = "fitness") -> Place:
+    suffix = uuid4().hex[:10]
+    place = Place(
+        id=f"{TEST_PLACE_PREFIX}{suffix}",
+        name="상담 테스트 헬스장",
+        category=category,
+        address="서울",
+    )
+    db_session.add(place)
+    db_session.commit()
+    return place
+
+
+def _create_trainer(
+    db_session,
+    *,
+    role: str = "trainer",
+    active: bool = True,
+    with_profile: bool = True,
+) -> User:
+    suffix = uuid4().hex[:10]
+    trainer = User(
+        id=f"consult-trainer-{suffix}",
+        email=f"{TEST_EMAIL_PREFIX}trainer-{suffix}@oncare.com",
+        name="상담 테스트 트레이너",
+        role=role,
+        is_active=active,
+    )
+    db_session.add(trainer)
+    db_session.flush()
+    if with_profile:
+        db_session.add(TrainerProfile(trainer_id=trainer.id))
+    db_session.commit()
+    return trainer
+
+
+def _payload(
+    *,
+    target_type: str = "gym",
+    gym_id: str | None = None,
+    trainer_id: str | None = None,
+) -> dict:
+    return {
+        "target_type": target_type,
+        "gym_id": gym_id,
+        "trainer_id": trainer_id,
+        "exercise_goal": "health",
+        "health_purpose_type": "general",
+        "health_purpose_detail": "  건강 습관 개선  ",
+        "preferred_date": (date.today() + timedelta(days=1)).isoformat(),
+        "preferred_time_slot": "afternoon",
+        "message": "  상담을 받고 싶습니다.  ",
+    }
+
+
+def test_create_gym_consultation_sets_server_fields(client, db_session):
+    member_id, token = _register_member(client)
+    gym = _create_place(db_session)
+    payload = _payload(gym_id=gym.id)
+    payload["preferred_date"] = date.today().isoformat()
+
+    response = client.post(
+        "/v1/consultations",
+        headers=_auth(token),
+        json=payload,
+    )
+
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["id"].startswith("consult-")
+    assert body["member_id"] == member_id
+    assert body["target_type"] == "gym"
+    assert body["gym_id"] == gym.id
+    assert body["trainer_id"] is None
+    assert body["status"] == "pending"
+    assert body["health_purpose_detail"] == "건강 습관 개선"
+    assert body["message"] == "상담을 받고 싶습니다."
+    assert body["created_at"]
+    assert body["updated_at"]
+
+
+def test_create_trainer_consultation(client, db_session):
+    _, token = _register_member(client)
+    trainer = _create_trainer(db_session)
+
+    response = client.post(
+        "/v1/consultations",
+        headers=_auth(token),
+        json=_payload(target_type="trainer", trainer_id=trainer.id),
+    )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["trainer_id"] == trainer.id
+    assert response.json()["gym_id"] is None
+
+
+def test_client_cannot_set_consultation_status(client, db_session):
+    _, token = _register_member(client)
+    gym = _create_place(db_session)
+    payload = _payload(gym_id=gym.id)
+    payload["status"] = "approved"
+
+    response = client.post(
+        "/v1/consultations", headers=_auth(token), json=payload
+    )
+
+    assert response.status_code == 422
+
+
+def test_past_preferred_date_is_rejected(client, db_session):
+    _, token = _register_member(client)
+    gym = _create_place(db_session)
+    payload = _payload(gym_id=gym.id)
+    payload["preferred_date"] = (date.today() - timedelta(days=1)).isoformat()
+
+    response = client.post(
+        "/v1/consultations", headers=_auth(token), json=payload
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("target_type", "hospital"),
+        ("exercise_goal", "bulk"),
+        ("health_purpose_type", "sleep"),
+        ("preferred_time_slot", "night"),
+    ],
+)
+def test_invalid_limited_value_is_rejected(
+    client, db_session, field: str, value: str
+):
+    _, token = _register_member(client)
+    gym = _create_place(db_session)
+    payload = _payload(gym_id=gym.id)
+    payload[field] = value
+
+    response = client.post(
+        "/v1/consultations", headers=_auth(token), json=payload
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize("detail", [None, "", "   "])
+def test_other_health_purpose_requires_detail(client, db_session, detail):
+    _, token = _register_member(client)
+    gym = _create_place(db_session)
+    payload = _payload(gym_id=gym.id)
+    payload["health_purpose_type"] = "other"
+    payload["health_purpose_detail"] = detail
+
+    response = client.post(
+        "/v1/consultations", headers=_auth(token), json=payload
+    )
+
+    assert response.status_code == 422
+
+
+def test_blank_optional_text_is_normalized_to_null(client, db_session):
+    _, token = _register_member(client)
+    gym = _create_place(db_session)
+    payload = _payload(gym_id=gym.id)
+    payload["health_purpose_detail"] = " "
+    payload["message"] = " "
+
+    response = client.post(
+        "/v1/consultations", headers=_auth(token), json=payload
+    )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["health_purpose_detail"] is None
+    assert response.json()["message"] is None
+
+
+def test_message_length_is_limited(client, db_session):
+    _, token = _register_member(client)
+    gym = _create_place(db_session)
+    payload = _payload(gym_id=gym.id)
+    payload["message"] = "a" * 2001
+
+    response = client.post(
+        "/v1/consultations", headers=_auth(token), json=payload
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize("category", [None, "medical"])
+def test_missing_or_non_fitness_gym_is_rejected(client, db_session, category):
+    _, token = _register_member(client)
+    gym_id = "consult-place-missing"
+    if category is not None:
+        gym_id = _create_place(db_session, category=category).id
+
+    response = client.post(
+        "/v1/consultations",
+        headers=_auth(token),
+        json=_payload(gym_id=gym_id),
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.parametrize(
+    "trainer_options",
+    [
+        None,
+        {"role": "member"},
+        {"active": False},
+        {"with_profile": False},
+    ],
+)
+def test_invalid_trainer_target_is_rejected(
+    client, db_session, trainer_options
+):
+    _, token = _register_member(client)
+    trainer_id = "consult-trainer-missing"
+    if trainer_options is not None:
+        trainer_id = _create_trainer(db_session, **trainer_options).id
+
+    response = client.post(
+        "/v1/consultations",
+        headers=_auth(token),
+        json=_payload(target_type="trainer", trainer_id=trainer_id),
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.parametrize(
+    "payload_changes",
+    [
+        {"target_type": "trainer", "gym_id": None, "trainer_id": None},
+        {"target_type": "gym", "trainer_id": "trainer-any"},
+        {"target_type": "gym", "gym_id": None},
+    ],
+)
+def test_target_id_contract_is_validated(
+    client, db_session, payload_changes
+):
+    _, token = _register_member(client)
+    gym = _create_place(db_session)
+    payload = _payload(gym_id=gym.id)
+    payload.update(payload_changes)
+
+    response = client.post(
+        "/v1/consultations", headers=_auth(token), json=payload
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize("target_type", ["gym", "trainer"])
+def test_duplicate_pending_consultation_is_rejected(
+    client, db_session, target_type
+):
+    _, token = _register_member(client)
+    if target_type == "gym":
+        target = _create_place(db_session)
+        payload = _payload(gym_id=target.id)
+    else:
+        target = _create_trainer(db_session)
+        payload = _payload(target_type="trainer", trainer_id=target.id)
+
+    first = client.post(
+        "/v1/consultations", headers=_auth(token), json=payload
+    )
+    second = client.post(
+        "/v1/consultations", headers=_auth(token), json=payload
+    )
+
+    assert first.status_code == 201
+    assert second.status_code == 409
+
+
+@pytest.mark.parametrize("target_type", ["gym", "trainer"])
+def test_partial_unique_index_allows_completed_but_rejects_second_pending(
+    client, db_session, target_type
+):
+    from sqlalchemy.exc import IntegrityError
+
+    member_id, _ = _register_member(client)
+    gym_id = trainer_id = None
+    if target_type == "gym":
+        gym_id = _create_place(db_session).id
+    else:
+        trainer_id = _create_trainer(db_session).id
+    common = {
+        "member_id": member_id,
+        "target_type": target_type,
+        "gym_id": gym_id,
+        "trainer_id": trainer_id,
+        "exercise_goal": "health",
+        "health_purpose_type": "general",
+        "preferred_date": date.today().isoformat(),
+        "preferred_time_slot": "flexible",
+    }
+
+    db_session.add(
+        ConsultationRequest(
+            id=f"consult-{uuid4().hex[:12]}",
+            status="accepted",
+            **common,
+        )
+    )
+    db_session.commit()
+    db_session.add(
+        ConsultationRequest(
+            id=f"consult-{uuid4().hex[:12]}",
+            status="pending",
+            **common,
+        )
+    )
+    db_session.commit()
+
+    db_session.add(
+        ConsultationRequest(
+            id=f"consult-{uuid4().hex[:12]}",
+            status="pending",
+            **common,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()
+
+
+def test_gym_and_trainer_pending_requests_are_independent(client, db_session):
+    _, token = _register_member(client)
+    gym = _create_place(db_session)
+    trainer = _create_trainer(db_session)
+
+    gym_response = client.post(
+        "/v1/consultations",
+        headers=_auth(token),
+        json=_payload(gym_id=gym.id),
+    )
+    trainer_response = client.post(
+        "/v1/consultations",
+        headers=_auth(token),
+        json=_payload(target_type="trainer", trainer_id=trainer.id),
+    )
+
+    assert gym_response.status_code == 201
+    assert trainer_response.status_code == 201
+
+
+def test_list_returns_only_current_member_in_latest_order(client, db_session):
+    first_member_id, first_token = _register_member(client)
+    _, second_token = _register_member(client)
+    first_gym = _create_place(db_session)
+    second_gym = _create_place(db_session)
+
+    first = client.post(
+        "/v1/consultations",
+        headers=_auth(first_token),
+        json=_payload(gym_id=first_gym.id),
+    )
+    assert first.status_code == 201
+    first_row = db_session.get(ConsultationRequest, first.json()["id"])
+    first_row.created_at = datetime.now(timezone.utc) - timedelta(days=1)
+    db_session.commit()
+
+    second = client.post(
+        "/v1/consultations",
+        headers=_auth(first_token),
+        json=_payload(gym_id=second_gym.id),
+    )
+    assert second.status_code == 201
+    other = client.post(
+        "/v1/consultations",
+        headers=_auth(second_token),
+        json=_payload(gym_id=first_gym.id),
+    )
+    assert other.status_code == 201
+
+    response = client.get(
+        "/v1/consultations/me", headers=_auth(first_token)
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [row["id"] for row in body] == [
+        second.json()["id"],
+        first.json()["id"],
+    ]
+    assert {row["member_id"] for row in body} == {first_member_id}
+
+
+def test_get_returns_own_consultation(client, db_session):
+    _, token = _register_member(client)
+    gym = _create_place(db_session)
+    created = client.post(
+        "/v1/consultations",
+        headers=_auth(token),
+        json=_payload(gym_id=gym.id),
+    )
+
+    response = client.get(
+        f"/v1/consultations/{created.json()['id']}",
+        headers=_auth(token),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["id"] == created.json()["id"]
+
+
+def test_other_members_consultation_is_hidden(client, db_session):
+    _, owner_token = _register_member(client)
+    _, other_token = _register_member(client)
+    gym = _create_place(db_session)
+    created = client.post(
+        "/v1/consultations",
+        headers=_auth(owner_token),
+        json=_payload(gym_id=gym.id),
+    )
+
+    response = client.get(
+        f"/v1/consultations/{created.json()['id']}",
+        headers=_auth(other_token),
+    )
+
+    assert response.status_code == 404
+
+
+def test_missing_consultation_returns_404(client):
+    _, token = _register_member(client)
+
+    response = client.get(
+        "/v1/consultations/consult-missing",
+        headers=_auth(token),
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("post", "/v1/consultations"),
+        ("get", "/v1/consultations/me"),
+        ("get", "/v1/consultations/consult-any"),
+    ],
+)
+def test_consultation_endpoints_require_authentication(
+    client, method: str, path: str
+):
+    kwargs = {"json": _payload(gym_id="consult-place-any")} if method == "post" else {}
+
+    response = getattr(client, method)(path, **kwargs)
+
+    assert response.status_code == 401
+
+
+def test_trainer_cannot_access_consultation_endpoints(client):
+    token_response = client.post(
+        "/v1/auth/login",
+        data={"username": "trainer@oncare.com", "password": "oncare123"},
+    )
+    assert token_response.status_code == 200
+    headers = _auth(token_response.json()["access_token"])
+
+    assert client.get("/v1/consultations/me", headers=headers).status_code == 403

--- a/backend/tests/test_consultations.py
+++ b/backend/tests/test_consultations.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import pytest
 
 from app.models.models import ConsultationRequest, Place, TrainerProfile, User
+from app.schemas.consultation_api import ConsultationOut
 
 TEST_EMAIL_PREFIX = "consult-test-"
 TEST_PLACE_PREFIX = "consult-place-"
@@ -157,17 +158,43 @@ def test_create_trainer_consultation(client, db_session):
     assert response.json()["gym_id"] is None
 
 
-def test_client_cannot_set_consultation_status(client, db_session):
+@pytest.mark.parametrize("status", ["pending", "accepted", "rejected"])
+def test_client_cannot_set_consultation_status(client, db_session, status):
     _, token = _register_member(client)
     gym = _create_place(db_session)
     payload = _payload(gym_id=gym.id)
-    payload["status"] = "approved"
+    payload["status"] = status
 
     response = client.post(
         "/v1/consultations", headers=_auth(token), json=payload
     )
 
     assert response.status_code == 422
+
+
+def test_consultation_out_validates_orm_instance():
+    now = datetime.now(timezone.utc)
+    consultation = ConsultationRequest(
+        id="consult-orm-validation",
+        member_id="user-orm-validation",
+        target_type="gym",
+        gym_id="place-orm-validation",
+        trainer_id=None,
+        exercise_goal="health",
+        health_purpose_type="general",
+        health_purpose_detail=None,
+        preferred_date=date.today().isoformat(),
+        preferred_time_slot="flexible",
+        message=None,
+        status="pending",
+        created_at=now,
+        updated_at=now,
+    )
+
+    response = ConsultationOut.model_validate(consultation)
+
+    assert response.id == consultation.id
+    assert response.preferred_date == date.today()
 
 
 def test_past_preferred_date_is_rejected(client, db_session):


### PR DESCRIPTION
## Summary

- 회원이 헬스장 또는 트레이너에게 상담 요청을 생성할 수 있습니다.
- 현재 회원의 상담 요청 목록과 상세 내용을 조회할 수 있습니다.
- 상담 대상, 날짜, enum, other 상세 입력, 소유권을 검증합니다.
- 동일 대상의 pending 요청은 서비스와 PostgreSQL partial unique index로 중복 방지합니다.

---

## Changes

### ✨ Features

- ConsultationRequest ORM 모델 추가
- 0014_consultation_requests migration 추가
- POST /v1/consultations
- GET /v1/consultations/me
- GET /v1/consultations/{consultation_id}
- 회원 전용 RequireMember 인증 적용
- 헬스장 및 트레이너 대상 검증
- pending 중복 방지
- 본인 목록 및 상세 조회

### 🔧 Improvements

- 소유권 불일치 시 존재 여부를 숨기기 위해 404 반환
- 동시 생성 시 IntegrityError rollback 후 중복 여부 재확인
- 목록 created_at 내림차순 정렬

### 🎨 UI/UX

- 해당 없음

### 📝 Docs

- 별도 문서 변경 없음

### 🐛 Fixes

- 해당 없음

---

## Commits

1. `39851e9` feat(consultation): 상담 요청 모델 및 마이그레이션 추가
2. `34bfa19` feat(consultation): 회원 상담 요청 생성·조회 API 구현
3. `12da493` test(consultation): 상담 요청 API 테스트 추가

---

## Notes

- gym_id는 영속된 Place.id를 사용합니다.
- Place.category == "fitness"인 장소만 허용합니다.
- trainer_id는 User.id이며 role == "trainer", is_active, TrainerProfile 존재를 검증합니다.
- TrainerProfile과 Place 사이 FK가 없어 트레이너의 헬스장 소속 여부는 검증하지 않습니다.
- Flutter Mock Gym ID와 Place.id 정렬은 이번 PR 범위가 아닙니다.
- 로컬 PostgreSQL 및 Docker 환경이 없어 상담 API 테스트는 공용 fixture 정책에 따라 skip되었습니다.
- 실제 PostgreSQL 환경의 API 및 partial unique index 동작은 CI에서 확인했습니다.
- PR #291이 main.py를 수정 중이므로 병합 순서에 따라 경미한 충돌 가능성이 있습니다.

---

## Screenshots (Optional)

- 백엔드 API 변경으로 별도 스크린샷 없음

---

## Test Plan

- [x] Python 3.11 compileall 통과
- [x] 전체 백엔드 테스트: 61 passed
- [x] 전체 결과: 61 passed, 167 skipped
- [x] Alembic 단일 head 확인
- [x] offline upgrade SQL 생성 통과
- [x] 0014 → 0013 offline downgrade SQL 생성 통과
- [x] partial unique index SQL 확인
- [x] git diff --check 통과
- [x] PostgreSQL 환경에서 상담 테스트 38개 실행
- [x] PostgreSQL CI: 231 passed, 1 warning, 0 skipped
- [x] 실제 DB Alembic 0013 → 0014 upgrade 통과
- [x] gym/trainer partial unique index DB 테스트 통과
- [x] ORM 응답 직렬화 테스트 통과

### Manual Test Steps

1. 회원 토큰으로 POST /v1/consultations 호출
2. 생성 응답 status가 pending인지 확인
3. 같은 대상에 pending 요청을 다시 생성해 409 확인
4. GET /v1/consultations/me에서 본인 요청만 최신순으로 반환되는지 확인
5. GET /v1/consultations/{id}에서 본인 요청 조회 확인
6. 다른 회원의 요청 ID로 접근 시 404 확인
7. trainer 토큰으로 접근 시 403 확인
8. 무인증 접근 시 401 확인

---

## Related Issues

Closes #264

## Checklist

- [x] 코드 리뷰 준비 완료
- [x] 불필요한 코드 제거
- [x] 하드코딩 값 점검
- [x] Merge 충돌 없음 또는 충돌 가능성 확인
- [x] 데모 시나리오 영향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 헬스장 또는 트레이너에게 상담 요청을 생성할 수 있습니다.
  * 내 상담 요청 목록과 개별 상담 상세 정보를 확인할 수 있습니다.
  * 상담 대상, 운동 목표, 건강 목적, 희망 일정 및 메시지를 입력할 수 있습니다.

* **버그 수정 및 검증**
  * 잘못된 대상, 과거 날짜, 중복 대기 상담 요청을 차단합니다.
  * 상담 요청에 대한 인증 및 본인 데이터 접근 권한을 강화했습니다.
  * 입력값 정리와 필수 항목 검증을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
