### PR TITLE
feat(notifications): 알림 화면 실 백엔드 연결(목 제거·읽음 영속화)

### DIFF
--- a/frontend/flutter/lib/features/notification/data/repositories/dio_notification_repository.dart
+++ b/frontend/flutter/lib/features/notification/data/repositories/dio_notification_repository.dart
@@ -16,6 +16,16 @@ class DioNotificationRepository implements NotificationRepository {
     return rows.cast<Map<String, Object?>>().map(_fromJson).toList();
   }
 
+  @override
+  Future<void> markRead(String id) async {
+    await _dio.post<Object?>('/notifications/$id/read');
+  }
+
+  @override
+  Future<void> markAllRead() async {
+    await _dio.post<Object?>('/notifications/read-all');
+  }
+
   static AlertItem _fromJson(Map<String, Object?> json) {
     return AlertItem(
       id: json['id']! as String,

--- a/frontend/flutter/lib/features/notification/data/repositories/mock_notification_repository.dart
+++ b/frontend/flutter/lib/features/notification/data/repositories/mock_notification_repository.dart
@@ -1,43 +1,54 @@
 import 'package:oncare/features/notification/domain/entities/alert_item.dart';
 import 'package:oncare/features/notification/domain/repositories/notification_repository.dart';
 
+/// 데모(둘러보기)·로컬 목 모드에서 노출되는 고정 알림.
+///
+/// 실서비스(실로그인) 화면은 `/notifications` 백엔드를 읽지만, 데모 둘러보기는
+/// 기존과 동일하게 보이도록 이 하드코딩 목록을 유지한다. 컨트롤러가 목 모드에서
+/// 이 목록을 즉시 시드로 사용한다.
+const List<AlertItem> demoAlerts = <AlertItem>[
+  AlertItem(
+    id: 'a1',
+    title: '나트륨 섭취 주의',
+    body: '점심 짬뽕으로 오늘 나트륨이 3,421mg까지 올랐어요. 물을 충분히 드세요.',
+    timeAgo: '10분 전',
+    category: AlertCategory.reminder,
+  ),
+  AlertItem(
+    id: 'a2',
+    title: 'PT 수업 완료',
+    body: '오늘 18:00 김트레이너와 12회차 PT를 마쳤어요!',
+    timeAgo: '1시간 전',
+    category: AlertCategory.achievement,
+  ),
+  AlertItem(
+    id: 'a3',
+    title: '트레이너 피드백 도착',
+    body: '마무리로 어깨 회전근개 스트레칭을 꼭 해주세요.',
+    timeAgo: '2시간 전',
+    category: AlertCategory.reminder,
+  ),
+  AlertItem(
+    id: 'a4',
+    title: '서비스 점검 안내',
+    body: '내일 02:00~03:00 점검 예정입니다.',
+    timeAgo: '어제',
+    category: AlertCategory.system,
+    read: true,
+  ),
+];
+
+/// 데모/로컬 모드용 [NotificationRepository]. 목록은 [demoAlerts] 고정이고,
+/// 읽음 변이는 세션 메모리(컨트롤러 state)에서만 처리하므로 no-op 이다.
 class MockNotificationRepository implements NotificationRepository {
   const MockNotificationRepository();
 
   @override
-  Future<List<AlertItem>> fetchAll() async {
-    await Future<void>.delayed(const Duration(milliseconds: 80));
-    return const <AlertItem>[
-      AlertItem(
-        id: 'a1',
-        title: '식단 입력 알림',
-        body: '오늘 점심 입력이 비어있어요.',
-        timeAgo: '10분 전',
-        category: AlertCategory.reminder,
-      ),
-      AlertItem(
-        id: 'a2',
-        title: '운동 목표 달성',
-        body: '주간 운동 240분 달성!',
-        timeAgo: '1시간 전',
-        category: AlertCategory.achievement,
-      ),
-      AlertItem(
-        id: 'a3',
-        title: '체중 측정 권장',
-        body: '오늘 체중을 기록해 보세요.',
-        timeAgo: '3시간 전',
-        category: AlertCategory.healthCheck,
-        read: true,
-      ),
-      AlertItem(
-        id: 'a4',
-        title: '서비스 점검 안내',
-        body: '내일 02:00~03:00 점검 예정입니다.',
-        timeAgo: '어제',
-        category: AlertCategory.system,
-        read: true,
-      ),
-    ];
-  }
+  Future<List<AlertItem>> fetchAll() async => demoAlerts;
+
+  @override
+  Future<void> markRead(String id) async {}
+
+  @override
+  Future<void> markAllRead() async {}
 }

--- a/frontend/flutter/lib/features/notification/domain/repositories/notification_repository.dart
+++ b/frontend/flutter/lib/features/notification/domain/repositories/notification_repository.dart
@@ -3,4 +3,10 @@ import 'package:oncare/features/notification/domain/entities/alert_item.dart';
 abstract class NotificationRepository {
   /// All notifications, newest first.
   Future<List<AlertItem>> fetchAll();
+
+  /// Persist a single notification as read.
+  Future<void> markRead(String id);
+
+  /// Persist all of the user's notifications as read.
+  Future<void> markAllRead();
 }

--- a/frontend/flutter/lib/features/notification/presentation/controllers/notification_controller.dart
+++ b/frontend/flutter/lib/features/notification/presentation/controllers/notification_controller.dart
@@ -12,13 +12,19 @@ class NotificationController extends StateNotifier<NotificationState> {
   /// 데모 둘러보기 화면이 기존과 동일하게 보이도록 유지한다. 실모드는 seed=null
   /// 로 생성해 백엔드(`/notifications`)에서 최신 알림을 불러온다.
   NotificationController(this._repo, {List<AlertItem>? seed})
-    : super(NotificationState(items: seed ?? const <AlertItem>[])) {
+    : _allowSimulatePush = seed != null,
+      super(NotificationState(items: seed ?? const <AlertItem>[])) {
     if (seed == null) {
       _load();
     }
   }
 
   final NotificationRepository _repo;
+
+  /// 가상 푸시 주입은 목/데모 모드에서만 허용한다(seed 가 주어진 경우).
+  /// 실모드는 서버가 진실원본이라, 로컬 팬텀을 넣으면 다음 [refresh] 에서
+  /// 사라져 상태가 어긋난다.
+  final bool _allowSimulatePush;
 
   Future<void> _load() async {
     try {
@@ -59,9 +65,10 @@ class NotificationController extends StateNotifier<NotificationState> {
   }
 
   /// Q9: in-app panel + simulated push. Inserts a new unread item
-  /// at the top, as if a real FCM notification had landed. 실모드에서도
-  /// 로컬로만 주입한다(서버 미전송, 개발/데모용).
+  /// at the top, as if a real FCM notification had landed. 목/데모 모드
+  /// 전용(개발용) — 실모드에서는 서버에 없는 팬텀을 만들지 않도록 무시한다.
   void simulatePush() {
+    if (!_allowSimulatePush) return;
     final id = 'sim-${DateTime.now().millisecondsSinceEpoch}';
     final injected = AlertItem(
       id: id,

--- a/frontend/flutter/lib/features/notification/presentation/controllers/notification_controller.dart
+++ b/frontend/flutter/lib/features/notification/presentation/controllers/notification_controller.dart
@@ -1,65 +1,66 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/core/network/dio_client.dart';
 import 'package:oncare/features/notification/data/repositories/dio_notification_repository.dart';
+import 'package:oncare/features/notification/data/repositories/mock_notification_repository.dart';
 import 'package:oncare/features/notification/domain/entities/alert_item.dart';
 import 'package:oncare/features/notification/domain/repositories/notification_repository.dart';
 
 class NotificationController extends StateNotifier<NotificationState> {
-  NotificationController() : super(_seed());
-
-  static NotificationState _seed() {
-    return const NotificationState(
-      items: <AlertItem>[
-        AlertItem(
-          id: 'a1',
-          title: '나트륨 섭취 주의',
-          body: '점심 짬뽕으로 오늘 나트륨이 3,421mg까지 올랐어요. 물을 충분히 드세요.',
-          timeAgo: '10분 전',
-          category: AlertCategory.reminder,
-        ),
-        AlertItem(
-          id: 'a2',
-          title: 'PT 수업 완료',
-          body: '오늘 18:00 김트레이너와 12회차 PT를 마쳤어요!',
-          timeAgo: '1시간 전',
-          category: AlertCategory.achievement,
-        ),
-        AlertItem(
-          id: 'a3',
-          title: '트레이너 피드백 도착',
-          body: '마무리로 어깨 회전근개 스트레칭을 꼭 해주세요.',
-          timeAgo: '2시간 전',
-          category: AlertCategory.reminder,
-        ),
-        AlertItem(
-          id: 'a4',
-          title: '서비스 점검 안내',
-          body: '내일 02:00~03:00 점검 예정입니다.',
-          timeAgo: '어제',
-          category: AlertCategory.system,
-          read: true,
-        ),
-      ],
-    );
+  /// [seed] 가 주어지면(데모/목 모드) 즉시 노출하고 네트워크 로드를 건너뛴다 —
+  /// 데모 둘러보기 화면이 기존과 동일하게 보이도록 유지한다. 실모드는 seed=null
+  /// 로 생성해 백엔드(`/notifications`)에서 최신 알림을 불러온다.
+  NotificationController(this._repo, {List<AlertItem>? seed})
+    : super(NotificationState(items: seed ?? const <AlertItem>[])) {
+    if (seed == null) {
+      _load();
+    }
   }
 
-  void markRead(String id) {
+  final NotificationRepository _repo;
+
+  Future<void> _load() async {
+    try {
+      final items = await _repo.fetchAll();
+      if (mounted) {
+        state = NotificationState(items: items);
+      }
+    } catch (_) {
+      // 알림 로드 실패는 화면 접근을 막지 않는다(빈 목록 유지).
+    }
+  }
+
+  /// 실모드에서 서버 알림을 다시 불러온다.
+  Future<void> refresh() => _load();
+
+  Future<void> markRead(String id) async {
     state = NotificationState(
       items: state.items
           .map((AlertItem i) => i.id == id ? i.copyWith(read: true) : i)
           .toList(),
     );
+    try {
+      await _repo.markRead(id);
+    } catch (_) {
+      // 낙관적 업데이트 유지 — 영속화 실패는 다음 로드에서 정정된다.
+    }
   }
 
-  void markAllRead() {
+  Future<void> markAllRead() async {
     state = NotificationState(
       items: state.items.map((AlertItem i) => i.copyWith(read: true)).toList(),
     );
+    try {
+      await _repo.markAllRead();
+    } catch (_) {
+      // 낙관적 업데이트 유지.
+    }
   }
 
   /// Q9: in-app panel + simulated push. Inserts a new unread item
-  /// at the top, as if a real FCM notification had landed.
+  /// at the top, as if a real FCM notification had landed. 실모드에서도
+  /// 로컬로만 주입한다(서버 미전송, 개발/데모용).
   void simulatePush() {
     final id = 'sim-${DateTime.now().millisecondsSinceEpoch}';
     final injected = AlertItem(
@@ -73,24 +74,24 @@ class NotificationController extends StateNotifier<NotificationState> {
   }
 }
 
+/// 데모/로컬 모드는 목, 실모드는 백엔드(`/notifications`) 리포.
+final notificationRepositoryProvider = Provider<NotificationRepository>((ref) {
+  if (ref.watch(appConfigProvider).useMockApi) {
+    return const MockNotificationRepository();
+  }
+  return DioNotificationRepository(ref.watch(dioProvider));
+}, name: 'notificationRepository');
+
+/// 알림 목록 + 세션 변이(읽음/전체읽음/가상푸시)를 담는 컨트롤러.
+/// 목 모드는 [demoAlerts] 를 즉시 시드로 사용하고, 실모드는 백엔드에서 로드한다.
 final notificationControllerProvider =
-    StateNotifierProvider<NotificationController, NotificationState>(
-      (ref) => NotificationController(),
-      name: 'notifications',
-    );
+    StateNotifierProvider<NotificationController, NotificationState>((ref) {
+      final useMock = ref.watch(appConfigProvider).useMockApi;
+      final repo = ref.watch(notificationRepositoryProvider);
+      return NotificationController(repo, seed: useMock ? demoAlerts : null);
+    }, name: 'notifications');
 
-/// Network-side notification source. Production code talks to dio →
-/// LocalApiInterceptor (drift) → FastAPI. Tests override this with a
-/// `MockNotificationRepository`.
-final notificationRepositoryProvider = Provider<NotificationRepository>(
-  (ref) => DioNotificationRepository(ref.watch(dioProvider)),
-  name: 'notificationRepository',
-);
-
-/// FutureProvider variant of the notifications list, sourced from the
-/// repo. The legacy [notificationControllerProvider] still holds the
-/// in-session mutations (markRead / simulatePush) — wholesale unifying
-/// is intentionally deferred to keep the UI/test surface stable.
+/// 안읽음 배지 등 가벼운 소비처용 목록(리포 직접). 컨트롤러와 별개로 유지한다.
 final notificationListProvider = FutureProvider.autoDispose<List<AlertItem>>(
   (ref) => ref.watch(notificationRepositoryProvider).fetchAll(),
   name: 'notificationList',

--- a/frontend/flutter/lib/features/notification/presentation/pages/notification_page.dart
+++ b/frontend/flutter/lib/features/notification/presentation/pages/notification_page.dart
@@ -55,7 +55,9 @@ class NotificationPage extends ConsumerWidget {
                 );
               },
             ),
-      floatingActionButton: !config.isProd
+      // 가상 푸시는 목/데모 모드 전용 개발 도구 — 실모드에서는 버튼을 숨긴다
+      // (서버에 없는 팬텀 알림 방지, 죽은 버튼 방지).
+      floatingActionButton: config.useMockApi
           ? FloatingActionButton.extended(
               icon: const Icon(Icons.notification_add_outlined),
               label: const Text('Simulate push'),

--- a/frontend/flutter/test/features/notification/notification_controller_test.dart
+++ b/frontend/flutter/test/features/notification/notification_controller_test.dart
@@ -1,11 +1,54 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/features/notification/domain/entities/alert_item.dart';
+import 'package:oncare/features/notification/domain/repositories/notification_repository.dart';
 import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
+
+// 목 모드 설정 — 컨트롤러가 데모 시드(demoAlerts)를 즉시 사용하고
+// 네트워크 없이 세션 변이만 검증한다.
+const AppConfig _mockConfig = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: true,
+);
+
+// 실모드 설정 — 컨트롤러가 리포에서 로드하고 읽음을 리포로 영속화한다.
+const AppConfig _realConfig = AppConfig(
+  environment: Environment.prod,
+  apiBaseUrl: 'https://api.test/v1',
+  useMockApi: false,
+);
+
+ProviderContainer _container() {
+  final container = ProviderContainer(
+    overrides: <Override>[appConfigProvider.overrideWithValue(_mockConfig)],
+  );
+  return container;
+}
+
+/// 실모드 검증용 리포 — fetchAll 결과를 돌려주고 읽음 호출을 기록한다.
+class _RecordingRepo implements NotificationRepository {
+  _RecordingRepo(this._items);
+
+  final List<AlertItem> _items;
+  final List<String> markReadCalls = <String>[];
+  int markAllReadCalls = 0;
+
+  @override
+  Future<List<AlertItem>> fetchAll() async => _items;
+
+  @override
+  Future<void> markRead(String id) async => markReadCalls.add(id);
+
+  @override
+  Future<void> markAllRead() async => markAllReadCalls++;
+}
 
 void main() {
   test('seed state has unread items', () {
-    final container = ProviderContainer();
+    final container = _container();
     addTearDown(container.dispose);
     final state = container.read(notificationControllerProvider);
     expect(state.items, isNotEmpty);
@@ -13,7 +56,7 @@ void main() {
   });
 
   test('markRead toggles a single item', () {
-    final container = ProviderContainer();
+    final container = _container();
     addTearDown(container.dispose);
     final notifier = container.read(notificationControllerProvider.notifier);
     final firstId = container
@@ -32,14 +75,14 @@ void main() {
   });
 
   test('markAllRead drops unread count to zero', () {
-    final container = ProviderContainer();
+    final container = _container();
     addTearDown(container.dispose);
     container.read(notificationControllerProvider.notifier).markAllRead();
     expect(container.read(notificationControllerProvider).unreadCount, 0);
   });
 
   test('simulatePush prepends an unread item', () {
-    final container = ProviderContainer();
+    final container = _container();
     addTearDown(container.dispose);
     final before = container.read(notificationControllerProvider);
     container.read(notificationControllerProvider.notifier).simulatePush();
@@ -47,5 +90,50 @@ void main() {
     expect(after.items.length, before.items.length + 1);
     expect(after.items.first.read, isFalse);
     expect(after.items.first.id.startsWith('sim-'), isTrue);
+  });
+
+  test('real mode loads from repo and persists read/all-read', () async {
+    final repo = _RecordingRepo(const <AlertItem>[
+      AlertItem(
+        id: 'n1',
+        title: '알림1',
+        body: 'b1',
+        timeAgo: '방금',
+        category: AlertCategory.reminder,
+      ),
+      AlertItem(
+        id: 'n2',
+        title: '알림2',
+        body: 'b2',
+        timeAgo: '1시간 전',
+        category: AlertCategory.achievement,
+      ),
+    ]);
+    final container = ProviderContainer(
+      overrides: <Override>[
+        appConfigProvider.overrideWithValue(_realConfig),
+        notificationRepositoryProvider.overrideWithValue(repo),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final notifier = container.read(notificationControllerProvider.notifier);
+    await notifier.refresh(); // deterministically await the backend load
+    expect(container.read(notificationControllerProvider).items.length, 2);
+
+    await notifier.markRead('n1');
+    expect(repo.markReadCalls, <String>['n1']);
+    expect(
+      container
+          .read(notificationControllerProvider)
+          .items
+          .firstWhere((AlertItem i) => i.id == 'n1')
+          .read,
+      isTrue,
+    );
+
+    await notifier.markAllRead();
+    expect(repo.markAllReadCalls, 1);
+    expect(container.read(notificationControllerProvider).unreadCount, 0);
   });
 }

--- a/frontend/flutter/test/features/notification/notification_controller_test.dart
+++ b/frontend/flutter/test/features/notification/notification_controller_test.dart
@@ -136,4 +136,34 @@ void main() {
     expect(repo.markAllReadCalls, 1);
     expect(container.read(notificationControllerProvider).unreadCount, 0);
   });
+
+  test('real mode ignores simulatePush (no phantom notification)', () async {
+    final repo = _RecordingRepo(const <AlertItem>[
+      AlertItem(
+        id: 'n1',
+        title: '알림1',
+        body: 'b1',
+        timeAgo: '방금',
+        category: AlertCategory.reminder,
+      ),
+    ]);
+    final container = ProviderContainer(
+      overrides: <Override>[
+        appConfigProvider.overrideWithValue(_realConfig),
+        notificationRepositoryProvider.overrideWithValue(repo),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final notifier = container.read(notificationControllerProvider.notifier);
+    await notifier.refresh();
+    final before = container.read(notificationControllerProvider).items.length;
+
+    notifier.simulatePush();
+
+    // 실모드는 서버가 진실원본 — 로컬 팬텀을 주입하지 않는다.
+    final after = container.read(notificationControllerProvider).items;
+    expect(after.length, before);
+    expect(after.any((AlertItem i) => i.id.startsWith('sim-')), isFalse);
+  });
 }


### PR DESCRIPTION
## Summary
알림 화면이 실백엔드가 이미 있음에도 인메모리 하드코딩 목만 읽던 gap을 해결한다. 페이지·패널이 이제 실모드에서 `/notifications`의 실데이터를 읽고, 읽음/전체읽음을 백엔드에 영속화한다. **데모 둘러보기(목 모드) 화면은 기존과 동일하게 유지**한다.

## Changes
- `notificationControllerProvider`를 리포 기반으로 전환.
  - 실모드(`USE_MOCK_API=false`): `GET /notifications`로 로드, 읽음/전체읽음을 `POST /notifications/{id}/read`·`POST /notifications/read-all`로 **낙관적 영속화**(실패 시 다음 로드에서 정정).
  - 데모/목 모드: 기존 하드코딩 시드(`demoAlerts`)를 즉시 노출 → 둘러보기 화면 플래시·변화 없음.
- `NotificationRepository`에 `markRead`/`markAllRead` 추가 — `DioNotificationRepository`는 실호출, `MockNotificationRepository`는 no-op.
- 데모 시드를 `mock_notification_repository.dart`로 이관(컨트롤러가 즉시 시드로 사용).
- `notificationRepositoryProvider`를 `useMockApi` 분기(다른 feature와 동일 관행).

## Verification
- `flutter analyze lib/features/notification test/features/notification` → No issues.
- `flutter test test/features/notification` → 8 passed. 목 모드 시드/변이 + **실모드 로드·읽음 영속화**(가짜 리포로 호출 검증) 케이스 추가.
- 백엔드 계약(`backend/app/api/v1/notifications.py`)의 경로와 일치.

## Notes
- 알림 **삭제** UI는 현재 없어 이번 범위에서 제외(백엔드 `DELETE /notifications/{id}`는 존재). 삭제 affordance 추가 시 후속.
- 헤더 벨 배지(`OncareHeader.hasUnreadNotifications`)는 현재 앱에서 인스턴스화되지 않은 미사용 컴포넌트라 별개.

Closes #325


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 알림을 개별 또는 전체 읽음 처리할 수 있습니다.
  - 알림 상태가 먼저 화면에 반영되며, 서버와 동기화됩니다.
  - 알림 목록을 새로고침해 최신 상태를 불러올 수 있습니다.

- **개선 사항**
  - 실제 환경에서는 서버 알림을 불러오고, 데모 환경에서는 예시 알림을 제공합니다.
  - 알림 불러오기나 읽음 처리에 실패해도 화면 이용이 중단되지 않습니다.
  - 읽지 않은 알림 수가 읽음 처리 결과에 맞게 즉시 업데이트됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->