### PR TITLE
feat(member): 헬스장 탭 트레이너 상태별 액션 버튼 UI 개선

### DIFF
--- a/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
@@ -8,7 +8,6 @@ import 'package:oncare/features/exercise/domain/entities/consultation_request.da
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/presentation/controllers/consultation_request_controller.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
-import 'package:oncare/features/exercise/presentation/widgets/exercise_flows.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 
 class GymTab extends ConsumerWidget {
@@ -411,54 +410,6 @@ class _MyGymTrainerCard extends StatelessWidget {
             trainer: trainer,
             selectedSlot: selectedSlot,
             onSlot: onSlot,
-          ),
-          const SizedBox(height: 14),
-          Row(
-            children: <Widget>[
-              Expanded(
-                child: OutlinedButton(
-                  onPressed: () => showGymInfoSheet(context, gym),
-                  style: OutlinedButton.styleFrom(
-                    foregroundColor: FigmaColors.primary,
-                    backgroundColor: FigmaColors.softBlue,
-                    side: BorderSide(color: FigmaColors.primaryA(0.18)),
-                    minimumSize: const Size(0, 44),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                  ),
-                  child: Text(
-                    l.exGymInfo,
-                    style: const TextStyle(
-                      fontSize: 12,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                ),
-              ),
-              const SizedBox(width: 8),
-              Expanded(
-                child: FilledButton(
-                  onPressed: () => showGymChatSheet(context, gym: gym),
-                  style: FilledButton.styleFrom(
-                    backgroundColor: FigmaColors.primary,
-                    minimumSize: const Size(0, 44),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                  ),
-                  child: Text(
-                    l.exConsultButton,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                      fontSize: 12,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                ),
-              ),
-            ],
           ),
         ],
       ),

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
@@ -33,6 +33,22 @@ class GymTab extends ConsumerWidget {
     final ConsultationRequest? recentRequest = requests.isEmpty
         ? null
         : requests.first;
+    final ConsultationRequest? pendingRequest =
+        recentRequest?.status == ConsultationStatus.pending
+        ? recentRequest
+        : null;
+    final GlobalKey recentConsultationKey = GlobalKey();
+
+    void showRecentConsultation() {
+      final BuildContext? targetContext = recentConsultationKey.currentContext;
+      if (targetContext == null) return;
+      Scrollable.ensureVisible(
+        targetContext,
+        duration: const Duration(milliseconds: 250),
+        curve: Curves.easeOut,
+        alignment: 0.1,
+      );
+    }
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 20),
@@ -47,10 +63,16 @@ class GymTab extends ConsumerWidget {
             onSlot: onSlot,
             onFind: onFind,
             onRetry: () => ref.invalidate(myGymProvider),
+            onPendingConsultationTap: pendingRequest == null
+                ? null
+                : showRecentConsultation,
           ),
           if (recentRequest != null) ...<Widget>[
             const SizedBox(height: 28),
-            _RecentConsultationSection(request: recentRequest),
+            _RecentConsultationSection(
+              key: recentConsultationKey,
+              request: recentRequest,
+            ),
           ],
           const SizedBox(height: 28),
           _RecommendedGymSection(
@@ -71,7 +93,7 @@ class GymTab extends ConsumerWidget {
 }
 
 class _RecentConsultationSection extends StatelessWidget {
-  const _RecentConsultationSection({required this.request});
+  const _RecentConsultationSection({required this.request, super.key});
 
   final ConsultationRequest request;
 
@@ -202,6 +224,7 @@ class _MyGymTrainerSection extends StatelessWidget {
     required this.onSlot,
     required this.onFind,
     required this.onRetry,
+    required this.onPendingConsultationTap,
   });
 
   final AsyncValue<Gym?> gymAsync;
@@ -209,6 +232,7 @@ class _MyGymTrainerSection extends StatelessWidget {
   final ValueChanged<String> onSlot;
   final VoidCallback onFind;
   final VoidCallback onRetry;
+  final VoidCallback? onPendingConsultationTap;
 
   @override
   Widget build(BuildContext context) {
@@ -225,6 +249,7 @@ class _MyGymTrainerSection extends StatelessWidget {
               onTrainerTap: gym.trainerName?.isNotEmpty ?? false
                   ? () => context.push(AppRoutes.trainerDetailPath(gym.id))
                   : null,
+              onPendingConsultationTap: onPendingConsultationTap,
             ),
     );
   }
@@ -237,6 +262,7 @@ class _MyGymTrainerCard extends StatelessWidget {
     required this.onSlot,
     required this.onGymTap,
     required this.onTrainerTap,
+    required this.onPendingConsultationTap,
   });
 
   final Gym gym;
@@ -244,6 +270,7 @@ class _MyGymTrainerCard extends StatelessWidget {
   final ValueChanged<String> onSlot;
   final VoidCallback onGymTap;
   final VoidCallback? onTrainerTap;
+  final VoidCallback? onPendingConsultationTap;
 
   @override
   Widget build(BuildContext context) {
@@ -411,6 +438,29 @@ class _MyGymTrainerCard extends StatelessWidget {
             selectedSlot: selectedSlot,
             onSlot: onSlot,
           ),
+          if (onPendingConsultationTap != null) ...<Widget>[
+            const SizedBox(height: 14),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: onPendingConsultationTap,
+                style: FilledButton.styleFrom(
+                  backgroundColor: FigmaColors.primary,
+                  minimumSize: const Size(0, 44),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                child: Text(
+                  l.exViewConsultationRequest,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ),
+          ],
         ],
       ),
     );

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -2372,6 +2372,12 @@ abstract class AppLocalizations {
   /// **'Consultation Request Pending'**
   String get exConsultPendingCta;
 
+  /// No description provided for @exViewConsultationRequest.
+  ///
+  /// In en, this message translates to:
+  /// **'View consultation request'**
+  String get exViewConsultationRequest;
+
   /// No description provided for @exConsultTarget.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -1240,6 +1240,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get exConsultPendingCta => 'Consultation Request Pending';
 
   @override
+  String get exViewConsultationRequest => 'View consultation request';
+
+  @override
   String get exConsultTarget => 'Consultation Target';
 
   @override

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -1222,6 +1222,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get exConsultPendingCta => '상담 요청 대기 중';
 
   @override
+  String get exViewConsultationRequest => '상담 요청 확인';
+
+  @override
   String get exConsultTarget => '상담 대상';
 
   @override

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -634,6 +634,7 @@
   "exGymConsultRequest": "Request a Gym Consultation",
   "exTrainerConsultRequest": "Request a Trainer Consultation",
   "exConsultPendingCta": "Consultation Request Pending",
+  "exViewConsultationRequest": "View consultation request",
   "exConsultTarget": "Consultation Target",
   "exGymConsultType": "Gym Consultation",
   "exTrainerConsultType": "Trainer Consultation",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -386,6 +386,7 @@
   "exGymConsultRequest": "헬스장 상담 요청하기",
   "exTrainerConsultRequest": "트레이너 상담 요청하기",
   "exConsultPendingCta": "상담 요청 대기 중",
+  "exViewConsultationRequest": "상담 요청 확인",
   "exConsultTarget": "상담 대상",
   "exGymConsultType": "헬스장 상담",
   "exTrainerConsultType": "트레이너 상담",

--- a/frontend/flutter/test/features/exercise/gym_tab_action_test.dart
+++ b/frontend/flutter/test/features/exercise/gym_tab_action_test.dart
@@ -116,10 +116,11 @@ void main() {
     expect(find.text(l.exViewConsultationRequest), findsNothing);
 
     expect(find.text(l.exAiSlotTitle), findsOneWidget);
+    const double expectedBottomInset = 17; // 16px padding + 1px border.
     expect(
       tester.getBottomRight(myGymCard()).dy -
           tester.getBottomRight(reservationPanel()).dy,
-      17,
+      expectedBottomInset,
     );
   });
 
@@ -173,12 +174,15 @@ void main() {
   ) async {
     await pumpGymTab(tester);
     await scrollToCard(tester);
+    final AppLocalizations l = AppLocalizations.of(
+      tester.element(find.byType(Scaffold).first),
+    );
 
     await tester.tap(
       find.descendant(of: myGymCard(), matching: find.text(_gym.name)),
     );
     await tester.pumpAndSettle();
-    expect(find.text('헬스장 상세'), findsOneWidget);
+    expect(find.text(l.exGymDetailTitle), findsOneWidget);
 
     router.go(AppRoutes.exerciseGym);
     await tester.pumpAndSettle();
@@ -187,6 +191,6 @@ void main() {
       find.descendant(of: myGymCard(), matching: find.text(_gym.trainerName!)),
     );
     await tester.pumpAndSettle();
-    expect(find.text('트레이너 상세'), findsOneWidget);
+    expect(find.text(l.exTrainerDetailTitle), findsOneWidget);
   });
 }

