### PR TITLE
feat(seed): 회원 운동·건강프로필 데모 실데이터 시드 (김민수)

### DIFF
--- a/backend/app/db/seed_member_data.py
+++ b/backend/app/db/seed_member_data.py
@@ -187,6 +187,12 @@ _EXERCISE_WEEK: dict[str, list[tuple[str, str, int, int]]] = {
     ],
 }
 
+# day_label → 요일 인덱스(월=0 … 일=6, date.weekday() 와 동일). 운동 시드는 이 인덱스로
+# "오늘까지의 요일"만 넣어, 주중 실행 시 미래 요일이 이번 주 합계·streak 에 잡히는 것을 막는다.
+_WEEKDAY_INDEX: dict[str, int] = {
+    "월": 0, "화": 1, "수": 2, "목": 3, "금": 4, "토": 5, "일": 6,
+}
+
 # 사용자 앱 데모 회원(김민수)의 건강 프로필 — 프론트 MockMyHealthRepository/프로필 목업과
 # 동일. 위험도·활동점수·기본정보 + 목표치는 구조화 컬럼(goal_*/daily_*)에 넣는다.
 # conditions 는 위험도 서술에서 추론(목업엔 명시 없음). 키(height_cm)·성별은 목업에 없어 비운다.
@@ -439,24 +445,30 @@ def _seed_history(db: Session, member_id: str) -> None:
 
 def _seed_exercise(db: Session, member_id: str) -> None:
     """회원 이번 주 운동 세션 시드(멱등, 날짜 인식) — 사용자 앱 운동 화면용.
-    이번 주 세션이 이미 있으면 스킵(주가 바뀌면 새 주로 시드되어 이력이 누적된다)."""
+
+    이번 주 세션 중 **오늘까지의 요일만** 넣는다. 주중에 실행돼도 미래 요일이 이번 주
+    합계·streak 에 잡히지 않도록(예: 수요일에 시드해도 목~일은 넣지 않음). 멱등은
+    세션 id 단위로 판정하므로, 주가 진행되며 재실행되면 새로 지난 요일이 채워지고
+    이미 있는 요일은 건너뛴다(중복·왜곡 없음). 주가 바뀌면 새 week_start 로 누적된다."""
     week = _EXERCISE_WEEK.get(member_id)
     if not week:
         return
     today = date.today()
     week_start = (today - timedelta(days=today.weekday())).isoformat()  # 이번 주 월요일
-    if db.scalar(
-        select(models.ExerciseSession.id)
-        .where(
-            models.ExerciseSession.user_id == member_id,
-            models.ExerciseSession.week_start == week_start,
-        )
-        .limit(1)
-    ) is not None:
-        return
+    added = False
     for day_label, ex_type, minutes, calories in week:
+        idx = _WEEKDAY_INDEX.get(day_label)
+        if idx is None or idx > today.weekday():
+            continue  # 미래(또는 알 수 없는) 요일은 아직 시드하지 않는다.
+        session_id = f"seed-ex-{member_id}-{week_start}-{day_label}"
+        if db.scalar(
+            select(models.ExerciseSession.id)
+            .where(models.ExerciseSession.id == session_id)
+            .limit(1)
+        ) is not None:
+            continue  # 멱등: 이미 있는 요일은 스킵.
         db.add(models.ExerciseSession(
-            id=f"seed-ex-{member_id}-{week_start}-{day_label}",
+            id=session_id,
             user_id=member_id,
             week_start=week_start,
             day_label=day_label,
@@ -465,7 +477,9 @@ def _seed_exercise(db: Session, member_id: str) -> None:
             calories=calories,
             intensity="moderate",
         ))
-    _safe_commit(db)
+        added = True
+    if added:
+        _safe_commit(db)
 
 
 def _seed_health_profile(db: Session, member_id: str) -> None:

--- a/backend/app/db/seed_member_data.py
+++ b/backend/app/db/seed_member_data.py
@@ -1,6 +1,11 @@
 """
 담당 회원의 건강 데이터 데모 시드 — 트레이너 로스터/식단/기록을 실데이터로 채운다.
 
