### PR TITLE
fix(ci): 백엔드 배포 workflow 조건부 비활성화

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -1,7 +1,9 @@
 name: Backend Deploy (ECR + App Runner)
 
-# main의 Backend CI를 통과한 정확한 커밋 이미지만 ECR과 App Runner에 배포한다.
-# 필요한 GitHub Secrets:
+# 배포 job은 기본적으로 비활성화된다. 배포 플랫폼과 인프라가 준비된 뒤
+# Repository Variable BACKEND_DEPLOY_ENABLED=true를 설정하면 활성화된다.
+# 현재 구현은 AWS ECR + App Runner 전용이며 최종 플랫폼 결정 후 바뀔 수 있다.
+# AWS 사용 시 필요한 GitHub Secrets:
 #   AWS_DEPLOY_ROLE_ARN   OIDC로 assume할 IAM 역할 ARN
 #   APPRUNNER_SERVICE_ARN 배포 대상 App Runner 서비스 ARN
 on:
@@ -34,13 +36,14 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     if: >-
-      ${{ (github.event_name == 'workflow_run' &&
-           github.event.workflow_run.conclusion == 'success' &&
-           github.event.workflow_run.event == 'push' &&
-           github.event.workflow_run.head_branch == 'main' &&
-           github.event.workflow_run.head_repository.full_name == github.repository) ||
-          (github.event_name == 'workflow_dispatch' &&
-           github.ref == 'refs/heads/main') }}
+      ${{ vars.BACKEND_DEPLOY_ENABLED == 'true' &&
+          ((github.event_name == 'workflow_run' &&
+            github.event.workflow_run.conclusion == 'success' &&
+            github.event.workflow_run.event == 'push' &&
+            github.event.workflow_run.head_branch == 'main' &&
+            github.event.workflow_run.head_repository.full_name == github.repository) ||
+           (github.event_name == 'workflow_dispatch' &&
+            github.ref == 'refs/heads/main')) }}
     steps:
       - name: Resolve and verify deploy commit
         id: target


### PR DESCRIPTION
## Summary

백엔드 배포 플랫폼과 인프라가 아직 준비되지 않은 상태에서 `Backend Deploy (ECR + App Runner)` workflow가 자동 실행되어 AWS OIDC 인증 단계에서 실패하던 문제를 해결했습니다.

Repository Variable `BACKEND_DEPLOY_ENABLED`가 정확히 문자열 `true`일 때만 배포 job이 실행되도록 조건을 추가했습니다.

## Root cause

`main`의 Backend CI 성공으로 AWS 배포 workflow가 자동 실행됐지만, 현재는 AWS IAM Role, ECR, App Runner가 준비되지 않았고 `AWS_DEPLOY_ROLE_ARN`도 설정되지 않아 다음 오류가 발생했습니다.

```text
Credentials could not be loaded, please check your action inputs:
Could not load credentials from any providers
```

실패 run: https://github.com/CSE-Sudo-26/sudo-capstone-project/actions/runs/30535171401

## Changes

- `build-and-deploy` job에 `vars.BACKEND_DEPLOY_ENABLED == 'true'` 조건 추가
- 변수가 없거나 `false`이면 전체 배포 job을 `skipped` 처리
- 기존 `workflow_run` 및 `workflow_dispatch` 보안·브랜치·CI 성공 조건 유지
- AWS 인증, ECR build/push, App Runner 업데이트 구현은 삭제하거나 우회하지 않고 보존
- 배포 플랫폼 결정 전까지 기본 비활성 상태임을 상단 주석에 명시

## Behavior

| 설정 및 이벤트 | 결과 |
| --- | --- |
| 변수 미등록 | 배포 job skipped |
| `BACKEND_DEPLOY_ENABLED=false` | 배포 job skipped |
| `BACKEND_DEPLOY_ENABLED=true` + 동일 저장소 main push Backend CI 성공 | 기존 배포 job 실행 |
| `BACKEND_DEPLOY_ENABLED=true` + PR CI | 배포 job skipped |
| `BACKEND_DEPLOY_ENABLED=true` + main 이외 브랜치 | 배포 job skipped |
| `BACKEND_DEPLOY_ENABLED=true` + main 이외 브랜치 수동 실행 | 배포 job skipped |

## Open PR check

현재 열린 미병합 PR 6개의 변경 파일을 확인했습니다. 배포 관련 PR #308은 Railway 이식성 파일과 `backend/docs/DEPLOY.md`를 수정하지만 `.github/workflows/backend-deploy.yml`, Backend CI, `BACKEND_DEPLOY_ENABLED`는 변경하지 않아 직접 충돌하거나 중복되지 않습니다.

## Notes

현재 workflow 구현은 AWS ECR + App Runner 기준이지만 최종 배포 플랫폼은 결정되지 않았습니다.

- AWS로 결정되면 필요한 IAM/ECR/App Runner 인프라와 Secret을 준비한 뒤 `BACKEND_DEPLOY_ENABLED=true`로 설정합니다.
- Railway로 결정되면 배포 workflow를 Railway용으로 교체한 뒤 같은 중립적 활성화 변수를 재사용할 수 있습니다.

Closes #335 

## Verification

- [x] PyYAML로 workflow YAML 문법 파싱
- [x] 활성화 변수와 기존 이벤트 조건을 조합한 6가지 조건 진리표 확인
- [x] `git diff --check` 통과
- [x] 변경 파일이 `.github/workflows/backend-deploy.yml` 한 개인지 확인
- [x] Backend CI workflow 파일과 trigger 조건이 변경되지 않았는지 확인
- [ ] `actionlint` 실행 — 로컬에 설치되어 있지 않아 미실행
- [ ] GitHub Actions에서 실제 `build-and-deploy: skipped` 확인 — 이 조건이 default branch에 반영된 이후의 run에서 확인 가능

## Scope

- 애플리케이션 코드 변경 없음
- Backend CI 변경 없음
- AWS 인증 오류 무시 또는 우회 없음
- 가짜 Secret 추가 없음
- AWS/Railway 플랫폼 신규 결정 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * 백엔드 배포 워크플로우의 활성화 조건과 지원 대상 환경에 대한 안내를 명확히 했습니다.
  * 배포 작업이 기본적으로 비활성화되며, 설정을 통해서만 활성화된다는 점을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->