### PR TITLE
fix(backend): Alembic migration head 충돌 해결

### DIFF
--- a/backend/migrations/versions/0015_merge_consultation_and_trainer_heads.py
+++ b/backend/migrations/versions/0015_merge_consultation_and_trainer_heads.py
@@ -1,6 +1,6 @@
 """Merge consultation request and trainer index migration heads.
 
-Revision ID: 0015_merge_consultation_and_trainer_heads
+Revision ID: 0015_merge_alembic_heads
 Revises: 0014_consultation_requests, 0014_drop_trainer_prof_ix
 Create Date: 2026-07-30
 """
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-revision: str = "0015_merge_consultation_and_trainer_heads"
+revision: str = "0015_merge_alembic_heads"
 down_revision: str | Sequence[str] | None = (
     "0014_consultation_requests",
     "0014_drop_trainer_prof_ix",

--- a/backend/migrations/versions/0015_merge_consultation_and_trainer_heads.py
+++ b/backend/migrations/versions/0015_merge_consultation_and_trainer_heads.py
@@ -1,0 +1,27 @@
+"""Merge consultation request and trainer index migration heads.
+
+Revision ID: 0015_merge_consultation_and_trainer_heads
+Revises: 0014_consultation_requests, 0014_drop_trainer_prof_ix
+Create Date: 2026-07-30
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+revision: str = "0015_merge_consultation_and_trainer_heads"
+down_revision: str | Sequence[str] | None = (
+    "0014_consultation_requests",
+    "0014_drop_trainer_prof_ix",
+)
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Merge both migration branches without changing the database schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Restore the two parent heads without changing the database schema."""
+    pass


### PR DESCRIPTION
## Summary

* `0014_consultation_requests`와 `0014_drop_trainer_prof_ix`가 동일한
  `0013_trainer_active_coach_uq`에서 분기되어 Alembic head가 2개가 된
  문제를 해결했습니다.
* 기존 두 migration을 수정하거나 삭제하지 않고, 두 revision을 부모로
  갖는 빈 merge migration을 추가했습니다.
* 애플리케이션 동작과 DB schema는 변경하지 않고 migration graph의
  최신 head만 하나로 연결했습니다.

---

## Changes

### ✨ Features

* 해당 없음

### 🔧 Improvements

* `0015_merge_alembic_heads` merge revision 추가
* `0014_consultation_requests`, `0014_drop_trainer_prof_ix`를
  `down_revision` tuple로 연결
* Alembic 기본 `version_num VARCHAR(32)`에 맞도록 revision ID를 32자
  이내로 지정

### 🎨 UI/UX

* 해당 없음

### 📝 Docs

* merge migration의 목적과 부모 revision을 docstring에 명시

### 🐛 Fixes

* `alembic heads`가 2개를 반환해 Backend CI의 단일 head 검사가
  실패하던 문제 수정

---

## Commits

1. `d153944` fix(backend): merge alembic migration heads
2. `d67c41e` fix(backend): keep alembic revision within version limit

---

## Notes

* 원인:

  ```text
  0013_trainer_active_coach_uq
  ├── 0014_consultation_requests
  └── 0014_drop_trainer_prof_ix
  ```

* `0014_consultation_requests`는 PR #300에서 추가되어 main에 merge됐습니다.
* `0014_drop_trainer_prof_ix`는 PR #309에서 추가되어 main에 merge됐습니다.
* 두 migration은 각각 상담 요청 테이블 생성과 트레이너 프로필 중복
  인덱스 제거를 담당하며 변경 대상이 겹치지 않습니다.
* 열린 PR #305와 #306의 전체 변경 파일을 확인했으며 Alembic migration
  또는 ORM model 변경은 없습니다.
* main의 migration/model 관련 merge 이력은 #98, #100, #101, #107,
  #115, #121, #153, #154, #162, #207, #209, #210, #231, #277, #285,
  #300, #309이며 모두 merged 상태입니다. #98~#121은 backend rework
  스택 내부 PR이고 최종적으로 #154를 통해 main에 반영됐습니다.
* 첫 CI run에서 긴 revision ID가 Alembic 기본 `VARCHAR(32)` 제한을
  초과하는 문제가 확인되어 `0015_merge_alembic_heads`로 수정했습니다.

---

## Screenshots (Optional)

* UI 변경 없음

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 변경 없음 확인
* [x] migration compile 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. `cd backend && alembic heads`에서
   `0015_merge_alembic_heads (head)` 하나만 출력되는지 확인합니다.
2. `alembic history`와 `alembic branches`에서 두 `0014`가 merge
   revision으로 연결되는지 확인합니다.
3. 빈 PostgreSQL/pgvector DB에서 `alembic upgrade head`를 실행합니다.
4. `pytest`를 실행합니다.

검증 결과:

* `alembic heads`, `alembic history`, `alembic branches`: 통과
* 전체 PostgreSQL offline upgrade SQL 생성: 통과
* 각 `0014` 단독 상태에서 head까지 offline upgrade SQL 생성: 통과
* Python 3.11 migration `compileall`: 통과
* 로컬 `pytest`: 66 passed, 177 skipped
* PostgreSQL/pgvector 실DB upgrade 및 전체 pytest: GitHub Actions 통과
  * [push run 30522706636](https://github.com/CSE-Sudo-26/sudo-capstone-project/actions/runs/30522706636)
  * [pull_request run 30522709446](https://github.com/CSE-Sudo-26/sudo-capstone-project/actions/runs/30522709446)

---

## Related Issues

Closes #323

* [기존 실패 Backend CI run 30519962484](https://github.com/CSE-Sudo-26/sudo-capstone-project/actions/runs/30519962484)

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