+**데모/개발 전용 (실서비스 아님).** 이 시드는 `SEED_DEMO_DATA=true` 일 때만 실행된다
+(init_db 게이팅). 실서비스(prod)는 `SEED_DEMO_DATA=false` 로 두어 여기서 만드는 고정
+데모 계정(김민수 등)을 넣지 않고, **진짜 사용자가 앱에서 직접 만든 데이터만** 쌓이게
+한다. 즉 이 파일은 데모/발표·개발·CI 재현용 고정 데이터이지, 운영 사용자 데이터가 아니다.
+
 여기서 넣는 식단(DietEntry)·운동기록(RoutineHistory)은 "회원이 회원 앱에서 남긴
 실제 데이터"다. 트레이너 API 는 이 데이터를 그대로 읽어 로스터를 집계하므로,
 트레이너↔회원 데이터 공유가 시드 단계에서부터 실제로 성립한다.
@@ -167,6 +172,46 @@ _ROUTINES: dict[str, list[tuple[str, int, str, str]]] = {
     ],
 }
 
+# 사용자 앱 데모 회원(김민수)의 이번 주 운동 세션 — 프론트 MockExerciseRepository 와 동일.
+# (요일, 종류, 분, 칼로리). 수요일은 휴식 → 목~일 4일 연속. 주간 칼로리 헤드라인은
+# 백엔드가 세션 합(=2450)으로 계산한다(프론트 목업의 튜닝 헤드라인 1980 은 세션 합과
+# 무관한 표시값이라 재현 대상이 아니다 — 실서비스는 합계가 정답).
+_EXERCISE_WEEK: dict[str, list[tuple[str, str, int, int]]] = {
+    "user-demo": [
+        ("월", "cardio", 40, 300),
+        ("화", "strength", 60, 420),
+        ("목", "cardio", 65, 480),
+        ("금", "cardio", 55, 400),
+        ("토", "cardio", 45, 330),
+        ("일", "strength", 50, 520),
+    ],
+}
+
+# 사용자 앱 데모 회원(김민수)의 건강 프로필 — 프론트 MockMyHealthRepository/프로필 목업과
+# 동일. 위험도·활동점수·기본정보 + 목표치는 구조화 컬럼(goal_*/daily_*)에 넣는다.
+# conditions 는 위험도 서술에서 추론(목업엔 명시 없음). 키(height_cm)·성별은 목업에 없어 비운다.
+_HEALTH_PROFILE: dict[str, dict] = {
+    "user-demo": {
+        "risk_title": "고혈압·당뇨 위험 주의",
+        "risk_body": "최근 혈압과 혈당 추세가 다소 높습니다. 식단·운동 관리에 신경 써주세요.",
+        "risk_level": "medium",
+        "conditions": "고혈압, 당뇨 전단계",
+        "phone": "010-1234-5678",
+        "birth_date": "1990-01-15",
+        "weight_kg": 72.7,
+        "activity_points": 1240,
+        "activity_rank": 14,
+        # 목표치(프론트 프로필 목업과 동일)
+        "goal_weight_kg": 70,
+        "goal_bp_systolic": 120,
+        "goal_blood_sugar": 100,
+        "daily_calories": 2000,
+        "daily_sodium_mg": 2000,
+        "daily_sugar_g": 50,
+        "onboarded": True,
+    },
+}
+
 
 # 트레이너 오늘 타임라인 (time, client, member_id, type, duration, status, note, program).
 # member_id 는 유효 회원일 때만 연결(아니면 표시용 이름만). 프론트 TRAINER_SCHEDULE 정렬.
@@ -206,6 +251,8 @@ def seed_member_health_data() -> None:
             _seed_history(db, user_id)
             _seed_chat(db, user_id)
             _seed_routines(db, user_id)
+            _seed_exercise(db, user_id)
+            _seed_health_profile(db, user_id)
         _seed_schedule(db, valid)
     finally:
         db.close()
@@ -387,4 +434,51 @@ def _seed_history(db: Session, member_id: str) -> None:
             client_feedback=feedback,
             trainer_note=note,
         ))
