### PR TITLE
feat(my-health): My Health 화면 실백엔드 연결(활동점수·프로필·위험도)

### DIFF
--- a/frontend/flutter/lib/features/my_health/domain/entities/health_history.dart
+++ b/frontend/flutter/lib/features/my_health/domain/entities/health_history.dart
@@ -169,7 +169,10 @@ class MyHealthState {
   final RiskAlert risk;
   final List<IndicatorTrend> indicators;
   final int activityPoints;
-  final int activityRank;
+  // 백엔드 계약상 nullable(schemas/user.py: activity_rank: Optional[int]).
+  // 온보딩만 마친 일반 사용자는 순위가 아직 없어 null 로 온다 — 강제 언랩하면
+  // My Health 화면 전체가 파싱 오류가 되므로 null 을 그대로 수용한다(UI 는 배지 숨김).
+  final int? activityRank;
   final List<SettingsItem> settings;
 
   factory MyHealthState.fromJson(Map<String, Object?> json) => MyHealthState(
@@ -180,7 +183,7 @@ class MyHealthState {
         .map(IndicatorTrend.fromJson)
         .toList(),
     activityPoints: (json['activity_points']! as num).toInt(),
-    activityRank: (json['activity_rank']! as num).toInt(),
+    activityRank: (json['activity_rank'] as num?)?.toInt(),
     settings: (json['settings']! as List<Object?>)
         .cast<Map<String, Object?>>()
         .map(SettingsItem.fromJson)

--- a/frontend/flutter/lib/features/my_health/presentation/controllers/my_health_controller.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/controllers/my_health_controller.dart
@@ -1,13 +1,21 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/core/network/dio_client.dart';
+import 'package:oncare/features/my_health/data/repositories/dio_my_health_repository.dart';
 import 'package:oncare/features/my_health/data/repositories/mock_my_health_repository.dart';
 import 'package:oncare/features/my_health/domain/entities/health_history.dart';
 import 'package:oncare/features/my_health/domain/repositories/my_health_repository.dart';
 
-final myHealthRepositoryProvider = Provider<MyHealthRepository>(
-  (ref) => const MockMyHealthRepository(),
-  name: 'myHealthRepository',
-);
+final myHealthRepositoryProvider = Provider<MyHealthRepository>((ref) {
+  // 실모드(USE_MOCK_API=false)에서는 백엔드 /users/me/health 로 실제 프로필·활동점수·
+  // 위험도를 읽는다(health_profile 있으면 실데이터, 없으면 백엔드가 데모 기본값 반환).
+  // 데모/로컬 모드에서만 인메모리 mock 을 사용한다. diet/exercise 와 동일한 분기.
+  if (ref.watch(appConfigProvider).useMockApi) {
+    return const MockMyHealthRepository();
+  }
+  return DioMyHealthRepository(ref.watch(dioProvider));
+}, name: 'myHealthRepository');
 
 final myHealthStateProvider = FutureProvider<MyHealthState>((ref) {
   return ref.watch(myHealthRepositoryProvider).fetchState();

--- a/frontend/flutter/test/features/my_health/my_health_activity_rank_test.dart
+++ b/frontend/flutter/test/features/my_health/my_health_activity_rank_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/core/logging/app_logger.dart';
+import 'package:oncare/features/my_health/data/repositories/dio_my_health_repository.dart';
+import 'package:oncare/features/my_health/data/repositories/mock_my_health_repository.dart';
+import 'package:oncare/features/my_health/domain/entities/health_history.dart';
+import 'package:oncare/features/my_health/presentation/controllers/my_health_controller.dart';
+
+/// 최소 유효 페이로드(indicators·settings 는 빈 배열). activity_rank 만 파라미터화.
+Map<String, Object?> _payload({required Object? activityRank}) => <String, Object?>{
+  'profile': <String, Object?>{'name': '김민수', 'email': 'minsu@oncare.com'},
+  'risk': <String, Object?>{'title': '주의', 'body': '관리 필요', 'level': 'medium'},
+  'indicators': <Object?>[],
+  'activity_points': 1240,
+  'activity_rank': activityRank,
+  'settings': <Object?>[],
+};
+
+void main() {
+  group('MyHealthState.fromJson activity_rank nullable (리뷰 #313)', () {
+    test('activity_rank: null 이어도 파싱 오류 없이 null 로 수용된다', () {
+      // 온보딩만 마친 일반 사용자는 백엔드가 activity_rank: null 을 반환한다.
+      final state = MyHealthState.fromJson(_payload(activityRank: null));
+      expect(state.activityRank, isNull);
+      expect(state.activityPoints, 1240);
+      expect(state.profile.name, '김민수');
+    });
+
+    test('activity_rank 값이 있으면 그대로 파싱된다', () {
+      final state = MyHealthState.fromJson(_payload(activityRank: 14));
+      expect(state.activityRank, 14);
+    });
+  });
+
+  group('myHealthRepositoryProvider 모드 분기', () {
+    ProviderContainer makeContainer({required bool useMockApi}) {
+      final container = ProviderContainer(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(
+            AppConfig(
+              environment: Environment.dev,
+              apiBaseUrl: 'https://dev.api.test/v1',
+              useMockApi: useMockApi,
+            ),
+          ),
+          // Dio 저장소 경로는 dioProvider → appLogger 를 타므로 조용한 로거로 오버라이드.
+          appLoggerProvider.overrideWithValue(Logger(level: Level.off)),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    test('USE_MOCK_API=false 면 Dio 저장소를 쓴다', () {
+      final container = makeContainer(useMockApi: false);
+      expect(
+        container.read(myHealthRepositoryProvider),
+        isA<DioMyHealthRepository>(),
+      );
+    });
+
+    test('USE_MOCK_API=true 면 Mock 저장소를 쓴다', () {
+      final container = makeContainer(useMockApi: true);
+      expect(
+        container.read(myHealthRepositoryProvider),
+        isA<MockMyHealthRepository>(),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
My Health 화면이 실백엔드 모드에서도 mock 을 읽던 gap 을 해결한다. `myHealthRepositoryProvider` 가 `MockMyHealthRepository` 를 하드코딩해 실로그인해도 항상 가짜 데이터(김민수/활동점수 1240 고정)를 보여줬다. diet/exercise 와 동일하게 `useMockApi` 로 분기하도록 맞춘다.

Closes #312

## Changes
`my_health_controller.dart`:
- `myHealthRepositoryProvider` 를 `useMockApi` 분기로 변경 — 실모드는 **`DioMyHealthRepository`(GET `/users/me/health`)**, 데모/로컬 모드는 기존 `MockMyHealthRepository`.
- 백엔드는 health_profile 이 있으면 실제 활동점수·위험도를, 없으면 데모 기본값을 반환(`users.py`).

## Commits
- `feat(my-health): My Health 화면 실백엔드 연결(활동점수·프로필·위험도)`

## Notes
- **검증**: TestClient 로 `/v1/users/me/health` 호출 → 시드된 회원의 **활동점수 1240 · rank 14 · 위험도(medium)** 실반환 확인. `flutter analyze`(my_health) 무이슈.
- 실서비스 전환 감사의 **최우선 gap(#1)** 해소. 남은 항목: 소셜 로그인 실 SDK, 신규 유저 빈 상태 UI, 헬스장(gym) 실백엔드 부재는 별도.
- `API_BASE_URL` 에는 `/v1` 접두어 포함 필요(백엔드 라우트가 `/v1` 마운트, DEPLOY.md 문서화됨).