### PR TITLE
chore(backend): 코드리뷰 후속 nit 일괄 정리 (#277~#287)

### DIFF
--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -10,6 +10,8 @@
 from __future__ import annotations
 
 import json
+import re
+from datetime import date as _date
 from datetime import datetime
 from typing import Annotated
 
@@ -28,6 +30,20 @@ from app.schemas.trainer_api import (
 from app.services import trainer_service
 
 router = APIRouter(tags=["trainer"])
+
+# 계약 형식은 정확히 YYYY-MM-DD. date.fromisoformat 는 3.11+ 에서 basic ISO·주 날짜도 받으므로
+# 정규식으로 먼저 좁힌 뒤 달력 유효성을 확인한다(schedule 라우트와 동일 규약).
+_YMD_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _is_ymd(v: str) -> bool:
+    if not _YMD_RE.fullmatch(v):
+        return False
+    try:
+        _date.fromisoformat(v)
+        return True
+    except ValueError:
+        return False
 
 
 def _require_client(db: Session, trainer_id: str, member_id: str) -> TrainerClient:
@@ -101,6 +117,9 @@ def trainer_client_diet(
     """담당 고객의 식단(회원이 회원 앱에서 기록한 실제 데이터)."""
     _require_client(db, trainer.id, member_id)
     day = date or trainer_service.today_iso()
+    # 형식 검증 — 잘못된 date 가 조용히 빈 목록으로 나가지 않게 422(캘린더 라우트와 일관, #278).
+    if not _is_ymd(day):
+        raise HTTPException(status_code=422, detail="date 는 YYYY-MM-DD 형식이어야 합니다.")
     return trainer_service.build_client_diet(db, member_id, day)
 
 

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -275,7 +275,8 @@ class TrainerProfile(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     trainer_id: Mapped[str] = mapped_column(
-        ForeignKey("users.id", ondelete="CASCADE"), unique=True, index=True
+        # unique=True 가 이미 유니크 인덱스를 만들므로 index=True 는 잉여(중복 인덱스). 제거.
+        ForeignKey("users.id", ondelete="CASCADE"), unique=True
     )
     phone: Mapped[str] = mapped_column(String(20), default="")
     specialty: Mapped[str] = mapped_column(String(50), default="")     # 퍼스널 트레이너

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -86,6 +86,11 @@ class RoutineHistoryOut(BaseModel):
     trainer_note: str
 
 
+# 채팅 sender 출력 허용값 — 뷰어 관점(_sender_out): 트레이너 앱은 trainer|client,
+# 회원 앱은 me|trainer.
+ChatSender = Literal["trainer", "client", "me"]
+
+
 class ChatMessageOut(BaseModel):
     """채팅 메시지 — 프론트 ClientChatMessage 계약 정렬.
 
@@ -94,7 +99,7 @@ class ChatMessageOut(BaseModel):
     가장 오래된 메시지의 (created_at, id)를 before/before_id 로 넘겨 요청한다.
     """
     id: str
-    sender: str        # trainer|client
+    sender: ChatSender  # trainer|client(트레이너 뷰) | me|trainer(회원 뷰)
     body: str
     time_label: str    # "18:10"
     created_at: str    # ISO datetime — 커서/정렬용
@@ -106,6 +111,7 @@ class ChatSendRequest(BaseModel):
 
 
 RoutineType = Literal["유산소", "근력", "스트레칭"]
+RoutineSource = Literal["ai", "trainer"]  # ai 추천 | 트레이너 직접 배정
 
 
 class RoutineOut(BaseModel):
@@ -113,9 +119,9 @@ class RoutineOut(BaseModel):
     id: str
     name: str
     minutes: int
-    type: str          # 유산소|근력|스트레칭
+    type: RoutineType
     reason: str
-    source: str        # ai|trainer
+    source: RoutineSource
 
 
 class RoutineAssignRequest(BaseModel):
@@ -127,7 +133,7 @@ class RoutineAssignRequest(BaseModel):
     minutes: int = Field(default=0, ge=0, le=600)   # 0..600분(현실적 상한)
     type: RoutineType
     reason: str = Field(default="", max_length=200)
-    source: Literal["trainer", "ai"] = "trainer"
+    source: RoutineSource = "trainer"
 
 
 # ---- 스케줄 (트레이너 타임라인 + 예약→수업→기록 루프) ----

--- a/backend/app/services/places/kakao.py
+++ b/backend/app/services/places/kakao.py
@@ -140,7 +140,10 @@ async def search_nearby(
         result.append(p)
     result = result[:15]
 
-    if len(_cache) >= _CACHE_MAX:
-        _cache.clear()  # 단순 상한 — 무한 증식 방지
-    _cache[key] = (now + _CACHE_TTL_SECONDS, result)
+    # 빈 결과는 캐시하지 않는다 — 일시적 0건(쿼터/지연 등)이 TTL 동안 seed 폴백을 고정시키지
+    # 않도록. 실제 장소가 나온 경우만 캐시한다(리뷰 #282).
+    if result:
+        if len(_cache) >= _CACHE_MAX:
+            _cache.clear()  # 단순 상한 — 무한 증식 방지
+        _cache[key] = (now + _CACHE_TTL_SECONDS, result)
     return result

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -425,6 +425,12 @@ def assign_routine(
     name: str, minutes: int, type_: str, reason: str, source: str,
 ) -> RoutineOut:
     """회원에게 루틴 배정. 로스터 last_routine 은 build_roster 가 최신 루틴을 읽어 반영."""
+    # 이 회원 루틴들의 현재 최대 sort_order + 1 로 끝에 붙인다. timestamp 방식은 시드(0..n)와
+    # 의미가 섞이고, 같은 초에 배정된 둘은 순서가 비결정적이었다(리뷰 #279).
+    max_order = db.scalar(
+        select(func.max(TrainerRoutine.sort_order))
+        .where(TrainerRoutine.trainer_id == trainer_id, TrainerRoutine.member_id == member_id)
+    )
     rt = TrainerRoutine(
         id=f"rt-{uuid.uuid4().hex[:12]}",
         trainer_id=trainer_id,
@@ -434,8 +440,7 @@ def assign_routine(
         type=type_,
         reason=reason,
         source=source,
-        # 새 루틴을 목록 끝에 붙인다(기존 시드는 0..n).
-        sort_order=int(datetime.now(timezone.utc).timestamp()),
+        sort_order=(max_order or 0) + 1,
         created_at=datetime.now(timezone.utc),
     )
     db.add(rt)
@@ -493,11 +498,21 @@ def build_schedule(db: Session, trainer_id: str, day: str) -> list[ScheduleSessi
     return [_schedule_out(s) for s in rows]
 
 
+#: booked_dates 조회 하한(일). 주간 스트립 도트용이라 과거 전체가 필요없다 — 시간이 갈수록
+#: 결과가 무한정 커지는 것을 막는다(리뷰 #280). 문자열 날짜(YYYY-MM-DD)는 사전식 비교 가능.
+_BOOKED_DATES_WINDOW_DAYS = 90
+
+
 def booked_dates(db: Session, trainer_id: str) -> list[str]:
-    """예약이 있는(공백 아닌) 날짜 목록 — 주간 스트립 도트용."""
+    """예약이 있는(공백 아닌) 날짜 목록 — 주간 스트립 도트용(최근 90일 이후)."""
+    cutoff = (_today() - timedelta(days=_BOOKED_DATES_WINDOW_DAYS)).isoformat()
     rows = db.scalars(
         select(TrainerSchedule.date)
-        .where(TrainerSchedule.trainer_id == trainer_id, TrainerSchedule.status != "공백")
+        .where(
+            TrainerSchedule.trainer_id == trainer_id,
+            TrainerSchedule.status != "공백",
+            TrainerSchedule.date >= cutoff,
+        )
         .distinct()
     ).all()
     return sorted(rows)
@@ -644,28 +659,33 @@ def complete_session(
 
 # ---- 회원측 미러 (내 담당 코치 / 받은 루틴 / 채팅 / 내 세션) ----
 
+def _active_link(db: Session, member_id: str) -> TrainerClient | None:
+    """회원의 현재 담당(활성) 링크 — 가장 오래된 active 1건. 없으면 None.
+
+    '현재 담당 코치 1명' 판정의 단일 소스. get_member_trainer_id / build_member_coach 등이
+    각자 같은 쿼리를 중복하면 divergence 위험이 있어 여기로 모은다(리뷰 #281).
+    """
+    return db.scalar(
+        select(TrainerClient)
+        .where(TrainerClient.member_id == member_id, TrainerClient.active.is_(True))
+        .order_by(TrainerClient.created_at)
+        .limit(1)
+    )
+
+
 def get_member_trainer_id(db: Session, member_id: str) -> str | None:
     """회원의 현재 담당 트레이너 id. 활성(active) 링크만 인정하며 없으면 None.
 
     휴면(비활성) 링크는 '현재 담당'이 아니므로 제외한다(리뷰 재-#3) — 비활성 링크만
     가진 회원은 코치 조회/발신이 불가(404/빈 목록)해야 한다.
     """
-    return db.scalar(
-        select(TrainerClient.trainer_id)
-        .where(TrainerClient.member_id == member_id, TrainerClient.active.is_(True))
-        .order_by(TrainerClient.created_at)
-        .limit(1)
-    )
+    link = _active_link(db, member_id)
+    return link.trainer_id if link is not None else None
 
 
 def build_member_coach(db: Session, member_id: str) -> MemberCoachOut | None:
     """회원의 '내 담당 코치' 요약. 활성 담당이 없으면 None(라우터 404)."""
-    link = db.scalar(
-        select(TrainerClient)
-        .where(TrainerClient.member_id == member_id, TrainerClient.active.is_(True))
-        .order_by(TrainerClient.created_at)
-        .limit(1)
-    )
+    link = _active_link(db, member_id)
     if link is None:
         return None
     trainer = db.get(User, link.trainer_id)

--- a/backend/docs/DEPLOY.md
+++ b/backend/docs/DEPLOY.md
@@ -15,6 +15,10 @@ GitHub(main push) ──> Actions ──> ECR(이미지) ──> App Runner(:800
 가 여러 인스턴스를 동시에 띄워도 하나만 마이그레이션하고 나머지는 대기 후 no-op 이다(리뷰 #3).
 운영은 `AUTO_CREATE_TABLES=false` 로 두고 Alembic 을 스키마의 유일한 소스로 삼는다.
 
+> **무거운 마이그레이션 주의**: lock 획득 대기 한도는 `MIGRATE_LOCK_TIMEOUT`(기본 120초)다.
+> 대형 RDS 에서 120초를 넘길 수 있는 마이그레이션을 배포하기 전에는, 동시에 뜬 다른 인스턴스가
+> fail-fast·재시작 루프에 빠지지 않도록 이 값을 넉넉히(예: `MIGRATE_LOCK_TIMEOUT=600`) 올려 둔다.
+
 **배포 게이팅**: `.github/workflows/backend-deploy.yml` 은 **"Backend CI" 가 성공**했을 때만
 (workflow_run) 실행되며, 자동 배포는 **동일 저장소의 `main` push**에서 발생한 성공 run만
 허용한다. PR·fork 등 다른 이벤트의 CI 결과로는 배포할 수 없다. 따라서 테스트/마이그레이션

--- a/backend/migrations/versions/0014_drop_trainer_prof_ix.py
+++ b/backend/migrations/versions/0014_drop_trainer_prof_ix.py
@@ -1,0 +1,30 @@
+"""trainer_profiles: 중복 인덱스 ix_trainer_profiles_trainer_id 제거
+
+trainer_profiles.trainer_id 는 UniqueConstraint(uq_trainer_profiles_trainer)로 이미
+유니크 인덱스를 갖는다. 0012 에서 함께 만든 비유니크 ix_trainer_profiles_trainer_id 는
+잉여이므로 제거한다(리뷰 #277). 모델에서도 index=True 를 뺐다.
+
+Revision ID: 0014_drop_trainer_prof_ix
+Revises: 0013_trainer_active_coach_uq
+Create Date: 2026-07-29
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0014_drop_trainer_prof_ix"
+down_revision: str | Sequence[str] | None = "0013_trainer_active_coach_uq"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_index("ix_trainer_profiles_trainer_id", table_name="trainer_profiles")
+
+
+def downgrade() -> None:
+    op.create_index(
+        "ix_trainer_profiles_trainer_id", "trainer_profiles", ["trainer_id"]
+    )

--- a/backend/tests/test_places.py
+++ b/backend/tests/test_places.py
@@ -104,6 +104,33 @@ def test_kakao_single_category_failure_still_propagates(monkeypatch):
         kakao._cache.clear()
 
 
+def test_kakao_empty_result_not_cached(monkeypatch):
+    """일시적 0건은 캐시하지 않는다 — 다음 요청이 다시 실검색을 시도(seed 폴백 고정 방지, #282)."""
+    import asyncio
+
+    import httpx
+
+    from app.services.places import kakao
+
+    kakao._cache.clear()
+
+    async def fake_get(self, url, params=None, headers=None):
+        class _Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"documents": []}
+
+        return _Resp()
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+    out = asyncio.run(kakao.search_nearby(37.5, 127.0, "fitness", 1000, "key"))
+    assert out == []
+    assert len(kakao._cache) == 0  # 빈 결과는 캐시에 남지 않음
+    kakao._cache.clear()
+
+
 def test_kakao_docs_to_places_parsing():
     from app.services.places.kakao import docs_to_places
 

--- a/backend/tests/test_trainer.py
+++ b/backend/tests/test_trainer.py
@@ -11,7 +11,6 @@ from uuid import uuid4
 def test_user_role_defaults_to_member():
     from app.models.models import User
 
-    u = User(id="u1", email="a@b.com", name="a")
     # SQLAlchemy 컬럼 default 는 flush 시 적용되므로, 여기선 모델 기본 문자열만 확인.
     assert User.__table__.c.role.default.arg == "member"
 

--- a/backend/tests/test_trainer_service.py
+++ b/backend/tests/test_trainer_service.py
@@ -38,3 +38,24 @@ def test_latest_by_member_returns_one_row_per_member(client, db_session):
             ChatMessage.id.in_(ids)
         ).delete(synchronize_session=False)
         db_session.commit()
+
+
+def test_assign_routine_sort_order_is_monotonic(client, db_session):
+    """연속 배정한 두 루틴의 sort_order 가 max+1 로 단조 증가(같은 초에도 순서 결정론적, #279)."""
+    from app.db.seed_trainer import TRAINER_ID
+    from app.models.models import TrainerRoutine
+    from app.services import trainer_service
+
+    kw = dict(minutes=10, type_="근력", reason="테스트", source="trainer")
+    r1 = trainer_service.assign_routine(db_session, TRAINER_ID, "user-jisu", name="rt-a", **kw)
+    r2 = trainer_service.assign_routine(db_session, TRAINER_ID, "user-jisu", name="rt-b", **kw)
+    try:
+        o1 = db_session.get(TrainerRoutine, r1.id).sort_order
+        o2 = db_session.get(TrainerRoutine, r2.id).sort_order
+        assert o2 == o1 + 1  # 뒤에 배정한 것이 정확히 +1
+    finally:
+        for rid in (r1.id, r2.id):
+            row = db_session.get(TrainerRoutine, rid)
+            if row is not None:
+                db_session.delete(row)
+        db_session.commit()


### PR DESCRIPTION
## Summary

* 트레이너 백엔드 스택(#277~#287) 리뷰에서 나온 **비블로커 nit**들을 한 PR로 정리.
* 결정론적 정렬·중복 쿼리 제거·조회 상한·캐시/로그 위생·형식 검증·중복 인덱스 제거·출력 계약(Literal) 등 폴리시성 개선.
* 동작 변경은 최소(행위 보존 위주), 새 마이그레이션 `0014` 1건(무해한 중복 인덱스 drop).
* 로컬 Postgres 전체 pytest **195 passed**, `alembic upgrade head` 단일 head(`0014`) 확인.

---

## Changes

### 🔧 Improvements

* `assign_routine`: `sort_order = max(기존)+1` 로 결정론적 정렬(timestamp 방식 제거, #279).
* `_active_link` 헬퍼 신설 → `get_member_trainer_id`·`build_member_coach` 가 재사용(중복 "활성 담당" 쿼리 divergence 제거, #281).
* `booked_dates`: 최근 90일로 조회 범위 바운드(주간 스트립 쿼리 무한 증식 방지, #280).
* `kakao.search_nearby`: **빈 결과는 캐시하지 않음** — 일시적 0건이 TTL 동안 seed 폴백을 고정하는 문제 방지(#282).
* 출력 스키마 Literal화: `ChatMessageOut.sender`(trainer|client|me), `RoutineOut.type`/`source` → OpenAPI 계약이 입력 Literal과 일치(#279).

### 🐛 Fixes

* 트레이너 `/clients/{id}/diet?date=`: 잘못된 date 가 조용히 `[]` 로 나가지 않게 **YYYY-MM-DD 검증 → 422**(캘린더 라우트와 일관, #278).
* `trainer_profiles.trainer_id`: `unique=True` 가 이미 인덱스를 만들므로 **중복 `ix_trainer_profiles_trainer_id` 제거**(모델 `index=True` 제거 + 마이그레이션 `0014`, #277).

### 📝 Docs

* `DEPLOY.md`: 무거운 마이그레이션 대비 `MIGRATE_LOCK_TIMEOUT` 상향 안내(#286).

---

## Commits

1. `574896f` chore(backend): apply post-review nits (#277~#287)
2. `424cde5` chore(backend): drop duplicate trainer-profile index (0014) and type chat/routine outputs

---

## Notes

* 마이그레이션 `0014_drop_trainer_prof_ix`(down_revision `0013_trainer_active_coach_uq`) — 선형 단일 head 유지(CI single-head 통과). 기존 DB 에도 중복 인덱스를 drop.
* 추가 테스트: kakao 빈결과 미캐시, `assign_routine` sort_order 단조 증가.
* **의도적으로 남긴 항목**(nit 범위 밖 → 별도 처리 권장): schedule update `date` 필드(드래그 날짜이동 **기능**), 응답 shape 통일·complete note divergence(코스메틱), base 이미지 digest 핀, chat `before` 단독 커서(프론트가 항상 둘 다 전송).

---

## Test Plan

* [x] 관련 테스트 통과 (전체 pytest 195 passed)
* [x] `alembic upgrade head` 단일 head(0014) 확인
* [x] 빌드/AST 확인
* [ ] 코드 리뷰

---

## Related Issues

Closes #289

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인