+    _safe_commit(db)
+
+
+def _seed_exercise(db: Session, member_id: str) -> None:
+    """회원 이번 주 운동 세션 시드(멱등, 날짜 인식) — 사용자 앱 운동 화면용.
+    이번 주 세션이 이미 있으면 스킵(주가 바뀌면 새 주로 시드되어 이력이 누적된다)."""
+    week = _EXERCISE_WEEK.get(member_id)
+    if not week:
+        return
+    today = date.today()
+    week_start = (today - timedelta(days=today.weekday())).isoformat()  # 이번 주 월요일
+    if db.scalar(
+        select(models.ExerciseSession.id)
+        .where(
+            models.ExerciseSession.user_id == member_id,
+            models.ExerciseSession.week_start == week_start,
+        )
+        .limit(1)
+    ) is not None:
+        return
+    for day_label, ex_type, minutes, calories in week:
+        db.add(models.ExerciseSession(
+            id=f"seed-ex-{member_id}-{week_start}-{day_label}",
+            user_id=member_id,
+            week_start=week_start,
+            day_label=day_label,
+            type=ex_type,
+            minutes=minutes,
+            calories=calories,
+            intensity="moderate",
+        ))
+    _safe_commit(db)
+
+
+def _seed_health_profile(db: Session, member_id: str) -> None:
+    """회원 건강 프로필(위험도·활동점수·기본정보) 시드(멱등). 이미 있으면 스킵.
+    사용자 앱 홈/My Health 의 위험 카드·활동점수가 실데이터로 뜨게 한다."""
+    fields = _HEALTH_PROFILE.get(member_id)
+    if not fields:
+        return
+    if db.scalar(
+        select(models.HealthProfile.id)
+        .where(models.HealthProfile.user_id == member_id)
+        .limit(1)
+    ) is not None:
+        return
+    db.add(models.HealthProfile(user_id=member_id, **fields))
     _safe_commit(db)

--- a/backend/tests/test_member_seed.py
+++ b/backend/tests/test_member_seed.py
@@ -19,14 +19,21 @@ def _this_monday_iso() -> str:
 
 
 def test_exercise_seed_has_this_week_start(client, db_session):
-    """시드된 운동 세션의 week_start 는 이번 주 월요일이다."""
+    """시드가 이번 주(월요일 기준) 세션을 적재한다 — 하드코딩된 과거 주가 아니라.
+
+    조회를 이번 주로 스코프한다: `_seed_exercise` 는 주가 바뀌면 지난주 행을
+    지우지 않고 새 주 행을 덧붙이므로, 유저 전체를 조회하면 다음 주부터 지난주
+    행까지 섞여 들어와 단정이 깨진다.
+    """
     from app.models.models import ExerciseSession
 
     rows = db_session.scalars(
-        select(ExerciseSession).where(ExerciseSession.user_id == _MEMBER_ID)
+        select(ExerciseSession).where(
+            ExerciseSession.user_id == _MEMBER_ID,
+            ExerciseSession.week_start == _this_monday_iso(),
+        )
     ).all()
-    assert rows, "운동 시드가 없습니다."
-    assert all(r.week_start == _this_monday_iso() for r in rows)
+    assert rows, "이번 주 운동 시드가 없습니다."
 
 
 def test_exercise_seed_skips_future_weekdays(client, db_session):