--- a/frontend/flutter/test/features/exercise/gym_tab_action_test.dart
+++ b/frontend/flutter/test/features/exercise/gym_tab_action_test.dart
@@ -6,7 +6,9 @@ import 'package:go_router/go_router.dart';
 import 'package:oncare/app/router/app_router.dart';
 import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/features/exercise/domain/entities/consultation_request.dart';
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
+import 'package:oncare/features/exercise/presentation/controllers/consultation_request_controller.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 
@@ -27,13 +29,39 @@ const AppConfig _config = AppConfig(
   useMockApi: true,
 );
 
+ConsultationRequest _consultation(ConsultationStatus status) {
+  return ConsultationRequest(
+    id: 'consultation-${status.name}',
+    targetType: ConsultationTargetType.trainer,
+    gymId: _gym.id,
+    gymName: _gym.name,
+    trainerName: _gym.trainerName,
+    trainerRole: _gym.trainerRole,
+    exerciseGoal: '체중 감량',
+    healthPurpose: '해당 없음',
+    preferredDate: DateTime(2026, 8),
+    preferredTimeSlot: '오후',
+    message: null,
+    status: status,
+    createdAt: DateTime(2026, 7, 31),
+  );
+}
+
 void main() {
   late GoRouter router;
+  late ConsultationRequestController consultationController;
 
-  Future<void> pumpGymTab(WidgetTester tester) async {
+  Future<void> pumpGymTab(
+    WidgetTester tester, {
+    ConsultationRequest? consultation,
+  }) async {
     await tester.binding.setSurfaceSize(const Size(390, 844));
     addTearDown(() => tester.binding.setSurfaceSize(null));
 
+    consultationController = ConsultationRequestController();
+    if (consultation != null) {
+      consultationController.add(consultation);
+    }
     router = buildAppRouter(config: _config);
     addTearDown(router.dispose);
     router.go(AppRoutes.exerciseGym);
@@ -43,6 +71,9 @@ void main() {
         overrides: <Override>[
           myGymProvider.overrideWith((ref) async => _gym),
           nearbyGymsProvider.overrideWith((ref) async => const <Gym>[_gym]),
+          consultationRequestControllerProvider.overrideWith(
+            (ref) => consultationController,
+          ),
         ],
         child: MaterialApp.router(
           routerConfig: router,
@@ -82,6 +113,7 @@ void main() {
     );
     expect(find.text(l.exGymInfo), findsNothing);
     expect(find.text(l.exConsultButton), findsNothing);
+    expect(find.text(l.exViewConsultationRequest), findsNothing);
 
     expect(find.text(l.exAiSlotTitle), findsOneWidget);
     expect(
@@ -90,6 +122,51 @@ void main() {
       17,
     );
   });
+
+  testWidgets('pending consultation shows one action and reuses status UI', (
+    WidgetTester tester,
+  ) async {
+    await pumpGymTab(
+      tester,
+      consultation: _consultation(ConsultationStatus.pending),
+    );
+    await scrollToCard(tester);
+
+    final AppLocalizations l = AppLocalizations.of(
+      tester.element(find.byType(Scaffold).first),
+    );
+    expect(find.text(l.exViewConsultationRequest), findsOneWidget);
+    expect(find.text(l.exGymInfo), findsNothing);
+    expect(find.text(l.exConsultButton), findsNothing);
+
+    final Finder statusSection = find.text(l.exConsultStatusSection);
+    final double statusTopBeforeTap = tester.getTopLeft(statusSection).dy;
+    final int requestCountBeforeTap = consultationController.state.length;
+
+    await tester.tap(find.text(l.exViewConsultationRequest));
+    await tester.pumpAndSettle();
+
+    expect(tester.getTopLeft(statusSection).dy, lessThan(statusTopBeforeTap));
+    expect(consultationController.state, hasLength(requestCountBeforeTap));
+    expect(find.byType(BottomSheet), findsNothing);
+  });
+
+  for (final ConsultationStatus status in <ConsultationStatus>[
+    ConsultationStatus.accepted,
+    ConsultationStatus.rejected,
+  ]) {
+    testWidgets('${status.name} consultation does not show an action', (
+      WidgetTester tester,
+    ) async {
+      await pumpGymTab(tester, consultation: _consultation(status));
+      await scrollToCard(tester);
+
+      final AppLocalizations l = AppLocalizations.of(
+        tester.element(find.byType(Scaffold).first),
+      );
+      expect(find.text(l.exViewConsultationRequest), findsNothing);
+    });
+  }
 
   testWidgets('gym and trainer information areas keep their detail routes', (
     WidgetTester tester,

--- a/frontend/flutter/test/features/exercise/gym_tab_action_test.dart
+++ b/frontend/flutter/test/features/exercise/gym_tab_action_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:oncare/app/router/app_router.dart';
+import 'package:oncare/app/router/routes.dart';
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/features/exercise/domain/entities/gym.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+const Gym _gym = Gym(
+  id: 'gym-action-test',
+  name: '액션 테스트 헬스장',
+  address: '서울시 테스트구',
+  distanceKm: 0.5,
+  rating: 4.9,
+  tags: <String>['PT'],
+  trainerName: '김액션',
+  trainerRole: '전담 트레이너',
+);
+
+const AppConfig _config = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: true,
+);
+
+void main() {
+  late GoRouter router;
+
+  Future<void> pumpGymTab(WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    router = buildAppRouter(config: _config);
+    addTearDown(router.dispose);
+    router.go(AppRoutes.exerciseGym);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          myGymProvider.overrideWith((ref) async => _gym),
+          nearbyGymsProvider.overrideWith((ref) async => const <Gym>[_gym]),
+        ],
+        child: MaterialApp.router(
+          routerConfig: router,
+          locale: const Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Finder myGymCard() => find.byWidgetPredicate(
+    (Widget widget) => widget.runtimeType.toString() == '_MyGymTrainerCard',
+  );
+
+  Finder reservationPanel() => find.byWidgetPredicate(
+    (Widget widget) => widget.runtimeType.toString() == '_ReservationPanel',
+  );
+
+  Future<void> scrollToCard(WidgetTester tester) async {
+    await tester.scrollUntilVisible(
+      myGymCard(),
+      250,
+      scrollable: find.byType(Scrollable).first,
+    );
+  }
+
+  testWidgets('legacy footer actions and their trailing space are removed', (
+    WidgetTester tester,
+  ) async {
+    await pumpGymTab(tester);
+    await scrollToCard(tester);
+
+    final AppLocalizations l = AppLocalizations.of(
+      tester.element(find.byType(Scaffold).first),
+    );
+    expect(find.text(l.exGymInfo), findsNothing);
+    expect(find.text(l.exConsultButton), findsNothing);
+
+    expect(find.text(l.exAiSlotTitle), findsOneWidget);
+    expect(
+      tester.getBottomRight(myGymCard()).dy -
+          tester.getBottomRight(reservationPanel()).dy,
+      17,
+    );
+  });
+
+  testWidgets('gym and trainer information areas keep their detail routes', (
+    WidgetTester tester,
+  ) async {
+    await pumpGymTab(tester);
+    await scrollToCard(tester);
+
+    await tester.tap(
+      find.descendant(of: myGymCard(), matching: find.text(_gym.name)),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('헬스장 상세'), findsOneWidget);
+
+    router.go(AppRoutes.exerciseGym);
+    await tester.pumpAndSettle();
+    await scrollToCard(tester);
+    await tester.tap(
+      find.descendant(of: myGymCard(), matching: find.text(_gym.trainerName!)),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('트레이너 상세'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

- `내 헬스장·트레이너` 카드의 기존 `헬스장 정보`, `1:1 상담` 버튼을 제거했습니다.
- 최신 상담 요청이 실제 `pending` 상태일 때만 `상담 요청 확인` 단일 버튼을 표시합니다.
- 버튼을 누르면 새 화면을 만들지 않고 기존 `상담 요청 현황` 섹션으로 이동합니다.
- 요청 없음·accepted·rejected 상태에서는 하단 액션과 관련 여백을 노출하지 않습니다.
- 헬스장 및 트레이너 정보 영역을 통한 기존 상세 진입은 유지했습니다.
- mock 연결 상태, 가짜 unread 숫자, `showGymChatSheet` 재사용은 추가하지 않았습니다.

## Scope

이번 PR은 사용자 앱의 헬스장 탭 UI, 관련 localization과 위젯 테스트로 제한됩니다. 실채팅 백엔드 연동, 트레이너 앱, 백엔드, DB, #315 인증·Dio 구조는 변경하지 않습니다.

## Related Issue

Closes #336

## Testing

- `dart analyze lib/features/exercise/presentation/widgets/gym_tab.dart test/features/exercise/gym_tab_action_test.dart`
  - No issues found
- `flutter test test/features/exercise/gym_tab_action_test.dart test/features/exercise/gym_detail_pages_test.dart test/features/exercise/consultation_request_flow_test.dart`
  - 13 tests passed
- 검증 항목:
  - 기존 `헬스장 정보`, `1:1 상담` 버튼 미표시
  - 요청 없음 상태의 하단 간격 미잔존
  - pending 상태에서 `상담 요청 확인` 단일 버튼 표시
  - pending 버튼 클릭 시 기존 상담 현황 UI로 이동하며 요청을 새로 생성하지 않음
  - accepted·rejected 상태에서 CTA 미표시
  - 헬스장 정보 영역 → 헬스장 상세
  - 트레이너 정보 영역 → 트레이너 상세

> `flutter analyze`는 Flutter 3.44 분석 서버가 저장소의 한글 경로를 포함한 LSP 초기화 JSON을 파싱하다 종료되어, 동일 analyzer 기반의 `dart analyze`로 변경 파일을 검증했습니다.

## Follow-up

실제 사용자–트레이너 공용 채팅과 unread 상태 연동은 #338에서 진행합니다.

## Conflict Review

- 열린 PR #315, #332, #311, #308, #334, #313, #333의 변경 파일과 diff를 검토했습니다.
- 이번 PR과 직접 겹치는 열린 PR 및 파일은 없습니다.
- #315 브랜치나 코드를 사용하지 않았으며 `main`에서 독립 분기했습니다.
- 백엔드·트레이너 앱·공통 네트워크를 수정하지 않아 현재 `main`에 독립적으로 병합할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
- 대기 중인 상담 요청이 있으면 해당 상담 섹션으로 바로 이동할 수 있습니다.
- 체육관 탭에서 대기 중인 상담 요청을 확인하는 버튼과 상태 안내를 제공합니다.
- 체육관·트레이너 상세 정보와 선택한 운동 슬롯을 확인하고 예약할 수 있습니다.

## 개선 사항
- 체육관 정보 및 채팅 중심 UI를 상담 요청 중심으로 개선했습니다.
- 카드와 예약 패널의 배치를 조정했습니다.
- 상담 요청 관련 한국어·영어 안내 문구를 추가했습니다.

## 테스트
- 상담 요청 상태별 버튼 표시와 상세 화면 이동을 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->