### PR TITLE
refactor(trainer-design): 트레이너 앱 디자인을 사용자 앱 기준으로 통일 (#267~273)

### DIFF
--- a/frontend/flutter/lib/design_system/figma/figma_kit.dart
+++ b/frontend/flutter/lib/design_system/figma/figma_kit.dart
@@ -29,12 +29,13 @@ class FigmaColors {
   static const Color greenTag = Color(0xFF34C782); // coaching 운동 tag
   static const Color orange = Color(0xFFFF953C); // fat bar / warn fill
   static const Color orangeText = Color(0xFFE8760A); // warn text
-  static const Color heartOrange = Color(0xFFFF7A45); // spark / trainer accent
+  static const Color heartOrange = Color(0xFFFF953C); // spark accent(주의 오렌지로 통일)
   static const Color sugarPurple = Color(0xFF9B8FD4); // 당류 chart
   static const Color sleepPurple = Color(0xFF6B7FE0); // 수면 chart
 
   // Dots / status
   static const Color redDot = Color(0xFFFF3B5C);
+  static const Color dangerRed = Color(0xFFF04438); // 초과/경고 강조(나트륨 초과 등)
   static const Color statusGreen = Color(0xFF34C759);
   static const Color onlineGreen = Color(0xFF4ADE80);
 

--- a/frontend/flutter/lib/features/auth/presentation/pages/sign_in_page.dart
+++ b/frontend/flutter/lib/features/auth/presentation/pages/sign_in_page.dart
@@ -108,7 +108,7 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                       ),
                       const SizedBox(height: AppSpacing.lg),
                       Text(
-                        'On - care',
+                        'On - Care',
                         textAlign: TextAlign.center,
                         style: theme.textTheme.headlineSmall?.copyWith(
                           fontWeight: FontWeight.w700,

--- a/frontend/flutter/lib/features/auth/presentation/pages/sign_up_page.dart
+++ b/frontend/flutter/lib/features/auth/presentation/pages/sign_up_page.dart
@@ -128,7 +128,7 @@ class _SignUpPageState extends ConsumerState<SignUpPage> {
                       ),
                       const SizedBox(height: 4),
                       Text(
-                        '온케어 계정을 만들어 건강 관리를 시작하세요',
+                        'On-Care 계정을 만들어 건강 관리를 시작하세요',
                         textAlign: TextAlign.center,
                         style: theme.textTheme.bodyMedium?.copyWith(
                           color: AppColors.mutedForeground,

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -261,10 +261,10 @@ class _CoachingBanner extends StatelessWidget {
   Widget build(BuildContext context) {
     return Material(
       color: Colors.transparent,
-      borderRadius: BorderRadius.circular(16),
+      borderRadius: BorderRadius.circular(20),
       child: InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(20),
         child: Container(
           decoration: BoxDecoration(
             gradient: const LinearGradient(
@@ -272,7 +272,7 @@ class _CoachingBanner extends StatelessWidget {
               end: Alignment.bottomRight,
               colors: <Color>[FigmaColors.bannerStart, FigmaColors.bannerEnd],
             ),
-            borderRadius: BorderRadius.circular(16),
+            borderRadius: BorderRadius.circular(20),
             border: Border.all(color: FigmaColors.primaryA(0.18)),
             boxShadow: kCardShadow,
           ),
@@ -352,7 +352,7 @@ class _StripeCard extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         color: Colors.white,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(20),
         border: Border.all(color: FigmaColors.primaryA(0.08)),
         boxShadow: kCardShadow,
       ),
@@ -486,7 +486,7 @@ class _DietNutritionCardState extends State<_DietNutritionCard> {
                             vertical: 2,
                           ),
                           decoration: BoxDecoration(
-                            color: const Color(0xFFF04438).withValues(alpha: 0.12),
+                            color: FigmaColors.dangerRed.withValues(alpha: 0.12),
                             borderRadius: BorderRadius.circular(999),
                           ),
                           child: const Text(
@@ -494,7 +494,7 @@ class _DietNutritionCardState extends State<_DietNutritionCard> {
                             style: TextStyle(
                               fontSize: 8.5,
                               fontWeight: FontWeight.w700,
-                              color: Color(0xFFF04438),
+                              color: FigmaColors.dangerRed,
                             ),
                           ),
                         ),
@@ -1063,7 +1063,7 @@ class _MetricTile extends StatelessWidget {
 
 /// 목표 대비 상태색: 초과(빨강) / 근접 90%↑(주황) / 안전(초록).
 Color _nutStatusColor(double v, double goal) {
-  if (v > goal) return const Color(0xFFF04438);
+  if (v > goal) return FigmaColors.dangerRed;
   if (v >= goal * 0.9) return FigmaColors.orange;
   return const Color(0xFF34C759);
 }
@@ -1701,7 +1701,7 @@ class _RecMealCard extends StatelessWidget {
       width: 130,
       decoration: BoxDecoration(
         color: Colors.white,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(20),
         border: Border.all(color: const Color(0x0D000000)),
         boxShadow: kCardShadow,
       ),

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -454,7 +454,7 @@ class _NutritionSummary extends StatelessWidget {
                   value: _formatInt(sodium),
                   unit: l.dietUnitMg,
                   // 오늘 나트륨 과다(짬뽕) → 빨간계열로 강조.
-                  color: const Color(0xFFF04438),
+                  color: FigmaColors.dangerRed,
                 ),
               ),
               const SizedBox(width: 8),
@@ -836,7 +836,7 @@ class _MealCard extends StatelessWidget {
                       value: '${_formatInt(meal.sodium)} ${l.dietUnitMg}',
                       // 좋으면 파란계열, 나트륨이 과다하면 빨간계열.
                       color: meal.sodium > 1000
-                          ? const Color(0xFFF04438)
+                          ? FigmaColors.dangerRed
                           : FigmaColors.primary,
                     ),
                     _TotalPill(

--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -611,15 +611,7 @@ class _StatCard extends StatelessWidget {
                     ? FigmaColors.primaryA(0.15)
                     : FigmaColors.hairline,
               ),
-        boxShadow: streak
-            ? <BoxShadow>[
-                BoxShadow(
-                  color: FigmaColors.heartOrange.withValues(alpha: 0.4),
-                  blurRadius: 14,
-                  offset: const Offset(0, 4),
-                ),
-              ]
-            : null,
+        boxShadow: streak ? kCardShadow : null,
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -830,7 +822,7 @@ class _TodayDonut extends StatelessWidget {
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         color: Colors.white,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(20),
         border: Border.all(color: FigmaColors.primaryA(0.10)),
         boxShadow: kCardShadow,
       ),
@@ -1112,7 +1104,7 @@ class _ActivityChart extends StatelessWidget {
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         color: Colors.white,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(20),
         border: Border.all(color: FigmaColors.primaryA(0.10)),
         boxShadow: kCardShadow,
       ),

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
@@ -1196,12 +1196,6 @@ BoxDecoration _cardDecoration() {
     color: Colors.white,
     borderRadius: BorderRadius.circular(20),
     border: Border.all(color: FigmaColors.hairline),
-    boxShadow: <BoxShadow>[
-      BoxShadow(
-        color: Colors.black.withValues(alpha: 0.09),
-        blurRadius: 24,
-        offset: const Offset(0, 4),
-      ),
-    ],
+    boxShadow: kCardShadow,
   );
 }

--- a/frontend/flutter/test/features/diet/mock_diet_repository_test.dart
+++ b/frontend/flutter/test/features/diet/mock_diet_repository_test.dart
@@ -2,8 +2,8 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 
 void main() {
   final Uint8List bytes = Uint8List(0);

--- a/frontend/flutter_trainer/lib/app/app.dart
+++ b/frontend/flutter_trainer/lib/app/app.dart
@@ -14,7 +14,7 @@ class OncareTrainerApp extends ConsumerWidget {
     final router = ref.watch(appRouterProvider);
 
     return MaterialApp.router(
-      title: '온케어 트레이너',
+      title: 'On-Care 트레이너',
       debugShowCheckedModeBanner: false,
       theme: AppTheme.light(),
       routerConfig: router,

--- a/frontend/flutter_trainer/lib/app/router/app_router.dart
+++ b/frontend/flutter_trainer/lib/app/router/app_router.dart
@@ -8,6 +8,7 @@ import 'package:oncare_trainer/features/ai_routine/presentation/pages/ai_routine
 import 'package:oncare_trainer/features/auth/domain/entities/session_state.dart';
 import 'package:oncare_trainer/features/auth/presentation/controllers/session_controller.dart';
 import 'package:oncare_trainer/features/auth/presentation/pages/trainer_sign_in_page.dart';
+import 'package:oncare_trainer/features/auth/presentation/pages/trainer_sign_up_page.dart';
 import 'package:oncare_trainer/features/clients/presentation/pages/client_detail_page.dart';
 import 'package:oncare_trainer/features/clients/presentation/pages/clients_page.dart';
 import 'package:oncare_trainer/features/my/presentation/pages/my_page.dart';
@@ -22,7 +23,8 @@ import 'package:oncare_trainer/features/schedule/presentation/pages/schedule_pag
 ///
 /// Returning `null` means "no redirect — stay put".
 String? sessionRedirect(SessionStatus status, String location) {
-  final onAuthRoute = location == AppRoutes.signIn;
+  final onAuthRoute =
+      location == AppRoutes.signIn || location == AppRoutes.signUp;
   switch (status) {
     case SessionStatus.unknown:
     case SessionStatus.signedOut:
@@ -96,6 +98,10 @@ GoRouter buildAppRouter({
       GoRoute(
         path: AppRoutes.signIn,
         builder: (context, state) => const TrainerSignInPage(),
+      ),
+      GoRoute(
+        path: AppRoutes.signUp,
+        builder: (context, state) => const TrainerSignUpPage(),
       ),
     ],
   );

--- a/frontend/flutter_trainer/lib/app/router/routes.dart
+++ b/frontend/flutter_trainer/lib/app/router/routes.dart
@@ -7,6 +7,9 @@ class AppRoutes {
   /// Trainer login screen (email/password + demo bypass).
   static const String signIn = '/auth/sign-in';
 
+  /// Trainer 회원가입 screen (name/email/password).
+  static const String signUp = '/auth/sign-up';
+
   // Main tabs (StatefulShellRoute branches).
 
   /// 고객 관리 — client list (home tab).

--- a/frontend/flutter_trainer/lib/core/storage/session_token_store.dart
+++ b/frontend/flutter_trainer/lib/core/storage/session_token_store.dart
@@ -17,6 +17,8 @@ class SessionTokenStore {
   final SharedPreferences _prefs;
 
   static const String _tokenKey = 'trainer_access_token';
+  static const String _nameKey = 'trainer_profile_name';
+  static const String _emailKey = 'trainer_profile_email';
 
   /// Returns the persisted access token, or `null` if the trainer is
   /// signed out.
@@ -26,11 +28,47 @@ class SessionTokenStore {
     return token;
   }
 
-  /// Persists [token] so the session survives an app restart.
-  Future<void> saveToken(String token) => _prefs.setString(_tokenKey, token);
+  /// Returns the persisted profile name submitted at 회원가입, or `null`
+  /// when the session used the seed identity (login / social / demo).
+  String? readProfileName() => _readNonEmpty(_nameKey);
 
-  /// Clears the persisted token (sign-out).
-  Future<void> clear() => _prefs.remove(_tokenKey);
+  /// Returns the persisted profile email submitted at 회원가입, or `null`
+  /// when the session used the seed identity.
+  String? readProfileEmail() => _readNonEmpty(_emailKey);
+
+  /// Persists [token] so the session survives an app restart, together
+  /// with the optional profile identity ([name] / [email]) submitted at
+  /// 회원가입. A `null`/blank identity field is removed so restore falls
+  /// back to the seed profile — logins keep the seed identity, while a
+  /// registered trainer's submitted name/email survive a restart.
+  Future<void> saveSession({
+    required String token,
+    String? name,
+    String? email,
+  }) async {
+    await _prefs.setString(_tokenKey, token);
+    await _writeOrRemove(_nameKey, name);
+    await _writeOrRemove(_emailKey, email);
+  }
+
+  /// Clears the persisted token and profile identity (sign-out).
+  Future<void> clear() async {
+    await _prefs.remove(_tokenKey);
+    await _prefs.remove(_nameKey);
+    await _prefs.remove(_emailKey);
+  }
+
+  String? _readNonEmpty(String key) {
+    final value = _prefs.getString(key);
+    if (value == null || value.isEmpty) return null;
+    return value;
+  }
+
+  Future<void> _writeOrRemove(String key, String? value) {
+    final trimmed = value?.trim();
+    if (trimmed == null || trimmed.isEmpty) return _prefs.remove(key);
+    return _prefs.setString(key, trimmed);
+  }
 }
 
 /// Provides the [SessionTokenStore], wired to the app-wide prefs.

--- a/frontend/flutter_trainer/lib/design_system/tokens/colors.dart
+++ b/frontend/flutter_trainer/lib/design_system/tokens/colors.dart
@@ -23,7 +23,7 @@ class AppColors {
 
   /// Trainer identity orange — kept only as a small accent (the
   /// "트레이너" brand word, MY-tab highlights), not as the main color.
-  static const Color brandOrange = Color(0xFFFF7A45);
+  static const Color brandOrange = Color(0xFFFF953C); // 주의 오렌지(#FF953C)로 통일
 
   // --- Accent (client blue) ---
   /// Blue used for client avatars, info chips, and the "AI 요약" card.
@@ -42,6 +42,11 @@ class AppColors {
   /// #FFF4EE,#FFE8D8)`) — kept orange as a trainer-identity block.
   static const Color statsGradientStart = Color(0xFFFFF4EE);
   static const Color statsGradientEnd = Color(0xFFFFE8D8);
+
+  /// 사용자 앱 "오늘의 AI 통합 조언" 배너 배경(연한 블루). 통계 카드 등
+  /// 블루 톤으로 통일할 때 사용.
+  static const Color bannerStart = Color(0xFFEDF7FC);
+  static const Color bannerEnd = Color(0xFFD6EEF8);
 
   // --- Surface / text ---
   /// App canvas behind cards (mock uses `#F8FAFC`).

--- a/frontend/flutter_trainer/lib/design_system/tokens/elevation.dart
+++ b/frontend/flutter_trainer/lib/design_system/tokens/elevation.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/painting.dart';
+
+/// Shared soft card shadow, matching the user app's `kCardShadow`
+/// (brand-blue tinted, ~12.5% alpha, blur 10, y+3) so cards across both
+/// apps read with the same elevation. The tint `0x203EAFDF` uses
+/// `AppColors.primary` (#3EAFDF), identical to the user app.
+const List<BoxShadow> kCardShadow = <BoxShadow>[
+  BoxShadow(
+    color: Color(0x203EAFDF),
+    blurRadius: 10,
+    offset: Offset(0, 3),
+  ),
+];

--- a/frontend/flutter_trainer/lib/design_system/tokens/typography.dart
+++ b/frontend/flutter_trainer/lib/design_system/tokens/typography.dart
@@ -7,25 +7,26 @@ class AppTypography {
   AppTypography._();
 
   static TextTheme buildTextTheme(TextTheme base) {
+    // 사용자 앱(design_system/tokens/typography.dart)의 가중치 스케일과 일치.
     return base.copyWith(
       displayLarge: base.displayLarge?.copyWith(
-        fontWeight: FontWeight.w800,
+        fontWeight: FontWeight.w700,
         height: 1.2,
       ),
       displayMedium: base.displayMedium?.copyWith(
-        fontWeight: FontWeight.w800,
+        fontWeight: FontWeight.w700,
         height: 1.25,
       ),
       headlineSmall: base.headlineSmall?.copyWith(
-        fontWeight: FontWeight.w800,
+        fontWeight: FontWeight.w700,
         height: 1.25,
       ),
       titleLarge: base.titleLarge?.copyWith(
-        fontWeight: FontWeight.w700,
+        fontWeight: FontWeight.w600,
         height: 1.3,
       ),
       titleMedium: base.titleMedium?.copyWith(
-        fontWeight: FontWeight.w700,
+        fontWeight: FontWeight.w600,
         height: 1.3,
       ),
       bodyLarge: base.bodyLarge?.copyWith(
@@ -33,7 +34,7 @@ class AppTypography {
         height: 1.45,
       ),
       bodyMedium: base.bodyMedium?.copyWith(height: 1.5),
-      labelLarge: base.labelLarge?.copyWith(fontWeight: FontWeight.w700),
+      labelLarge: base.labelLarge?.copyWith(fontWeight: FontWeight.w600),
     );
   }
 }

--- a/frontend/flutter_trainer/lib/features/ai_routine/presentation/pages/ai_routine_page.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/presentation/pages/ai_routine_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/elevation.dart';
 import 'package:oncare_trainer/design_system/tokens/layout.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
@@ -403,11 +404,6 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
       Row(
         children: <Widget>[
           _sectionLabel('AI 추천 루틴'),
-          const SizedBox(width: AppSpacing.xs),
-          const Text(
-            '· 수정 가능',
-            style: TextStyle(fontSize: 11, color: AppColors.disabledForeground),
-          ),
           const Spacer(),
           Container(
             padding: const EdgeInsets.symmetric(
@@ -542,9 +538,12 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
               // registration is in flight, so a second tap can't queue a
               // duplicate session (review PR 220).
               registered: _registered || _registeringClientId == client.id,
+              icon: _registered
+                  ? Icons.check_rounded
+                  : Icons.calendar_today_outlined,
               label: _registered
-                  ? '✓ ${_dateChipLabel(_registerOffset)} 스케줄에 등록됨'
-                  : '📅 ${_dateChipLabel(_registerOffset)} PT 스케줄에 등록',
+                  ? '${_dateChipLabel(_registerOffset)} 스케줄에 등록됨'
+                  : '${_dateChipLabel(_registerOffset)} PT 스케줄에 등록',
               onTap: () => _registerToSchedule(client, items),
             ),
             if (_registered)
@@ -663,6 +662,7 @@ class _DietSummaryCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColors.card,
         borderRadius: const BorderRadius.all(AppRadius.card),
+        boxShadow: kCardShadow,
         border: Border.all(color: AppColors.border),
       ),
       child: Column(
@@ -758,6 +758,7 @@ class _RoutineCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColors.card,
         borderRadius: const BorderRadius.all(AppRadius.card),
+        boxShadow: kCardShadow,
         border: Border.all(
           color: isCustom
               ? AppColors.warning.withValues(alpha: 0.35)
@@ -836,13 +837,29 @@ class _RoutineCard extends StatelessWidget {
             ],
           ),
           const SizedBox(height: AppSpacing.xs),
-          Text(
-            '💡 $reason',
-            style: const TextStyle(
-              fontSize: 10,
-              fontWeight: FontWeight.w500,
-              color: AppColors.subtleForeground,
-            ),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              const Padding(
+                padding: EdgeInsets.only(top: 1),
+                child: Icon(
+                  Icons.lightbulb_outline,
+                  size: 12,
+                  color: AppColors.subtleForeground,
+                ),
+              ),
+              const SizedBox(width: 4),
+              Expanded(
+                child: Text(
+                  reason,
+                  style: const TextStyle(
+                    fontSize: 10,
+                    fontWeight: FontWeight.w500,
+                    color: AppColors.subtleForeground,
+                  ),
+                ),
+              ),
+            ],
           ),
           const SizedBox(height: AppSpacing.sm),
           Row(
@@ -1039,6 +1056,7 @@ class _AddExerciseFormState extends State<_AddExerciseForm> {
       decoration: BoxDecoration(
         color: AppColors.card,
         borderRadius: const BorderRadius.all(AppRadius.card),
+        boxShadow: kCardShadow,
         border: Border.all(color: AppColors.warning.withValues(alpha: 0.35)),
       ),
       child: Column(
@@ -1259,11 +1277,13 @@ class _DateChip extends StatelessWidget {
 class _RegisterButton extends StatelessWidget {
   const _RegisterButton({
     required this.registered,
+    required this.icon,
     required this.label,
     required this.onTap,
   });
 
   final bool registered;
+  final IconData icon;
   final String label;
   final VoidCallback onTap;
 
@@ -1283,13 +1303,24 @@ class _RegisterButton extends StatelessWidget {
             borderRadius: const BorderRadius.all(AppRadius.card),
             border: Border.all(color: color.withValues(alpha: 0.5)),
           ),
-          child: Text(
-            label,
-            style: TextStyle(
-              fontSize: 12.5,
-              fontWeight: FontWeight.w700,
-              color: color,
-            ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Icon(icon, size: 15, color: color),
+              const SizedBox(width: 6),
+              Flexible(
+                child: Text(
+                  label,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 12.5,
+                    fontWeight: FontWeight.w700,
+                    color: color,
+                  ),
+                ),
+              ),
+            ],
           ),
         ),
       ),

--- a/frontend/flutter_trainer/lib/features/auth/data/repositories/mock_trainer_auth_repository.dart
+++ b/frontend/flutter_trainer/lib/features/auth/data/repositories/mock_trainer_auth_repository.dart
@@ -25,6 +25,40 @@ class MockTrainerAuthRepository implements TrainerAuthRepository {
 
     return 'demo-trainer-token-${DateTime.now().microsecondsSinceEpoch}';
   }
+
+  @override
+  Future<String> register({
+    required String email,
+    required String password,
+    required String name,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 400));
+
+    if (email.trim().isEmpty || password.isEmpty) {
+      throw const AuthException('이메일과 비밀번호를 입력해 주세요');
+    }
+
+    // Mock: no persistence — issues a fake token. The submitted name is
+    // reflected on the profile by the SessionController. Real account
+    // creation arrives with the backend.
+    return 'demo-trainer-signup-${DateTime.now().microsecondsSinceEpoch}';
+  }
+
+  @override
+  Future<String> socialLogin({
+    required String provider,
+    required String token,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 400));
+
+    if (token.isEmpty) {
+      throw const AuthException('소셜 로그인 토큰이 없어요');
+    }
+
+    // Mock: accepts the demo token as-is. The real backend validates the
+    // kakao/google token before issuing a session token.
+    return 'demo-trainer-$provider-${DateTime.now().microsecondsSinceEpoch}';
+  }
 }
 
 /// Provides the trainer auth repository. Swapped for a real

--- a/frontend/flutter_trainer/lib/features/auth/domain/repositories/trainer_auth_repository.dart
+++ b/frontend/flutter_trainer/lib/features/auth/domain/repositories/trainer_auth_repository.dart
@@ -21,4 +21,21 @@ abstract class TrainerAuthRepository {
   /// Exchanges email/password for an access token. Throws
   /// [AuthException] on failure.
   Future<String> login({required String email, required String password});
+
+  /// Creates a new trainer account (POST /auth/register) and returns an
+  /// access token. Distinct from [login] so the real backend can enforce
+  /// account-creation semantics and persist [name]. Throws [AuthException].
+  Future<String> register({
+    required String email,
+    required String password,
+    required String name,
+  });
+
+  /// Exchanges a provider (kakao/google) [token] for an access token
+  /// (POST /auth/social). The real backend validates the provider token;
+  /// the mock issues a demo token. Throws [AuthException].
+  Future<String> socialLogin({
+    required String provider,
+    required String token,
+  });
 }

--- a/frontend/flutter_trainer/lib/features/auth/presentation/controllers/session_controller.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/controllers/session_controller.dart
@@ -59,11 +59,21 @@ class SessionController extends StateNotifier<SessionState> {
     required String password,
     required String name,
   }) async {
-    final token = await _authRepository.login(email: email, password: password);
+    final token = await _authRepository.register(
+      email: email,
+      password: password,
+      name: name,
+    );
     await _tokenStore.saveToken(token);
-    state = const SessionState(
+    final trimmedName = name.trim();
+    final trimmedEmail = email.trim();
+    state = SessionState(
       status: SessionStatus.authenticated,
-      profile: seedTrainerProfile,
+      // 데모: 제출한 이름/이메일을 시드 프로필에 반영(빈 값이면 시드 값 유지).
+      profile: seedTrainerProfile.copyWith(
+        name: trimmedName.isEmpty ? null : trimmedName,
+        email: trimmedEmail.isEmpty ? null : trimmedEmail,
+      ),
     );
   }
 
@@ -71,9 +81,11 @@ class SessionController extends StateNotifier<SessionState> {
   /// real provider SDK lands, this exchanges a demo credential through the
   /// mock repo, persists the token, and attaches the seed profile.
   Future<void> socialLogin({required String provider}) async {
-    final token = await _authRepository.login(
-      email: '$provider@trainer.demo',
-      password: 'social-$provider',
+    // 사용자 앱과 동일: 실기기 SDK 연동 전까지 데모 토큰을 보내고, 실서버가
+    // provider 토큰을 검증한다(트레이너 auth는 아직 전부 mock).
+    final token = await _authRepository.socialLogin(
+      provider: provider,
+      token: 'demo-$provider-token',
     );
     await _tokenStore.saveToken(token);
     state = const SessionState(

--- a/frontend/flutter_trainer/lib/features/auth/presentation/controllers/session_controller.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/controllers/session_controller.dart
@@ -51,6 +51,37 @@ class SessionController extends StateNotifier<SessionState> {
     );
   }
 
+  /// 회원가입 — creates an account and signs in. Mock: reuses the login
+  /// exchange (any non-empty credentials succeed) and attaches the seed
+  /// profile. The real backend (POST /auth/register) replaces this later.
+  Future<void> register({
+    required String email,
+    required String password,
+    required String name,
+  }) async {
+    final token = await _authRepository.login(email: email, password: password);
+    await _tokenStore.saveToken(token);
+    state = const SessionState(
+      status: SessionStatus.authenticated,
+      profile: seedTrainerProfile,
+    );
+  }
+
+  /// Social sign-in (kakao / google). Mirrors the user app: until the
+  /// real provider SDK lands, this exchanges a demo credential through the
+  /// mock repo, persists the token, and attaches the seed profile.
+  Future<void> socialLogin({required String provider}) async {
+    final token = await _authRepository.login(
+      email: '$provider@trainer.demo',
+      password: 'social-$provider',
+    );
+    await _tokenStore.saveToken(token);
+    state = const SessionState(
+      status: SessionStatus.authenticated,
+      profile: seedTrainerProfile,
+    );
+  }
+
   /// Enters demo mode — skip login, no token, browse with mock data.
   /// Not persisted, so a restart returns to the signed-out state.
   void enterDemo() {

--- a/frontend/flutter_trainer/lib/features/auth/presentation/controllers/session_controller.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/controllers/session_controller.dart
@@ -25,14 +25,20 @@ class SessionController extends StateNotifier<SessionState> {
   final SessionTokenStore _tokenStore;
 
   /// Resolves the initial session from persisted state. A stored token
-  /// means the trainer stays logged in (with the seed profile);
-  /// otherwise they land signed out. Demo mode is never persisted.
+  /// means the trainer stays logged in; the profile identity submitted at
+  /// 회원가입 (name/email) is restored from persistence so a restart keeps
+  /// the registered account instead of reverting to the seed. Otherwise
+  /// they land signed out. Demo mode is never persisted.
   void _restore() {
     final token = _tokenStore.readToken();
     if (token != null) {
-      state = const SessionState(
+      state = SessionState(
         status: SessionStatus.authenticated,
-        profile: seedTrainerProfile,
+        // 저장된 이름/이메일이 있으면 복원(가입 세션), 없으면 시드 유지(로그인 세션).
+        profile: seedTrainerProfile.copyWith(
+          name: _tokenStore.readProfileName(),
+          email: _tokenStore.readProfileEmail(),
+        ),
       );
     } else {
       state = const SessionState(status: SessionStatus.signedOut);
@@ -44,7 +50,8 @@ class SessionController extends StateNotifier<SessionState> {
   /// Throws [AuthException] on failure.
   Future<void> login({required String email, required String password}) async {
     final token = await _authRepository.login(email: email, password: password);
-    await _tokenStore.saveToken(token);
+    // 로그인은 시드 정체성 — 저장된 가입 이름/이메일이 있으면 지워 시드로 복원되게 한다.
+    await _tokenStore.saveSession(token: token);
     state = const SessionState(
       status: SessionStatus.authenticated,
       profile: seedTrainerProfile,
@@ -64,12 +71,17 @@ class SessionController extends StateNotifier<SessionState> {
       password: password,
       name: name,
     );
-    await _tokenStore.saveToken(token);
     final trimmedName = name.trim();
     final trimmedEmail = email.trim();
+    // 데모: 제출한 이름/이메일을 토큰과 함께 영속화해 앱 재시작 후에도 가입 정체성이
+    // 시드 계정으로 되돌아가지 않게 한다(빈 값이면 저장하지 않아 시드 값 유지).
+    await _tokenStore.saveSession(
+      token: token,
+      name: trimmedName.isEmpty ? null : trimmedName,
+      email: trimmedEmail.isEmpty ? null : trimmedEmail,
+    );
     state = SessionState(
       status: SessionStatus.authenticated,
-      // 데모: 제출한 이름/이메일을 시드 프로필에 반영(빈 값이면 시드 값 유지).
       profile: seedTrainerProfile.copyWith(
         name: trimmedName.isEmpty ? null : trimmedName,
         email: trimmedEmail.isEmpty ? null : trimmedEmail,
@@ -87,7 +99,8 @@ class SessionController extends StateNotifier<SessionState> {
       provider: provider,
       token: 'demo-$provider-token',
     );
-    await _tokenStore.saveToken(token);
+    // 소셜 로그인도 시드 정체성 — 저장된 가입 이름/이메일이 있으면 지운다.
+    await _tokenStore.saveSession(token: token);
     state = const SessionState(
       status: SessionStatus.authenticated,
       profile: seedTrainerProfile,

--- a/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_in_page.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_in_page.dart
@@ -4,7 +4,6 @@ import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
-import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/features/auth/domain/repositories/trainer_auth_repository.dart';
 import 'package:oncare_trainer/features/auth/presentation/controllers/session_controller.dart';
@@ -40,6 +39,26 @@ class _TrainerSignInPageState extends ConsumerState<TrainerSignInPage> {
     context.go(AppRoutes.clients);
   }
 
+  void _onSignUp() => context.push(AppRoutes.signUp);
+
+  Future<void> _social(String provider) async {
+    if (_loading) return;
+    final messenger = ScaffoldMessenger.of(context);
+    setState(() => _loading = true);
+    try {
+      await ref
+          .read(sessionControllerProvider.notifier)
+          .socialLogin(provider: provider);
+      if (!mounted) return;
+      context.go(AppRoutes.clients);
+    } catch (_) {
+      if (mounted) setState(() => _loading = false);
+      messenger.showSnackBar(
+        const SnackBar(content: Text('소셜 로그인에 실패했어요. 잠시 후 다시 시도해 주세요')),
+      );
+    }
+  }
+
   Future<void> _login() async {
     if (_loading) return;
     final messenger = ScaffoldMessenger.of(context);
@@ -73,7 +92,8 @@ class _TrainerSignInPageState extends ConsumerState<TrainerSignInPage> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Scaffold(
-      backgroundColor: AppColors.background,
+      // 사용자 앱 로그인 화면과 동일한 흰색 배경.
+      backgroundColor: Colors.white,
       body: SafeArea(
         child: Center(
           child: SingleChildScrollView(
@@ -84,37 +104,30 @@ class _TrainerSignInPageState extends ConsumerState<TrainerSignInPage> {
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: <Widget>[
-                  // Brand — On-Care logo in a rounded card.
+                  // 브랜드 — On-Care 로고(테두리 없이 크게), 사용자 앱과 동일.
                   Center(
-                    child: Container(
-                      width: 84,
-                      height: 84,
-                      padding: const EdgeInsets.all(AppSpacing.sm),
-                      decoration: BoxDecoration(
-                        color: AppColors.card,
-                        borderRadius: const BorderRadius.all(AppRadius.card),
-                        border: Border.all(color: AppColors.border),
-                      ),
-                      child: Image.asset(
-                        'assets/images/oncare-logo.png',
-                        fit: BoxFit.contain,
-                      ),
+                    child: Image.asset(
+                      'assets/images/oncare-logo.png',
+                      width: 132,
+                      height: 132,
+                      fit: BoxFit.contain,
                     ),
                   ),
                   const SizedBox(height: AppSpacing.lg),
                   Text(
-                    '온케어 트레이너',
+                    'On - Care 트레이너',
                     textAlign: TextAlign.center,
                     style: theme.textTheme.headlineSmall?.copyWith(
-                      fontWeight: FontWeight.w800,
+                      fontWeight: FontWeight.w700,
+                      color: const Color(0xFF262626),
                     ),
                   ),
-                  const SizedBox(height: AppSpacing.xs),
+                  const SizedBox(height: 4),
                   Text(
                     '고객 관리를 위한 트레이너 전용 앱',
                     textAlign: TextAlign.center,
                     style: theme.textTheme.bodyMedium?.copyWith(
-                      color: AppColors.mutedForeground,
+                      color: const Color(0xFF64748B),
                     ),
                   ),
                   const SizedBox(height: AppSpacing.xxl),
@@ -136,7 +149,7 @@ class _TrainerSignInPageState extends ConsumerState<TrainerSignInPage> {
                       icon: Icon(
                         _obscure ? Icons.visibility_off : Icons.visibility,
                         size: 20,
-                        color: AppColors.subtleForeground,
+                        color: const Color(0xFF64748B),
                       ),
                       onPressed: () => setState(() => _obscure = !_obscure),
                     ),
@@ -149,6 +162,32 @@ class _TrainerSignInPageState extends ConsumerState<TrainerSignInPage> {
                     onTap: _login,
                   ),
                   const SizedBox(height: AppSpacing.lg),
+                  const _OrDivider(),
+                  const SizedBox(height: AppSpacing.lg),
+                  _SocialButton.kakao(
+                    onTap: _loading ? null : () => _social('kakao'),
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                  _SocialButton.google(
+                    onTap: _loading ? null : () => _social('google'),
+                  ),
+                  const SizedBox(height: AppSpacing.md),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      const Text(
+                        '계정이 없으신가요?',
+                        style: TextStyle(color: Color(0xFF64748B)),
+                      ),
+                      TextButton(
+                        onPressed: _loading ? null : _onSignUp,
+                        style: TextButton.styleFrom(
+                          foregroundColor: AppColors.primary,
+                        ),
+                        child: const Text('회원가입'),
+                      ),
+                    ],
+                  ),
                   Center(
                     child: TextButton(
                       onPressed: _loading ? null : _enterDemo,
@@ -161,6 +200,102 @@ class _TrainerSignInPageState extends ConsumerState<TrainerSignInPage> {
                 ],
               ),
             ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// "— 또는 —" separator between the email login and social buttons.
+/// Mirrors the user app's sign-in divider.
+class _OrDivider extends StatelessWidget {
+  const _OrDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Row(
+      children: <Widget>[
+        Expanded(child: Divider(color: Color(0x1A000000))),
+        Padding(
+          padding: EdgeInsets.symmetric(horizontal: AppSpacing.md),
+          child: Text(
+            '또는',
+            style: TextStyle(color: Color(0xFF64748B), fontSize: 13),
+          ),
+        ),
+        Expanded(child: Divider(color: Color(0x1A000000))),
+      ],
+    );
+  }
+}
+
+/// Provider-branded social sign-in button (kakao / google), matching the
+/// user app. [onTap] drives the demo-token social exchange.
+class _SocialButton extends StatelessWidget {
+  const _SocialButton({
+    required this.label,
+    required this.icon,
+    required this.background,
+    required this.foreground,
+    required this.onTap,
+    this.border,
+    this.iconSize = 20,
+  });
+
+  factory _SocialButton.kakao({required VoidCallback? onTap}) => _SocialButton(
+    label: '카카오로 시작하기',
+    icon: Icons.chat_bubble_rounded,
+    background: const Color(0xFFFEE500),
+    foreground: const Color(0xFF191600),
+    onTap: onTap,
+  );
+
+  factory _SocialButton.google({required VoidCallback? onTap}) => _SocialButton(
+    label: '구글로 시작하기',
+    icon: Icons.g_mobiledata,
+    background: const Color(0xFFFFFFFF),
+    foreground: const Color(0xFF262626),
+    border: const Color(0x1A000000),
+    iconSize: 28,
+    onTap: onTap,
+  );
+
+  final String label;
+  final IconData icon;
+  final Color background;
+  final Color foreground;
+  final Color? border;
+  final double iconSize;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: background,
+      borderRadius: const BorderRadius.all(Radius.circular(14)),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: const BorderRadius.all(Radius.circular(14)),
+        child: Container(
+          height: 50,
+          decoration: BoxDecoration(
+            borderRadius: const BorderRadius.all(Radius.circular(14)),
+            border: border != null ? Border.all(color: border!) : null,
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Icon(icon, color: foreground, size: iconSize),
+              const SizedBox(width: AppSpacing.sm),
+              Text(
+                label,
+                style: TextStyle(
+                  color: foreground,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
           ),
         ),
       ),

--- a/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_up_page.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_up_page.dart
@@ -1,0 +1,206 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/features/auth/domain/repositories/trainer_auth_repository.dart';
+import 'package:oncare_trainer/features/auth/presentation/controllers/session_controller.dart';
+import 'package:oncare_trainer/features/auth/presentation/widgets/auth_fields.dart';
+
+/// 트레이너 회원가입 화면 — 사용자 앱 회원가입과 동일한 디자인. 이름/이메일/
+/// 비밀번호로 계정을 만들고, 성공 시 자동 로그인해 고객 탭으로 진입한다
+/// (라우터 가드가 인증 상태를 감지).
+class TrainerSignUpPage extends ConsumerStatefulWidget {
+  /// Creates the trainer sign-up screen.
+  const TrainerSignUpPage({super.key});
+
+  @override
+  ConsumerState<TrainerSignUpPage> createState() => _TrainerSignUpPageState();
+}
+
+class _TrainerSignUpPageState extends ConsumerState<TrainerSignUpPage> {
+  final TextEditingController _name = TextEditingController();
+  final TextEditingController _email = TextEditingController();
+  final TextEditingController _password = TextEditingController();
+  final TextEditingController _passwordConfirm = TextEditingController();
+  bool _obscure = true;
+  bool _loading = false;
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _email.dispose();
+    _password.dispose();
+    _passwordConfirm.dispose();
+    super.dispose();
+  }
+
+  void _backToSignIn() {
+    if (context.canPop()) {
+      context.pop();
+    } else {
+      context.go(AppRoutes.signIn);
+    }
+  }
+
+  Future<void> _register() async {
+    if (_loading) return;
+    final messenger = ScaffoldMessenger.of(context);
+    final name = _name.text.trim();
+    final email = _email.text.trim();
+    final password = _password.text;
+    final confirm = _passwordConfirm.text;
+    if (email.isEmpty || password.isEmpty) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('이메일과 비밀번호를 입력해 주세요')),
+      );
+      return;
+    }
+    if (password.length < 8) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('비밀번호는 8자 이상이어야 해요')),
+      );
+      return;
+    }
+    if (password != confirm) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('비밀번호가 일치하지 않아요')),
+      );
+      return;
+    }
+    setState(() => _loading = true);
+    try {
+      await ref
+          .read(sessionControllerProvider.notifier)
+          .register(email: email, password: password, name: name);
+      if (!mounted) return;
+      context.go(AppRoutes.clients);
+    } on AuthException catch (e) {
+      if (mounted) setState(() => _loading = false);
+      messenger.showSnackBar(SnackBar(content: Text(e.message)));
+    } catch (_) {
+      if (mounted) setState(() => _loading = false);
+      messenger.showSnackBar(
+        const SnackBar(content: Text('회원가입에 실패했어요. 잠시 후 다시 시도해 주세요.')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        child: Stack(
+          children: <Widget>[
+            Align(
+              alignment: Alignment.topLeft,
+              child: Padding(
+                padding: const EdgeInsets.all(AppSpacing.xs),
+                child: IconButton(
+                  onPressed: _backToSignIn,
+                  icon: const Icon(Icons.arrow_back),
+                  color: const Color(0xFF64748B),
+                ),
+              ),
+            ),
+            Center(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(AppSpacing.xl),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 400),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: <Widget>[
+                      Text(
+                        '회원가입',
+                        textAlign: TextAlign.center,
+                        style: theme.textTheme.headlineSmall?.copyWith(
+                          fontWeight: FontWeight.w700,
+                          color: const Color(0xFF262626),
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        'On-Care 계정을 만들어 회원 관리를 시작하세요',
+                        textAlign: TextAlign.center,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: const Color(0xFF64748B),
+                        ),
+                      ),
+                      const SizedBox(height: AppSpacing.xxl),
+
+                      AuthField(
+                        controller: _name,
+                        hint: '이름',
+                        icon: Icons.person_outline,
+                      ),
+                      const SizedBox(height: AppSpacing.md),
+                      AuthField(
+                        controller: _email,
+                        hint: '이메일',
+                        icon: Icons.mail_outline,
+                        keyboardType: TextInputType.emailAddress,
+                      ),
+                      const SizedBox(height: AppSpacing.md),
+                      AuthField(
+                        controller: _password,
+                        hint: '비밀번호 (8자 이상)',
+                        icon: Icons.lock_outline,
+                        obscure: _obscure,
+                        trailing: IconButton(
+                          icon: Icon(
+                            _obscure ? Icons.visibility_off : Icons.visibility,
+                            size: 20,
+                            color: const Color(0xFF64748B),
+                          ),
+                          onPressed: () => setState(() => _obscure = !_obscure),
+                        ),
+                      ),
+                      const SizedBox(height: AppSpacing.md),
+                      AuthField(
+                        controller: _passwordConfirm,
+                        hint: '비밀번호 확인',
+                        icon: Icons.lock_outline,
+                        obscure: _obscure,
+                        onSubmitted: (_) => _register(),
+                      ),
+                      const SizedBox(height: AppSpacing.xl),
+
+                      AuthGradientButton(
+                        loading: _loading,
+                        label: '가입하고 시작하기',
+                        onTap: _register,
+                      ),
+                      const SizedBox(height: AppSpacing.sm),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: <Widget>[
+                          const Text(
+                            '이미 계정이 있으신가요?',
+                            style: TextStyle(color: Color(0xFF64748B)),
+                          ),
+                          TextButton(
+                            onPressed: _backToSignIn,
+                            style: TextButton.styleFrom(
+                              foregroundColor: AppColors.primary,
+                            ),
+                            child: const Text('로그인'),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/flutter_trainer/lib/features/auth/presentation/widgets/auth_fields.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/widgets/auth_fields.dart
@@ -1,16 +1,23 @@
 import 'package:flutter/material.dart';
 
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
-import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 
-/// Trainer brand gradient (orange) used by the auth screens. Layout /
-/// widget shape mirrors the user app's auth fields, but every color is
-/// read from the trainer design tokens.
+// 로그인 화면을 사용자 앱과 픽셀 단위로 동일하게 맞추기 위해, 사용자 앱
+// AppColors 값을 그대로 사용한다(트레이너 로그인 전용).
+const Color _authText = Color(0xFF262626); // 사용자 앱 foreground
+const Color _authMutedText = Color(0xFF64748B); // 사용자 앱 mutedForeground / hint
+const Color _authInputBg = Color(0xFFF3F3F5); // 사용자 앱 inputBackground
+const Color _authLoadingBg = Color(0xFFE8F4F8); // 사용자 앱 muted
+const BorderRadius _authRadius =
+    BorderRadius.all(Radius.circular(14)); // 사용자 앱 AppRadius.lg
+
+/// Brand gradient for the auth screens — matched to the user app
+/// (primary #3EAFDF → secondary #277DA1).
 const LinearGradient authBrandGradient = LinearGradient(
   begin: Alignment.topLeft,
   end: Alignment.bottomRight,
-  colors: <Color>[AppColors.primary, AppColors.secondary],
+  colors: <Color>[Color(0xFF3EAFDF), Color(0xFF277DA1)],
 );
 
 /// Filled, icon-prefixed text field used on the trainer login screen.
@@ -58,18 +65,20 @@ class AuthField extends StatelessWidget {
       controller: controller,
       obscureText: obscure,
       keyboardType: keyboardType,
+      style: const TextStyle(color: _authText),
       textInputAction:
           textInputAction ??
           (onSubmitted != null ? TextInputAction.done : TextInputAction.next),
       onSubmitted: onSubmitted,
       decoration: InputDecoration(
         hintText: hint,
-        prefixIcon: Icon(icon, color: AppColors.subtleForeground, size: 20),
+        hintStyle: const TextStyle(color: _authMutedText),
+        prefixIcon: Icon(icon, color: _authMutedText, size: 20),
         suffixIcon: trailing,
         filled: true,
-        fillColor: AppColors.inputBackground,
+        fillColor: _authInputBg,
         border: const OutlineInputBorder(
-          borderRadius: BorderRadius.all(AppRadius.lg),
+          borderRadius: _authRadius,
           borderSide: BorderSide.none,
         ),
         contentPadding: const EdgeInsets.symmetric(
@@ -105,16 +114,16 @@ class AuthGradientButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return Material(
       color: Colors.transparent,
-      borderRadius: const BorderRadius.all(AppRadius.lg),
+      borderRadius: _authRadius,
       child: InkWell(
         onTap: loading ? null : onTap,
-        borderRadius: const BorderRadius.all(AppRadius.lg),
+        borderRadius: _authRadius,
         child: Ink(
           height: 52,
           decoration: BoxDecoration(
             gradient: loading ? null : authBrandGradient,
-            color: loading ? AppColors.inputBackground : null,
-            borderRadius: const BorderRadius.all(AppRadius.lg),
+            color: loading ? _authLoadingBg : null,
+            borderRadius: _authRadius,
           ),
           child: Center(
             child: loading

--- a/frontend/flutter_trainer/lib/features/clients/presentation/pages/clients_page.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/pages/clients_page.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/elevation.dart';
 import 'package:oncare_trainer/design_system/tokens/layout.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
@@ -229,6 +230,12 @@ class _ClientsView extends StatelessWidget {
   }
 }
 
+/// 신규 고객 등록 시트의 입력칸 공통 테두리 — 검정 밑줄 대신 둥근 네모.
+const OutlineInputBorder _sheetInputBorder = OutlineInputBorder(
+  borderRadius: BorderRadius.all(AppRadius.lg),
+  borderSide: BorderSide.none,
+);
+
 /// Bottom sheet collecting the new client's 이름/목표.
 class _AddClientSheet extends ConsumerStatefulWidget {
   const _AddClientSheet();
@@ -310,34 +317,22 @@ class _AddClientSheetState extends ConsumerState<_AddClientSheet> {
             ),
           ),
           const SizedBox(height: AppSpacing.lg),
-          Row(
-            children: <Widget>[
-              const Text(
-                '이름',
-                style: TextStyle(
-                  fontSize: 12,
-                  fontWeight: FontWeight.w600,
-                  color: AppColors.subtleForeground,
-                ),
-              ),
-              const SizedBox(width: 3),
-              Text(
-                '*필수',
-                style: TextStyle(
-                  fontSize: 9,
-                  fontWeight: FontWeight.w700,
-                  color: AppColors.destructive.withValues(alpha: 0.85),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: AppSpacing.xs),
           TextField(
             controller: _name,
             decoration: InputDecoration(
               hintText: '고객 이름',
+              hintStyle: const TextStyle(color: AppColors.subtleForeground),
               isDense: true,
+              filled: true,
+              fillColor: AppColors.inputBackground,
               errorText: _nameError,
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: AppSpacing.md,
+                vertical: AppSpacing.md,
+              ),
+              border: _sheetInputBorder,
+              enabledBorder: _sheetInputBorder,
+              focusedBorder: _sheetInputBorder,
             ),
             onChanged: (_) {
               if (_nameError != null) setState(() => _nameError = null);
@@ -348,7 +343,17 @@ class _AddClientSheetState extends ConsumerState<_AddClientSheet> {
             controller: _goal,
             decoration: const InputDecoration(
               hintText: '목표 (예: 체중 감량 · 근력 향상)',
+              hintStyle: TextStyle(color: AppColors.subtleForeground),
               isDense: true,
+              filled: true,
+              fillColor: AppColors.inputBackground,
+              contentPadding: EdgeInsets.symmetric(
+                horizontal: AppSpacing.md,
+                vertical: AppSpacing.md,
+              ),
+              border: _sheetInputBorder,
+              enabledBorder: _sheetInputBorder,
+              focusedBorder: _sheetInputBorder,
             ),
           ),
           const SizedBox(height: AppSpacing.lg),
@@ -400,6 +405,7 @@ class _AiSummaryCard extends StatelessWidget {
         ),
         borderRadius: const BorderRadius.all(AppRadius.card),
         border: Border.all(color: AppColors.borderStrong),
+        boxShadow: kCardShadow,
       ),
       child: Row(
         children: <Widget>[

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_card.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/elevation.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
@@ -33,10 +34,16 @@ class ClientCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: selected ? AppColors.accentSurface : AppColors.card,
-      borderRadius: const BorderRadius.all(AppRadius.card),
-      child: InkWell(
+    return DecoratedBox(
+      // 사용자 앱과 동일한 kCardShadow(소프트 블루)로 통일.
+      decoration: const BoxDecoration(
+        borderRadius: BorderRadius.all(AppRadius.card),
+        boxShadow: kCardShadow,
+      ),
+      child: Material(
+        color: selected ? AppColors.accentSurface : AppColors.card,
+        borderRadius: const BorderRadius.all(AppRadius.card),
+        child: InkWell(
         onTap: onTap,
         borderRadius: const BorderRadius.all(AppRadius.card),
         child: Container(
@@ -167,6 +174,7 @@ class ClientCard extends StatelessWidget {
             ],
           ),
         ),
+      ),
       ),
     );
   }

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/diet_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/diet_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/elevation.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
@@ -65,6 +66,7 @@ class _NutritionSummary extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColors.card,
         borderRadius: const BorderRadius.all(AppRadius.card),
+        boxShadow: kCardShadow,
         border: Border.all(color: AppColors.border),
       ),
       child: Column(
@@ -157,6 +159,7 @@ class _SodiumTrendCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColors.card,
         borderRadius: const BorderRadius.all(AppRadius.card),
+        boxShadow: kCardShadow,
         border: Border.all(color: AppColors.border),
       ),
       child: Column(
@@ -289,6 +292,7 @@ class _MealCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColors.card,
         borderRadius: const BorderRadius.all(AppRadius.card),
+        boxShadow: kCardShadow,
         border: Border.all(color: AppColors.border),
       ),
       child: Column(

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/workout_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/workout_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/elevation.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
@@ -80,6 +81,7 @@ class _WeekCompletionCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColors.card,
         borderRadius: const BorderRadius.all(AppRadius.card),
+        boxShadow: kCardShadow,
         border: Border.all(color: AppColors.border),
       ),
       child: Column(
@@ -202,6 +204,7 @@ class _HistoryCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColors.card,
         borderRadius: const BorderRadius.all(AppRadius.card),
+        boxShadow: kCardShadow,
         border: Border.all(color: AppColors.border),
       ),
       child: Column(

--- a/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
+++ b/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/elevation.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 // Session은 앱 전역 상태라 예외적으로 auth feature 의 provider 를 직접
@@ -303,6 +304,7 @@ class _ProfileCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColors.card,
         borderRadius: const BorderRadius.all(AppRadius.card),
+        boxShadow: kCardShadow,
         border: Border.all(
           color: editing
               ? AppColors.primary.withValues(alpha: 0.35)
@@ -313,20 +315,30 @@ class _ProfileCard extends StatelessWidget {
         children: <Widget>[
           Row(
             children: <Widget>[
-              // Warm gradient avatar — trainer identity accent (mock).
+              // 사용자 앱 MY 프로필과 동일한 이니셜 원형 아바타(블루 그라데이션).
               Container(
                 width: 52,
                 height: 52,
                 alignment: Alignment.center,
-                decoration: const BoxDecoration(
+                decoration: BoxDecoration(
                   shape: BoxShape.circle,
-                  gradient: LinearGradient(
+                  gradient: const LinearGradient(
                     begin: Alignment.topLeft,
                     end: Alignment.bottomRight,
-                    colors: <Color>[AppColors.brandOrange, AppColors.warning],
+                    colors: <Color>[AppColors.primary, AppColors.secondary],
+                  ),
+                  border: Border.all(color: AppColors.primary, width: 2.5),
+                ),
+                child: Text(
+                  profile.name.isNotEmpty
+                      ? profile.name.substring(0, 1)
+                      : '·',
+                  style: const TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w800,
+                    color: Colors.white,
                   ),
                 ),
-                child: const Text('🧑‍💼', style: TextStyle(fontSize: 22)),
               ),
               const SizedBox(width: AppSpacing.md),
               Expanded(
@@ -354,7 +366,7 @@ class _ProfileCard extends StatelessWidget {
                       children: <Widget>[
                         _Tag(
                           text: profile.specialty,
-                          color: AppColors.brandOrange,
+                          color: AppColors.success,
                         ),
                         const SizedBox(width: AppSpacing.xs),
                         _Tag(
@@ -502,6 +514,7 @@ class _CertsCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColors.card,
         borderRadius: const BorderRadius.all(AppRadius.card),
+        boxShadow: kCardShadow,
         border: Border.all(color: AppColors.border),
       ),
       child: Column(
@@ -517,14 +530,14 @@ class _CertsCard extends StatelessWidget {
                     width: 24,
                     height: 24,
                     alignment: Alignment.center,
-                    decoration: BoxDecoration(
-                      color: AppColors.brandOrange.withValues(alpha: 0.1),
-                      borderRadius: const BorderRadius.all(AppRadius.sm),
+                    decoration: const BoxDecoration(
+                      color: AppColors.accentSurface,
+                      borderRadius: BorderRadius.all(AppRadius.sm),
                     ),
                     child: const Icon(
                       Icons.workspace_premium_outlined,
                       size: 13,
-                      color: AppColors.brandOrange,
+                      color: AppColors.primary,
                     ),
                   ),
                   const SizedBox(width: AppSpacing.md),
@@ -602,19 +615,32 @@ class _StatsCard extends StatelessWidget {
         gradient: const LinearGradient(
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
-          colors: <Color>[
-            AppColors.statsGradientStart,
-            AppColors.statsGradientEnd,
-          ],
+          colors: <Color>[AppColors.bannerStart, AppColors.bannerEnd],
         ),
         borderRadius: const BorderRadius.all(AppRadius.card),
-        border: Border.all(color: AppColors.brandOrange.withValues(alpha: 0.2)),
+        border: Border.all(color: AppColors.primary.withValues(alpha: 0.18)),
+        boxShadow: kCardShadow,
       ),
       child: Row(
         children: <Widget>[
-          _Stat(icon: '👥', value: '$clientCount', unit: '명', label: '담당 고객'),
-          const _Stat(icon: '✅', value: '24', unit: '회', label: '완료 세션'),
-          const _Stat(icon: '📤', value: '18', unit: '건', label: '루틴 전송'),
+          _Stat(
+            icon: Icons.people_alt_outlined,
+            value: '$clientCount',
+            unit: '명',
+            label: '담당 고객',
+          ),
+          const _Stat(
+            icon: Icons.check_circle_outline_rounded,
+            value: '24',
+            unit: '회',
+            label: '완료 세션',
+          ),
+          const _Stat(
+            icon: Icons.send_rounded,
+            value: '18',
+            unit: '건',
+            label: '루틴 전송',
+          ),
         ],
       ),
     );
@@ -629,7 +655,7 @@ class _Stat extends StatelessWidget {
     required this.label,
   });
 
-  final String icon;
+  final IconData icon;
   final String value;
   final String unit;
   final String label;
@@ -639,14 +665,14 @@ class _Stat extends StatelessWidget {
     return Expanded(
       child: Column(
         children: <Widget>[
-          Text(icon, style: const TextStyle(fontSize: 15)),
-          const SizedBox(height: 2),
+          Icon(icon, size: 18, color: AppColors.primary),
+          const SizedBox(height: 4),
           Text(
             value,
             style: const TextStyle(
               fontSize: 20,
               fontWeight: FontWeight.w800,
-              color: AppColors.brandOrange,
+              color: AppColors.secondary,
             ),
           ),
           Text(
@@ -654,7 +680,7 @@ class _Stat extends StatelessWidget {
             style: const TextStyle(
               fontSize: 9,
               fontWeight: FontWeight.w700,
-              color: AppColors.warning,
+              color: AppColors.primary,
             ),
           ),
           Text(
@@ -689,6 +715,7 @@ class _GymCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColors.card,
         borderRadius: const BorderRadius.all(AppRadius.card),
+        boxShadow: kCardShadow,
         border: Border.all(
           color: editing
               ? AppColors.primary.withValues(alpha: 0.35)

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/elevation.dart';
 import 'package:oncare_trainer/design_system/tokens/layout.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
@@ -1105,6 +1106,7 @@ class _SessionCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColors.card,
         borderRadius: const BorderRadius.all(AppRadius.card),
+        boxShadow: kCardShadow,
         border: Border.all(
           color: sent
               ? AppColors.success.withValues(alpha: 0.4)

--- a/frontend/flutter_trainer/lib/shared/models/trainer_profile.dart
+++ b/frontend/flutter_trainer/lib/shared/models/trainer_profile.dart
@@ -63,6 +63,30 @@ class TrainerProfile {
 
   /// Gym the trainer belongs to.
   final TrainerGym gym;
+
+  /// Returns a copy with the given fields replaced. Used by 회원가입 to
+  /// reflect the submitted name/email on the (otherwise seed) demo profile.
+  TrainerProfile copyWith({
+    String? name,
+    String? email,
+    String? phone,
+    String? specialty,
+    String? career,
+    String? intro,
+    List<String>? certifications,
+    TrainerGym? gym,
+  }) {
+    return TrainerProfile(
+      name: name ?? this.name,
+      email: email ?? this.email,
+      phone: phone ?? this.phone,
+      specialty: specialty ?? this.specialty,
+      career: career ?? this.career,
+      intro: intro ?? this.intro,
+      certifications: certifications ?? this.certifications,
+      gym: gym ?? this.gym,
+    );
+  }
 }
 
 /// The single fixed trainer profile attached on a successful (mock)

--- a/frontend/flutter_trainer/lib/shared/widgets/brand_header.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/brand_header.dart
@@ -33,7 +33,11 @@ class BrandHeader extends StatelessWidget implements PreferredSizeWidget {
               shape: BoxShape.circle,
               color: AppColors.accentSurface,
             ),
-            child: const Text('🧑', style: TextStyle(fontSize: 13)),
+            child: const Icon(
+              Icons.person,
+              size: 16,
+              color: AppColors.primary,
+            ),
           ),
           const SizedBox(width: AppSpacing.sm),
           const Text.rich(
@@ -45,7 +49,7 @@ class BrandHeader extends StatelessWidget implements PreferredSizeWidget {
                 ),
                 TextSpan(
                   text: '트레이너',
-                  style: TextStyle(color: AppColors.brandOrange),
+                  style: TextStyle(color: AppColors.primary),
                 ),
               ],
               style: TextStyle(fontSize: 15, fontWeight: FontWeight.w800),

--- a/frontend/flutter_trainer/test/features/auth/session_controller_test.dart
+++ b/frontend/flutter_trainer/test/features/auth/session_controller_test.dart
@@ -100,6 +100,79 @@ void main() {
       expect(container.read(sessionTokenStoreProvider).readToken(), isNull);
     });
 
+    test(
+      'registered identity survives a restart (does not revert to seed)',
+      () async {
+        final container = await _makeContainer();
+        await container
+            .read(sessionControllerProvider.notifier)
+            .register(
+              email: 'hong@example.com',
+              password: 'pw',
+              name: '홍길동',
+            );
+
+        // Simulate a restart: a fresh container over the same prefs.
+        final prefs = await SharedPreferences.getInstance();
+        final restarted = ProviderContainer(
+          overrides: <Override>[
+            sharedPreferencesProvider.overrideWithValue(prefs),
+          ],
+        );
+        addTearDown(restarted.dispose);
+
+        final state = restarted.read(sessionControllerProvider);
+        expect(state.status, SessionStatus.authenticated);
+        // 재시작 후에도 가입 이름/이메일 유지(시드로 되돌아가지 않음).
+        expect(state.profile?.name, '홍길동');
+        expect(state.profile?.email, 'hong@example.com');
+      },
+    );
+
+    test('login session restores to the seed identity after a restart', () async {
+      final container = await _makeContainer();
+      await container
+          .read(sessionControllerProvider.notifier)
+          .login(email: 'trainer@oncare.com', password: 'pw');
+
+      final prefs = await SharedPreferences.getInstance();
+      final restarted = ProviderContainer(
+        overrides: <Override>[
+          sharedPreferencesProvider.overrideWithValue(prefs),
+        ],
+      );
+      addTearDown(restarted.dispose);
+
+      final state = restarted.read(sessionControllerProvider);
+      expect(state.status, SessionStatus.authenticated);
+      expect(state.profile?.name, '김트레이너');
+      expect(state.profile?.email, 'trainer@oncare.com');
+    });
+
+    test(
+      'signOut clears the registered identity (next launch is signed out)',
+      () async {
+        final container = await _makeContainer();
+        final controller = container.read(sessionControllerProvider.notifier);
+        await controller.register(
+          email: 'hong@example.com',
+          password: 'pw',
+          name: '홍길동',
+        );
+
+        await controller.signOut();
+
+        expect(
+          container.read(sessionTokenStoreProvider).readProfileName(),
+          isNull,
+        );
+        expect(
+          container.read(sessionTokenStoreProvider).readProfileEmail(),
+          isNull,
+        );
+      },
+    );
+
     test('signOut clears the token and returns to signedOut', () async {
       final container = await _makeContainer();
       final controller = container.read(sessionControllerProvider.notifier);

--- a/frontend/flutter_trainer/web/index.html
+++ b/frontend/flutter_trainer/web/index.html
@@ -23,13 +23,13 @@
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="온케어 트레이너">
+  <meta name="apple-mobile-web-app-title" content="On-Care 트레이너">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>온케어 트레이너</title>
+  <title>On-Care 트레이너</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/frontend/flutter_trainer/web/manifest.json
+++ b/frontend/flutter_trainer/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "온케어 트레이너",
-    "short_name": "온케어 트레이너",
+    "name": "On-Care 트레이너",
+    "short_name": "On-Care 트레이너",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#3EAFDF",


### PR DESCRIPTION
Closes #267
Closes #268
Closes #269
Closes #270
Closes #271
Closes #272
Closes #273

## Summary
트래킹 이슈 #267의 목표대로 트레이너 앱(`frontend/flutter_trainer`)의 시각 디자인을 사용자 앱(`frontend/flutter`) 기준으로 통일한다. 기능·데이터 흐름은 유지하고 룩앤필만 정합하며, 오너 지시에 따라 **두 앱 공통 규격(오렌지·카드 그림자·카드 반경)** 통일을 위해 사용자 앱도 소폭 함께 손봤다(원래 #267 out-of-scope였던 "사용자 앱 변경 없음"을 오너 결정으로 완화).

스택: #293(feature/292) ← #295(feature/294) ← 본 PR. base가 순차 병합 시 자동 재지정된다.

## Changes
- **토큰·공통(#268):** 타이포 가중치 사용자 앱 스케일 정합, 공통 카드 그림자 `kCardShadow` 신설, `brandOrange`→#FF953C, AI 통합 조언 배너색 토큰 추가, 헤더 아이콘(단색 상체 실루엣)·'트레이너' 색(#3EAFDF), 앱/웹 타이틀 'On-Care 트레이너'.
- **clients(#269):** 고객 카드·AI 요약·식단/운동 기록 카드에 `kCardShadow`, 신규 고객 시트 입력칸 둥근 네모화·'*필수' 제거·힌트 회색화.
- **schedule(#270):** 세션 카드 그림자 정합.
- **ai_routine(#271):** 카드 그림자, 'AI 추천 루틴 수정 가능'→'AI 추천 루틴', 색상 이모지(💡/📅)→단색 선 아이콘.
- **my(#272):** 프로필 이니셜 원형 아바타, '퍼스널 트레이너' 뱃지 초록, 자격증 아이콘 블루/하늘색, '이번 달 통계' 카드 블루 배너색+선 아이콘, 카드 그림자.
- **auth(#273):** 로그인 화면을 사용자 앱과 동일(배경 흰색·132px 로고·소셜 로그인·색/치수 정합), **회원가입 화면 신설**(폼·문구 사용자 앱과 동일, 부제목 'On-Care 계정을 만들어 회원 관리를 시작하세요') + 라우트/가드/`register()` 배선.
- **cross-app(#267):** 오렌지 #FF953C 통일·경고색 토큰화, 카드 반경 20 통일, 이질적 그림자(스트릭 오렌지·gym_tab 검정)→`kCardShadow`, 로그인 'On - care'→'On - Care'·회원가입 '온케어…'→'On-Care…'.

## Commits
지표 단위로 7개 커밋(#268 토큰/헤더/타이틀 → #269 clients → #270 schedule → #271 ai_routine → #272 my → #273 auth → #267 cross-app).

## Notes
- 두 앱 `flutter analyze` 무경고. 기능/상태/이벤트 무변경(로그인 소셜·회원가입은 요청에 따라 추가). 트레이너 IconData 종류·오렌지 아이덴티티(브랜드 오렌지 통일값) 유지.
- 사용자 앱·트레이너 앱 로컬 프리뷰(:5182 / :5184)로 로그인·회원가입·고객·MY·AI루틴 전 화면 육안 확인.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 트레이너 회원가입 화면과 회원가입 경로를 추가했습니다.
  - 카카오·구글 소셜 로그인 및 로그인 화면의 회원가입 진입을 지원합니다.

- **개선 사항**
  - 트레이너 앱 전반의 카드 그림자, 모서리, 글꼴 및 색상 스타일을 통일했습니다.
  - AI 루틴 화면의 자동 생성 표시와 일정 등록 버튼을 개선했습니다.
  - 프로필 통계와 카드 아이콘을 보다 일관된 시각 요소로 변경했습니다.

- **브랜딩**
  - 앱 이름과 로고 표기를 On-Care 기준으로 정리했습니다.
  - 경고 및 브랜드 색상을 새로운 디자인 기준에 맞게 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->