### PR TITLE
feat(vitals): My Health 빠른 기록 진입점 추가(체중·혈압·혈당 → 바이탈 API)

### DIFF
--- a/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
@@ -10,6 +10,7 @@ import 'package:oncare/features/my_health/presentation/controllers/my_health_con
 import 'package:oncare/features/my_health/presentation/widgets/my_flows.dart';
 import 'package:oncare/features/notification/presentation/widgets/notification_panel.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/modals/quick_input_dialog.dart';
 import 'package:oncare/shared/widgets/modals/right_slide_panel.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
 
@@ -33,6 +34,19 @@ class MyHealthPage extends ConsumerWidget {
         showNotifSheet(context);
       case _MySetting.support:
         showSupportSheet(context);
+    }
+  }
+
+  /// 체중/혈압/혈당 빠른 기록 다이얼로그를 열고, 저장되면 백엔드 건강 지표를
+  /// 다시 불러온다(활동점수·위험도·지표 갱신). 데모/목 모드는 로컬 저장만 된다.
+  Future<void> _record(
+    BuildContext context,
+    WidgetRef ref,
+    QuickInputKind kind,
+  ) async {
+    final bool saved = await showQuickInputDialog(context, kind: kind);
+    if (saved) {
+      ref.invalidate(myHealthStateProvider);
     }
   }
 