--- a/backend/tests/test_member_seed.py
+++ b/backend/tests/test_member_seed.py
@@ -1,0 +1,97 @@
+"""회원 데모 시드(운동·건강프로필)의 주간 경계·멱등성 — 리뷰 반영(#311).
+
+DB 필요(로컬 skip, CI 의 Postgres 서비스에서 실행). client 픽스처가 init_db →
+seed_member_health_data 를 먼저 돌린 상태를 검증한다.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from sqlalchemy import func, select
+
+
+_MEMBER_ID = "user-demo"
+
+
+def _this_monday_iso() -> str:
+    today = date.today()
+    return (today - timedelta(days=today.weekday())).isoformat()
+
+
+def test_exercise_seed_has_this_week_start(client, db_session):
+    """시드된 운동 세션의 week_start 는 이번 주 월요일이다."""
+    from app.models.models import ExerciseSession
+
+    rows = db_session.scalars(
+        select(ExerciseSession).where(ExerciseSession.user_id == _MEMBER_ID)
+    ).all()
+    assert rows, "운동 시드가 없습니다."
+    assert all(r.week_start == _this_monday_iso() for r in rows)
+
+
+def test_exercise_seed_skips_future_weekdays(client, db_session):
+    """미래 요일은 이번 주 합계·streak 에 잡히지 않도록 시드하지 않는다(#311)."""
+    from app.db.seed_member_data import _WEEKDAY_INDEX
+    from app.models.models import ExerciseSession
+
+    today_idx = date.today().weekday()
+    labels = db_session.scalars(
+        select(ExerciseSession.day_label).where(
+            ExerciseSession.user_id == _MEMBER_ID,
+            ExerciseSession.week_start == _this_monday_iso(),
+        )
+    ).all()
+    assert labels, "이번 주 운동 시드가 없습니다."
+    # 시드된 모든 요일은 오늘(포함) 이전이어야 한다.
+    assert all(_WEEKDAY_INDEX[label] <= today_idx for label in labels)
+
+
+def test_exercise_seed_is_idempotent(client, db_session):
+    """재실행해도 세션 수가 늘지 않는다(세션 id 단위 멱등)."""
+    from app.db.seed_member_data import _seed_exercise
+    from app.models.models import ExerciseSession
+
+    def _count() -> int:
+        return db_session.scalar(
+            select(func.count())
+            .select_from(ExerciseSession)
+            .where(
+                ExerciseSession.user_id == _MEMBER_ID,
+                ExerciseSession.week_start == _this_monday_iso(),
+            )
+        )
+
+    before = _count()
+    assert before > 0
+    _seed_exercise(db_session, _MEMBER_ID)
+    _seed_exercise(db_session, _MEMBER_ID)
+    assert _count() == before
+
+
+def test_health_profile_seeded_once(client, db_session):
+    """건강 프로필은 시드되어 있고, 재실행해도 중복 생성되지 않는다(멱등)."""
+    from app.db.seed_member_data import _seed_health_profile
+    from app.models.models import HealthProfile
+
+    def _count() -> int:
+        return db_session.scalar(
+            select(func.count())
+            .select_from(HealthProfile)
+            .where(HealthProfile.user_id == _MEMBER_ID)
+        )
+
+    assert _count() == 1
+    _seed_health_profile(db_session, _MEMBER_ID)
+    assert _count() == 1
+
+
+def test_health_profile_goals_persisted(client, db_session):
+    """프로필이 없던 회원에 시드하면 위험도·활동 관련 필드가 저장된다."""
+    from app.models.models import HealthProfile
+
+    profile = db_session.scalar(
+        select(HealthProfile).where(HealthProfile.user_id == _MEMBER_ID)
+    )
+    assert profile is not None
+    assert profile.risk_level == "medium"
+    assert profile.risk_title


### PR DESCRIPTION
## Summary
데모 때 사용자 앱의 **운동 화면**과 **홈/My Health 활동점수**가 실백엔드(실로그인)에서도 프론트 목업과 동일한 실데이터로 렌더링되도록, 데모 회원(user-demo/김민수)의 데이터를 **백엔드 seed 스크립트**에 추가한다. 하드코딩 데모가 아니라 seed(버전관리·멱등·배포 자동적용).

Closes #310

## Changes
`backend/app/db/seed_member_data.py`:
- **`_seed_exercise`** — 이번 주 운동 6세션(월40/화60/목65/금55/토45/일50분, 유산소·근력) = 주간 315분·2450kcal·4일 연속. 프론트 `MockExerciseRepository` 동일. `week_start`=이번 주 월요일(동적).
- **`_seed_health_profile`** — 위험도(medium)·활동점수(1240/14위)·기본정보 + 목표치 구조화 컬럼(goal_weight 70·goal_bp 120·goal_bs 100·daily 2000/2000/50)·onboarded.
- 모두 **멱등**(주/프로필 존재 시 스킵), 회원 루프에서 **user-demo 에만** 적용.

## Commits
- `feat(seed): 회원 운동·건강프로필 데모 실데이터 시드 (김민수)`

## Notes
- **바이탈(체중·혈압·혈당)은 시드 대상에서 제외.** 앱 방향 변경으로 바이탈을 표시하던 화면(My Health 지표 카드·추세 모달·빠른입력)이 제거돼 **어느 화면에도 렌더링되지 않기 때문**. (바이탈 관련 dead code 정리는 별도 cleanup PR에서 진행 예정)
- **운동 주간 칼로리**는 세션 합(**2450**)으로 계산됨. 프론트 목업의 튜닝 헤드라인 1980 은 세션과 무관한 표시값이라 미재현(실서비스는 합계가 정답).
- **검증**: 일회용 로컬 test DB에서 마이그레이션+시드 후 운동 6세션·활동점수 1240 확인, 바이탈 0건 확인, **전체 205개 테스트 통과**(GEMINI 키 없이).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 회원 데이터에 이번 주 운동 세션이 추가로 시드됩니다(주간 기준으로 생성).
  * 회원별 건강 프로필이 자동으로 생성됩니다.
  * 이미 등록된 운동 세션/건강 프로필은 중복 생성되지 않으며, 이번 주 합계 계산에 미래 요일은 포함되지 않습니다.
* **테스트**
  * 회원 데모 시드의 주간 경계, 멱등 동작, 데이터 보존 및 저장 필드 반영 여부를 검증하는 DB 기반 테스트가 추가됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->