@@ -71,6 +85,14 @@ class MyHealthPage extends ConsumerWidget {
                   child: _PointsBanner(
                     points: health.valueOrNull?.activityPoints,
                     rank: health.valueOrNull?.activityRank,
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: _QuickRecordCard(
+                    onRecord: (QuickInputKind kind) =>
+                        _record(context, ref, kind),
                   ),
                 ),
                 const SizedBox(height: 20),
@@ -367,6 +389,113 @@ class _PointRule extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// "빠른 기록" 카드 — 체중/혈압/혈당을 바로 기록하는 진입점.
+/// 각 타일은 [showQuickInputDialog] 를 열고, 저장되면 상위에서 건강 지표를
+/// 새로고침한다. (바이탈 입력 다이얼로그는 기존에 진입점이 없어 고아 상태였다.)
+class _QuickRecordCard extends StatelessWidget {
+  const _QuickRecordCard({required this.onRecord});
+  final ValueChanged<QuickInputKind> onRecord;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        const Text(
+          '빠른 기록',
+          style: TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.w700,
+            color: FigmaColors.ink,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(color: FigmaColors.hairline),
+            boxShadow: kCardShadow,
+          ),
+          child: Row(
+            children: <Widget>[
+              Expanded(
+                child: _QuickRecordTile(
+                  icon: Icons.monitor_weight_outlined,
+                  label: '체중',
+                  onTap: () => onRecord(QuickInputKind.weight),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _QuickRecordTile(
+                  icon: Icons.favorite_outline,
+                  label: '혈압',
+                  onTap: () => onRecord(QuickInputKind.bloodPressure),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _QuickRecordTile(
+                  icon: Icons.water_drop_outlined,
+                  label: '혈당',
+                  onTap: () => onRecord(QuickInputKind.bloodSugar),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _QuickRecordTile extends StatelessWidget {
+  const _QuickRecordTile({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(14),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 10),
+        child: Column(
+          children: <Widget>[
+            Container(
+              width: 40,
+              height: 40,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: FigmaColors.softBlue,
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Icon(icon, size: 20, color: FigmaColors.primary),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              label,
+              style: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: FigmaColors.ink,
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/frontend/flutter/lib/shared/widgets/modals/quick_input_dialog.dart
+++ b/frontend/flutter/lib/shared/widgets/modals/quick_input_dialog.dart
@@ -15,15 +15,20 @@ enum QuickInputKind { weight, bloodPressure, bloodSugar }
 /// 입력" modal. Submitting now persists through [VitalsRepository] so
 /// the value survives the drift round-trip; the `latestVitalProvider`
 /// family is invalidated on success so MyHealth/Dashboard can refetch.
-Future<void> showQuickInputDialog(
+///
+/// Resolves to `true` when a value was saved (the caller can then refresh
+/// its own aggregates, e.g. `myHealthStateProvider`), and `false` when the
+/// dialog was cancelled/dismissed.
+Future<bool> showQuickInputDialog(
   BuildContext context, {
   required QuickInputKind kind,
-}) {
-  return showDialog<void>(
+}) async {
+  final bool? saved = await showDialog<bool>(
     context: context,
     barrierColor: Colors.black54,
     builder: (BuildContext ctx) => _QuickInputDialog(kind: kind),
   );
+  return saved ?? false;
 }
 
 class _QuickInputDialog extends ConsumerStatefulWidget {
@@ -87,7 +92,7 @@ class _QuickInputDialogState extends ConsumerState<_QuickInputDialog> {
       // Refresh listeners (MyHealth IndicatorTile / Dashboard tiles).
       ref.invalidate(latestVitalProvider(submission.kind));
       if (!mounted) return;
-      Navigator.of(context).pop();
+      Navigator.of(context).pop(true);
     } catch (e) {
       setState(() {
         _saving = false;

--- a/frontend/flutter/test/features/vitals/quick_input_dialog_test.dart
+++ b/frontend/flutter/test/features/vitals/quick_input_dialog_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/vitals/data/repositories/mock_vitals_repository.dart';
+import 'package:oncare/features/vitals/presentation/controllers/vitals_controller.dart';
+import 'package:oncare/shared/widgets/modals/quick_input_dialog.dart';
+
+// showQuickInputDialog 의 반환 계약 — 저장 성공 시 true(호출부가 지표를
+// 새로고침할 수 있도록), 취소/닫기 시 false.
+void main() {
+  // 다이얼로그를 열고, 반환값을 [results] 에 담는 버튼을 펌프한다.
+  Future<List<bool>> pumpOpen(
+    WidgetTester tester, {
+    required QuickInputKind kind,
+  }) async {
+    final List<bool> results = <bool>[];
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          vitalsRepositoryProvider.overrideWithValue(MockVitalsRepository()),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) => Center(
+                child: ElevatedButton(
+                  onPressed: () async {
+                    results.add(await showQuickInputDialog(context, kind: kind));
+                  },
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    return results;
+  }
+
+  testWidgets('저장 성공 시 true 를 반환하고 다이얼로그가 닫힌다', (
+    WidgetTester tester,
+  ) async {
+    final List<bool> results = await pumpOpen(
+      tester,
+      kind: QuickInputKind.weight,
+    );
+    expect(find.text('체중 입력'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField).first, '72.5');
+    await tester.tap(find.text('저장하기'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('체중 입력'), findsNothing);
+    expect(results, <bool>[true]);
+  });
+
+  testWidgets('잘못된 값은 저장되지 않고 다이얼로그가 유지된다', (
+    WidgetTester tester,
+  ) async {
+    final List<bool> results = await pumpOpen(
+      tester,
+      kind: QuickInputKind.weight,
+    );
+    await tester.tap(find.text('저장하기')); // 빈 입력
+    await tester.pumpAndSettle();
+
+    expect(find.text('값을 확인해 주세요.'), findsOneWidget);
+    expect(find.text('체중 입력'), findsOneWidget); // 그대로 열려 있음
+    expect(results, isEmpty); // 아직 닫히지 않음
+  });
+}


### PR DESCRIPTION
> ⚠️ This PR is **stacked on #313** (`feat/my-health-live-data`).
> Please review/merge #313 first — this branch will be retargeted to `main` after #313 lands.

## Summary
바이탈(체중·혈압·혈당) 입력 다이얼로그(`showQuickInputDialog`)는 완성돼 있었지만 **앱 어디에도 여는 진입점이 없어** 실사용자가 바이탈을 기록할 수 없었다(고아 상태). My Health 화면에 "빠른 기록" 카드를 추가해 이를 연결하고, 저장 시 건강 지표를 새로고침한다.

## Changes
- `my_health_page.dart`: 포인트 배너 아래에 **"빠른 기록" 카드**(체중/혈압/혈당 3개 타일) 추가. 타일 탭 → `showQuickInputDialog(kind)`.
- 저장 성공 시 `myHealthStateProvider` 무효화 → 활동점수·지표 재조회.
- `quick_input_dialog.dart`: `showQuickInputDialog`가 **저장 성공 여부(`bool`)를 반환**하도록 변경(저장=true, 취소/닫기=false). 호출부가 새로고침 여부를 판단.
- 저장 자체는 기존대로 `vitalsRepository`(실모드 `POST /vitals/{kind}` 백엔드, 데모/목은 LocalApiInterceptor)로 영속화.

## Verification
- `flutter analyze` (변경 파일) → No issues.
- `flutter test test/features/vitals test/features/my_health` → 15 passed. 다이얼로그 반환 계약(저장=true·다이얼로그 닫힘, 잘못된 값=유지) 위젯 테스트 추가.
- 데모(목) 모드: 인터셉터가 `/vitals` 3종을 지원해 저장이 정상 동작(둘러보기 비차단).

## Notes
- 건강 지표(체중/혈압/혈당 추이) 자체의 화면 노출은 별개(현재 Figma MY 페이지에 미표시) — 이번 PR은 **입력 진입점**에 한정.
- 관련: #312/#313(My Health 실데이터). 바이탈 입력이 생겨야 실지표가 채워진다.

Closes #326
