### PR TITLE
feat(dashboard): 홈 대시보드 잔여 실연결(주간추이·코칭시트·네비·고정값)

### DIFF
--- a/backend/app/api/v1/dashboard.py
+++ b/backend/app/api/v1/dashboard.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterable
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
@@ -21,7 +21,8 @@ from app.api.deps import CurrentUser
 from app.db.session import get_db
 from app.models.models import DietEntry, ExerciseSession, ScheduleEvent
 from app.schemas.dashboard_api import (
-    DashboardIndicator, DashboardScheduleItem, DashboardSummary,
+    DashboardIndicator, DashboardNutritionDay, DashboardScheduleItem,
+    DashboardSummary,
 )
 from app.schemas.diet_api import calculate_macros
 from app.services.exercise_service import monday_of_this_week_str
@@ -32,6 +33,51 @@ router = APIRouter(tags=["dashboard"])
 _MAX_CALORIES = 2000
 _MAX_SODIUM_MG = 2000
 _MAX_SUGAR_G = 50
+
+# 요일 라벨(월=0 … 일=6) — 홈 주간 추이 차트 x축용
+_DAY_LABELS = ["월", "화", "수", "목", "금", "토", "일"]
+
+
+def _score_for(sodium_ok: bool, exercise_minutes: int) -> int:
+    """식단 균형(나트륨) + 운동량 기반 간이 주간 점수(0~100)."""
+    score = 50
+    if sodium_ok:
+        score += 20
+    if exercise_minutes >= 150:
+        score += 30
+    elif exercise_minutes > 0:
+        score += 15
+    return min(score, 100)
+
+
+def _nutrition_week(
+    db: Session, uid: str, monday: datetime,
+) -> list[DashboardNutritionDay]:
+    """월요일 [monday]부터 일요일까지 7일의 일별 영양 집계(월→일).
+
+    차트 x축이 고정 월~일이므로 달력 주(캘린더 위크) 기준으로 집계해 요일이
+    정확히 정렬되게 한다. 오늘 이후(미래) 요일은 기록이 없어 0으로 남는다.
+    """
+    dates = [
+        (monday + timedelta(days=i)).strftime("%Y-%m-%d") for i in range(7)
+    ]
+    rows = db.scalars(
+        select(DietEntry).where(DietEntry.user_id == uid).where(DietEntry.date.in_(dates))
+    ).all()
+    acc: dict[str, list[int]] = {d: [0, 0, 0] for d in dates}  # [cal, na, sugar]
+    for r in rows:
+        a = acc.get(r.date)
+        if a is not None:
+            a[0] += r.total_calories
+            a[1] += r.sodium_mg
+            a[2] += r.sugar_g
+    return [
+        DashboardNutritionDay(
+            date=d, label=_DAY_LABELS[i],
+            calories=acc[d][0], sodium_mg=acc[d][1], sugar_g=acc[d][2],
+        )
+        for i, d in enumerate(dates)
+    ]
 
 
 def _build_sodium_warning(
@@ -80,7 +126,8 @@ def dashboard_summary(
     db: Annotated[Session, Depends(get_db)],
 ) -> DashboardSummary:
     uid = current_user.id
-    today = datetime.now().strftime("%Y-%m-%d")
+    today_dt = datetime.now()
+    today = today_dt.strftime("%Y-%m-%d")
 
     # --- 오늘 식단 집계 ---
     diet_rows = db.scalars(
@@ -104,6 +151,11 @@ def dashboard_summary(
     ]
     source_names = _rank_sodium_sources(row.foods_json for row in diet_rows)
     sodium_warning = _build_sodium_warning(total_na, source_names)
+
+    # --- 식단 주간 추이(이번 주 월~일 + 지난 주 월~일 비교선) ---
+    this_monday = today_dt - timedelta(days=today_dt.weekday())
+    nutrition_week = _nutrition_week(db, uid, this_monday)
+    nutrition_week_prev = _nutrition_week(db, uid, this_monday - timedelta(days=7))
 
     # --- 이번 주 운동 집계 ---
     week = monday_of_this_week_str()
@@ -132,15 +184,22 @@ def dashboard_summary(
         for s in sched_rows
     ]
 
-    # --- 주간 점수 (식단 균형 + 운동량 기반 간이 점수) ---
-    score = 50
-    if total_na <= _MAX_SODIUM_MG:
-        score += 20
-    if exercise_minutes >= 150:
-        score += 30
-    elif exercise_minutes > 0:
-        score += 15
-    score = min(score, 100)
+    # --- 주간 점수 + 지난주 대비 변화량(동일 공식으로 실제 차이 집계) ---
+    score = _score_for(total_na <= _MAX_SODIUM_MG, exercise_minutes)
+    last_week = (today_dt - timedelta(days=today_dt.weekday() + 7)).strftime("%Y-%m-%d")
+    last_ex_minutes = sum(
+        r.minutes for r in db.scalars(
+            select(ExerciseSession).where(ExerciseSession.user_id == uid)
+            .where(ExerciseSession.week_start == last_week)
+        ).all()
+    )
+    prev_days_logged = [d for d in nutrition_week_prev if d.calories > 0]
+    last_avg_sodium = (
+        sum(d.sodium_mg for d in prev_days_logged) / len(prev_days_logged)
+        if prev_days_logged else 0
+    )
+    last_week_score = _score_for(last_avg_sodium <= _MAX_SODIUM_MG, last_ex_minutes)
+    week_score_delta = score - last_week_score
 
     return DashboardSummary(
         indicators=indicators,
@@ -149,9 +208,11 @@ def dashboard_summary(
         exercise_minutes=exercise_minutes,
         exercise_calories=exercise_calories,
         exercise_count=exercise_count,
+        nutrition_week=nutrition_week,
+        nutrition_week_prev=nutrition_week_prev,
         today_schedule=today_schedule,
         week_score=score,
-        week_score_delta=5,  # 지난주 대비(추세 추적 전까지 데모 고정값)
+        week_score_delta=week_score_delta,
         sodium_warning=sodium_warning,
         exercise_feedback=exercise_feedback,
     )

--- a/backend/app/api/v1/dashboard.py
+++ b/backend/app/api/v1/dashboard.py
@@ -50,6 +50,18 @@ def _score_for(sodium_ok: bool, exercise_minutes: int) -> int:
     return min(score, 100)
 
 
+def _avg_sodium_of_logged(days: list[DashboardNutritionDay]) -> float | None:
+    """기록된(칼로리>0) 날짜들의 평균 나트륨(mg). 기록이 없으면 None.
+
+    주간 점수를 이번 주·지난 주 모두 "기록된 날짜들의 평균 나트륨"으로 계산해
+    하루치와 주간 평균을 비교하는 왜곡을 막는다.
+    """
+    logged = [d for d in days if d.calories > 0]
+    if not logged:
+        return None
+    return sum(d.sodium_mg for d in logged) / len(logged)
+
+
 def _nutrition_week(
     db: Session, uid: str, monday: datetime,
 ) -> list[DashboardNutritionDay]:
@@ -185,7 +197,14 @@ def dashboard_summary(
     ]
 
     # --- 주간 점수 + 지난주 대비 변화량(동일 공식으로 실제 차이 집계) ---
-    score = _score_for(total_na <= _MAX_SODIUM_MG, exercise_minutes)
+    # 이번 주 점수도 지난주와 같은 방식(기록된 날짜들의 평균 나트륨)으로 계산한다.
+    # 하루치(total_na)를 주간 평균과 비교하면 왜곡되고, 오늘 아직 식사를 기록하지
+    # 않았을 때 total_na==0 이라 주간 식습관과 무관하게 나트륨 조건을 통과하는
+    # 문제가 있었다. 이번 주 기록이 아직 없으면 오늘 하루치로 폴백한다.
+    this_avg_sodium = _avg_sodium_of_logged(nutrition_week)
+    if this_avg_sodium is None:
+        this_avg_sodium = total_na
+    score = _score_for(this_avg_sodium <= _MAX_SODIUM_MG, exercise_minutes)
     last_week = (today_dt - timedelta(days=today_dt.weekday() + 7)).strftime("%Y-%m-%d")
     last_ex_minutes = sum(
         r.minutes for r in db.scalars(
@@ -193,11 +212,7 @@ def dashboard_summary(
             .where(ExerciseSession.week_start == last_week)
         ).all()
     )
-    prev_days_logged = [d for d in nutrition_week_prev if d.calories > 0]
-    last_avg_sodium = (
-        sum(d.sodium_mg for d in prev_days_logged) / len(prev_days_logged)
-        if prev_days_logged else 0
-    )
+    last_avg_sodium = _avg_sodium_of_logged(nutrition_week_prev) or 0
     last_week_score = _score_for(last_avg_sodium <= _MAX_SODIUM_MG, last_ex_minutes)
     week_score_delta = score - last_week_score
 

--- a/backend/app/schemas/dashboard_api.py
+++ b/backend/app/schemas/dashboard_api.py
@@ -23,6 +23,15 @@ class DashboardScheduleItem(BaseModel):
     emoji: str
 
 
+class DashboardNutritionDay(BaseModel):
+    """홈 식단 카드의 주간 추이 차트 한 점 — 하루치 영양 집계."""
+    date: str        # YYYY-MM-DD
+    label: str       # 요일 라벨(월/화/…) — 프론트 x축용
+    calories: int
+    sodium_mg: int
+    sugar_g: int
+
+
 class DashboardSummary(BaseModel):
     indicators: list[DashboardIndicator]
     macros: Macros
@@ -30,6 +39,11 @@ class DashboardSummary(BaseModel):
     exercise_minutes: int
     exercise_calories: int
     exercise_count: int
+    # 운동 소모 목표(kcal) — 홈 운동 카드 진행률용. 개인화 전까지 서버 기본값.
+    exercise_burn_goal: int = 500
+    # 식단 카드 주간 추이(최근 7일 일별 영양) + 지난 주 같은 요일(비교선)
+    nutrition_week: list[DashboardNutritionDay] = []
+    nutrition_week_prev: list[DashboardNutritionDay] = []
     today_schedule: list[DashboardScheduleItem]
     week_score: int
     week_score_delta: int

--- a/backend/app/services/coach_service.py
+++ b/backend/app/services/coach_service.py
@@ -75,6 +75,39 @@ def _exercise_suggestion(db: Session, user_id: str) -> CoachSuggestion:
     )
 
 
+def _hydration_suggestion(db: Session, user_id: str) -> CoachSuggestion:
+    """수분 제안 — 오늘 나트륨/시간대 기반 간단 규칙(고정 문구 대체).
+
+    RAG/LLM 전까지 규칙 기반으로 개인화한다: 나트륨이 높으면 배출을 위해 물을
+    더 권하고, 그렇지 않으면 시간대에 맞춰 다르게 안내한다.
+    """
+    today = datetime.now().strftime("%Y-%m-%d")
+    total_na = sum(
+        r.sodium_mg for r in db.scalars(
+            select(DietEntry).where(DietEntry.user_id == user_id)
+            .where(DietEntry.date == today)
+        ).all()
+    )
+    if total_na > 2000:
+        return CoachSuggestion(
+            tag="hydration", title="물을 더 챙기세요",
+            body=(
+                f"오늘 나트륨이 {total_na}mg으로 높아요. "
+                "물을 충분히 마시면 나트륨 배출에 도움이 됩니다."
+            ),
+        )
+    hour = datetime.now().hour
+    if hour < 11:
+        body = "아침 물 한 잔으로 하루를 시작해 보세요. 하루 6~8잔이 목표예요."
+    elif hour < 18:
+        body = "지금까지 물을 얼마나 드셨나요? 틈틈이 마셔 6~8잔을 채워요."
+    else:
+        body = "오늘 물 6~8잔을 채웠는지 확인해요. 자기 전 과한 수분은 피하세요."
+    return CoachSuggestion(
+        tag="hydration", title="수분 섭취 잊지 마세요", body=body,
+    )
+
+
 def build_feedback(db: Session, user_id: str, user_name: str) -> AiCoachFeedback:
     """
     도메인별 코치를 각각 호출해 합친다.
@@ -96,9 +129,6 @@ def build_feedback(db: Session, user_id: str, user_name: str) -> AiCoachFeedback
     suggestions = [
         diet_coach(db, user_id),       # 식단 RAG 코치 (실패 시 규칙 폴백)
         exercise_coach(db, user_id),   # 운동 RAG 코치 (실패 시 규칙 폴백)
-        CoachSuggestion(
-            tag="hydration", title="수분 섭취 잊지 마세요",
-            body="하루 6~8잔의 물은 혈압 관리에도 도움이 됩니다.",
-        ),
+        _hydration_suggestion(db, user_id),  # 나트륨/시간대 기반 수분 제안
     ]
     return AiCoachFeedback(greeting=greeting, suggestions=suggestions)

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -6,7 +6,16 @@ import json
 import pytest
 from sqlalchemy import delete
 
-from app.api.v1.dashboard import _build_sodium_warning, _rank_sodium_sources
+from app.api.v1.dashboard import (
+    _build_sodium_warning, _rank_sodium_sources, _score_for,
+)
+
+
+def test_score_for_combines_sodium_and_exercise():
+    assert _score_for(True, 200) == 100   # 50 + 20(나트륨) + 30(운동 150+)
+    assert _score_for(True, 100) == 85    # 50 + 20 + 15(운동 1~149)
+    assert _score_for(True, 0) == 70      # 50 + 20
+    assert _score_for(False, 0) == 50     # 기본만
 
 
 @pytest.mark.parametrize(
@@ -118,3 +127,14 @@ def test_dashboard_summary_includes_macros_and_sodium_sources(client, db_session
     assert isinstance(body["exercise_minutes"], int)
     assert isinstance(body["exercise_calories"], int)
     assert isinstance(body["exercise_count"], int)
+
+    # 주간 추이(이번 주 월~일 7일) + 지난 주 비교선 7일
+    assert len(body["nutrition_week"]) == 7
+    assert len(body["nutrition_week_prev"]) == 7
+    assert [d["label"] for d in body["nutrition_week"]] == \
+        ["월", "화", "수", "목", "금", "토", "일"]
+    # 오늘 점심(780)+저녁(570)이 이번 주 어느 요일에 집계돼야 한다.
+    assert sum(d["calories"] for d in body["nutrition_week"]) >= 1350
+    # 소모 목표 필드(기본값) + 지난주 대비 변화량은 정수
+    assert body["exercise_burn_goal"] == 500
+    assert isinstance(body["week_score_delta"], int)

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -7,8 +7,56 @@ import pytest
 from sqlalchemy import delete
 
 from app.api.v1.dashboard import (
-    _build_sodium_warning, _rank_sodium_sources, _score_for,
+    _avg_sodium_of_logged, _build_sodium_warning, _rank_sodium_sources,
+    _score_for,
 )
+from app.schemas.dashboard_api import DashboardNutritionDay
+
+
+def _nday(label: str, *, calories: int, sodium_mg: int) -> DashboardNutritionDay:
+    return DashboardNutritionDay(
+        date="2026-07-27", label=label, calories=calories,
+        sodium_mg=sodium_mg, sugar_g=0,
+    )
+
+
+def test_avg_sodium_of_logged_ignores_unlogged_days():
+    # 미래 요일(칼로리 0)은 평균에서 빠진다 — 월·화만 기록됐다면 그 둘의 평균.
+    week = [
+        _nday("월", calories=1600, sodium_mg=2400),
+        _nday("화", calories=1500, sodium_mg=1600),
+        _nday("수", calories=0, sodium_mg=0),
+        _nday("목", calories=0, sodium_mg=0),
+    ]
+    assert _avg_sodium_of_logged(week) == pytest.approx(2000.0)
+
+
+def test_avg_sodium_of_logged_is_none_when_nothing_logged():
+    week = [_nday("월", calories=0, sodium_mg=0)]
+    assert _avg_sodium_of_logged(week) is None
+
+
+def test_weekly_score_uses_average_not_single_day():
+    # 지난 주는 기록된 날 평균 나트륨이 초과(2400>2000)라 나트륨 보너스가 빠지고,
+    # 이번 주는 평균이 예산 이내(1800<=2000)라 보너스가 붙는다 — 하루치가 아니라
+    # 주간 평균으로 두 점수를 같은 잣대로 비교한다.
+    this_week = [
+        _nday("월", calories=1500, sodium_mg=1800),
+        _nday("화", calories=1500, sodium_mg=1800),
+        _nday("수", calories=0, sodium_mg=0),  # 미래 요일은 무시
+    ]
+    prev_week = [
+        _nday("월", calories=1500, sodium_mg=2400),
+        _nday("화", calories=1500, sodium_mg=2400),
+    ]
+    this_avg = _avg_sodium_of_logged(this_week)
+    prev_avg = _avg_sodium_of_logged(prev_week)
+    assert this_avg == pytest.approx(1800.0)
+    assert prev_avg == pytest.approx(2400.0)
+    # 운동량 동일(0)일 때: 이번 주는 +20, 지난 주는 미포함 → delta = 20.
+    this_score = _score_for(this_avg <= 2000, 0)
+    prev_score = _score_for(prev_avg <= 2000, 0)
+    assert this_score - prev_score == 20
 
 
 def test_score_for_combines_sodium_and_exercise():

--- a/frontend/flutter/lib/features/dashboard/domain/entities/dashboard_summary.dart
+++ b/frontend/flutter/lib/features/dashboard/domain/entities/dashboard_summary.dart
@@ -51,6 +51,28 @@ class ScheduleItem {
   );
 }
 
+/// One day of the 식단 카드 weekly-trend chart (칼로리/나트륨/당류).
+class NutritionDay {
+  const NutritionDay({
+    required this.label,
+    required this.calories,
+    required this.sodiumMg,
+    required this.sugarG,
+  });
+
+  final String label; // 요일(월/화/…)
+  final int calories;
+  final int sodiumMg;
+  final int sugarG;
+
+  factory NutritionDay.fromJson(Map<String, Object?> json) => NutritionDay(
+    label: (json['label'] as String?) ?? '',
+    calories: (json['calories'] as num?)?.toInt() ?? 0,
+    sodiumMg: (json['sodium_mg'] as num?)?.toInt() ?? 0,
+    sugarG: (json['sugar_g'] as num?)?.toInt() ?? 0,
+  );
+}
+
 /// Snapshot displayed on the home dashboard. Mirrors the data the
 /// React `Dashboard.tsx` mounts in `healthData` / `todaySchedule` /
 /// `quickStats` / weekly score.
@@ -62,6 +84,9 @@ class DashboardSummary {
     required this.exerciseMinutes,
     this.exerciseCalories = 0,
     this.exerciseCount = 0,
+    this.exerciseBurnGoal = 500,
+    this.nutritionWeek = const <NutritionDay>[],
+    this.nutritionWeekPrev = const <NutritionDay>[],
     required this.todaySchedule,
     required this.weekScore,
     required this.weekScoreDelta,
@@ -86,6 +111,14 @@ class DashboardSummary {
 
   /// Number of exercise sessions included in this summary.
   final int exerciseCount;
+
+  /// 운동 카드 소모 목표(kcal). 개인화 전까지 서버 기본값(500).
+  final int exerciseBurnGoal;
+
+  /// 식단 카드 주간 추이(최근 7일 일별 영양) + 지난 주 같은 요일(비교선).
+  /// 비어 있으면(데모/목·데이터 없음) 화면은 기존 데모 상수로 폴백한다.
+  final List<NutritionDay> nutritionWeek;
+  final List<NutritionDay> nutritionWeekPrev;
 
   /// Today's schedule list (병원 정기검진 / 헬스장 운동 …).
   final List<ScheduleItem> todaySchedule;
@@ -130,29 +163,40 @@ class DashboardSummary {
       todaySchedule.isEmpty &&
       calorieIndicator.current == 0;
 
-  factory DashboardSummary.fromJson(Map<String, Object?> json) =>
-      DashboardSummary(
-        indicators: (json['indicators']! as List<Object?>)
+  factory DashboardSummary.fromJson(
+    Map<String, Object?> json,
+  ) => DashboardSummary(
+    indicators: (json['indicators']! as List<Object?>)
+        .cast<Map<String, Object?>>()
+        .map(HealthIndicator.fromJson)
+        .toList(),
+    macros: json['macros'] is Map<Object?, Object?>
+        ? DietMacros.fromJson(
+            (json['macros']! as Map<Object?, Object?>).cast<String, Object?>(),
+          )
+        : const DietMacros.zero(),
+    dietEntries: (json['diet_entries']! as num).toInt(),
+    exerciseMinutes: (json['exercise_minutes']! as num).toInt(),
+    exerciseCalories: (json['exercise_calories'] as num?)?.toInt() ?? 0,
+    exerciseCount: (json['exercise_count'] as num?)?.toInt() ?? 0,
+    exerciseBurnGoal: (json['exercise_burn_goal'] as num?)?.toInt() ?? 500,
+    nutritionWeek:
+        ((json['nutrition_week'] as List<Object?>?) ?? const <Object?>[])
             .cast<Map<String, Object?>>()
-            .map(HealthIndicator.fromJson)
+            .map(NutritionDay.fromJson)
             .toList(),
-        macros: json['macros'] is Map<Object?, Object?>
-            ? DietMacros.fromJson(
-                (json['macros']! as Map<Object?, Object?>)
-                    .cast<String, Object?>(),
-              )
-            : const DietMacros.zero(),
-        dietEntries: (json['diet_entries']! as num).toInt(),
-        exerciseMinutes: (json['exercise_minutes']! as num).toInt(),
-        exerciseCalories: (json['exercise_calories'] as num?)?.toInt() ?? 0,
-        exerciseCount: (json['exercise_count'] as num?)?.toInt() ?? 0,
-        todaySchedule: (json['today_schedule']! as List<Object?>)
+    nutritionWeekPrev:
+        ((json['nutrition_week_prev'] as List<Object?>?) ?? const <Object?>[])
             .cast<Map<String, Object?>>()
-            .map(ScheduleItem.fromJson)
+            .map(NutritionDay.fromJson)
             .toList(),
-        weekScore: (json['week_score']! as num).toInt(),
-        weekScoreDelta: (json['week_score_delta']! as num).toInt(),
-        sodiumWarning: json['sodium_warning'] as String?,
-        exerciseFeedback: json['exercise_feedback'] as String?,
-      );
+    todaySchedule: (json['today_schedule']! as List<Object?>)
+        .cast<Map<String, Object?>>()
+        .map(ScheduleItem.fromJson)
+        .toList(),
+    weekScore: (json['week_score']! as num).toInt(),
+    weekScoreDelta: (json['week_score_delta']! as num).toInt(),
+    sodiumWarning: json['sodium_warning'] as String?,
+    exerciseFeedback: json['exercise_feedback'] as String?,
+  );
 }

--- a/frontend/flutter/lib/features/dashboard/domain/entities/dashboard_summary.dart
+++ b/frontend/flutter/lib/features/dashboard/domain/entities/dashboard_summary.dart
@@ -161,7 +161,10 @@ class DashboardSummary {
       dietEntries == 0 &&
       exerciseMinutes == 0 &&
       todaySchedule.isEmpty &&
-      calorieIndicator.current == 0;
+      calorieIndicator.current == 0 &&
+      // 오늘 기록이 없어도 이번 주(과거 요일)에 실제 식단 기록이 있으면 홈은
+      // 비어 있지 않다 — 주간 추이 차트가 표시돼야 한다.
+      !nutritionWeek.any((NutritionDay day) => day.calories > 0);
 
   factory DashboardSummary.fromJson(
     Map<String, Object?> json,

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -13,6 +13,7 @@ import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart
 import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/widgets/coaching_sheet.dart';
+import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
 
 /// The Home tab, rebuilt to match the On-Care Figma redesign.
 ///
@@ -965,15 +966,15 @@ class _ExerciseCard extends StatelessWidget {
   final bool showCharts;
   final VoidCallback onOpen;
 
-  static const double _burnGoal = 500;
-
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
     final double burned = summary.exerciseCalories.toDouble();
-    final double pct = (burned / _burnGoal).clamp(0.0, 1.0);
+    // 소모 목표는 백엔드 summary 필드(개인화 전까지 서버 기본값)에서 온다.
+    final double burnGoal = summary.exerciseBurnGoal.toDouble();
+    final double pct = burnGoal <= 0 ? 0 : (burned / burnGoal).clamp(0.0, 1.0);
     // 진행바는 100%로 채우되, 라벨의 달성률은 실제 비율(목표 초과 시 100% 초과)을 보여준다.
-    final double rawPct = burned / _burnGoal;
+    final double rawPct = burnGoal <= 0 ? 0 : burned / burnGoal;
     const week = _demoExerciseWeekCalories;
     final List<String> days = _weekDayLabels(l);
     final (double lo, double hi) = _barScale(week);
@@ -1072,7 +1073,7 @@ class _ExerciseCard extends StatelessWidget {
                     ),
                     TextSpan(
                       text:
-                          ' / ${nf.format(_burnGoal)} ${l.unitKcal}'
+                          ' / ${nf.format(burnGoal)} ${l.unitKcal}'
                           '  ·  ${(rawPct * 100).round()}%',
                       style: const TextStyle(
                         fontSize: 10,
@@ -1421,20 +1422,41 @@ _demoNutritionHistory = <_NutTabKind, _NutData>{
   ),
 };
 
+double _nutritionValue(_NutTabKind kind, NutritionDay day) => switch (kind) {
+  _NutTabKind.calories => day.calories.toDouble(),
+  _NutTabKind.sodium => day.sodiumMg.toDouble(),
+  _NutTabKind.sugar => day.sugarG.toDouble(),
+};
+
 Map<_NutTabKind, _NutData> _nutritionFor(DashboardSummary summary) {
   final liveValues = <_NutTabKind, HealthIndicator>{
     _NutTabKind.calories: summary.calorieIndicator,
     _NutTabKind.sodium: summary.sodiumIndicator,
     _NutTabKind.sugar: summary.sugarIndicator,
   };
+  // 실 주간 집계(월~일)가 있으면 7일 실데이터로 채운다(실모드). 비어 있으면
+  // (데모/목·데이터 없음) 기존 데모 상수를 유지하고 마지막 점만 오늘 실측치로
+  // 대체 — 데모 둘러보기 화면이 기존과 동일하게 보이도록 한다.
+  final bool hasWeek = summary.nutritionWeek.isNotEmpty;
+  final bool hasPrev = summary.nutritionWeekPrev.isNotEmpty;
   return <_NutTabKind, _NutData>{
     for (final entry in _demoNutritionHistory.entries)
       entry.key: _NutData(
-        cur: <double>[
-          ...entry.value.cur.take(6),
-          liveValues[entry.key]!.current.toDouble(),
-        ],
-        prev: entry.value.prev,
+        cur: hasWeek
+            ? <double>[
+                for (final NutritionDay day in summary.nutritionWeek)
+                  _nutritionValue(entry.key, day),
+              ]
+            : <double>[
+                ...entry.value.cur.take(6),
+                liveValues[entry.key]!.current.toDouble(),
+              ],
+        prev: hasPrev
+            ? <double>[
+                for (final NutritionDay day in summary.nutritionWeekPrev)
+                  _nutritionValue(entry.key, day),
+              ]
+            : entry.value.prev,
         unit: entry.value.unit,
         goal: liveValues[entry.key]!.max.toDouble(),
         ticks: entry.value.ticks,
@@ -1920,12 +1942,16 @@ class _RecommendedMeals extends StatelessWidget {
                 ),
               ),
               const SizedBox(width: 8),
-              Text(
-                l.homeViewAll,
-                style: const TextStyle(
-                  fontSize: 12,
-                  fontWeight: FontWeight.w600,
-                  color: FigmaColors.primary,
+              GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () => context.go(AppRoutes.diet),
+                child: Text(
+                  l.homeViewAll,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: FigmaColors.primary,
+                  ),
                 ),
               ),
             ],
@@ -2073,12 +2099,16 @@ class _ScheduleCard extends StatelessWidget {
                 ],
               ),
             ),
-            Text(
-              l.homeViewAll,
-              style: const TextStyle(
-                fontSize: 12,
-                fontWeight: FontWeight.w600,
-                color: FigmaColors.primary,
+            GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () => showScheduleCalendarSheet(context),
+              child: Text(
+                l.homeViewAll,
+                style: const TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: FigmaColors.primary,
+                ),
               ),
             ),
           ],
@@ -2115,49 +2145,57 @@ class _ScheduleItemCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: FigmaColors.softBlue,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: FigmaColors.primaryA(0.12)),
-      ),
-      child: Row(
-        children: <Widget>[
-          Text(
-            item.time,
-            style: const TextStyle(
-              fontSize: 15,
-              fontWeight: FontWeight.w800,
-              color: FigmaColors.primary,
-              letterSpacing: -0.3,
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () => showScheduleCalendarSheet(context),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: FigmaColors.softBlue,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: FigmaColors.primaryA(0.12)),
+        ),
+        child: Row(
+          children: <Widget>[
+            Text(
+              item.time,
+              style: const TextStyle(
+                fontSize: 15,
+                fontWeight: FontWeight.w800,
+                color: FigmaColors.primary,
+                letterSpacing: -0.3,
+              ),
             ),
-          ),
-          const SizedBox(width: 16),
-          Container(width: 1, height: 34, color: FigmaColors.primaryA(0.35)),
-          const SizedBox(width: 16),
-          Expanded(
-            child: Row(
-              children: <Widget>[
-                if (item.emoji.isNotEmpty) ...<Widget>[
-                  Text(item.emoji),
-                  const SizedBox(width: 8),
-                ],
-                Expanded(
-                  child: Text(
-                    item.title,
-                    style: const TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w700,
-                      color: FigmaColors.ink,
+            const SizedBox(width: 16),
+            Container(width: 1, height: 34, color: FigmaColors.primaryA(0.35)),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Row(
+                children: <Widget>[
+                  if (item.emoji.isNotEmpty) ...<Widget>[
+                    Text(item.emoji),
+                    const SizedBox(width: 8),
+                  ],
+                  Expanded(
+                    child: Text(
+                      item.title,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w700,
+                        color: FigmaColors.ink,
+                      ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
-          ),
-          const Icon(Icons.chevron_right, size: 18, color: FigmaColors.primary),
-        ],
+            const Icon(
+              Icons.chevron_right,
+              size: 18,
+              color: FigmaColors.primary,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -527,10 +527,11 @@ class _DietNutritionCardState extends State<_DietNutritionCard> {
     final nutrition = _nutritionFor(widget.summary);
     final _NutData cfg = nutrition[_tab]!;
     final List<String> days = _weekDayLabels(l);
-    final (double lo, double hi) = _trendScale(cfg);
+    final int todayIdx = _weekTodayIndex();
+    final (double lo, double hi) = _trendScale(cfg, todayIdx);
     final NumberFormat nf = NumberFormat('#,###');
     // 오늘 값의 목표 대비 상태색(안전 초록 / 근접 주황 / 초과 빨강).
-    final Color todayColor = _nutStatusColor(cfg.cur.last, cfg.goal);
+    final Color todayColor = _nutStatusColor(cfg.cur[todayIdx], cfg.goal);
 
     return _StripeCard(
       child: Column(
@@ -740,6 +741,7 @@ class _DietNutritionCardState extends State<_DietNutritionCard> {
                                       ticks: cfg.ticks,
                                       lo: lo,
                                       hi: hi,
+                                      todayIndex: todayIdx,
                                     ),
                                   ),
                                 ),
@@ -754,7 +756,7 @@ class _DietNutritionCardState extends State<_DietNutritionCard> {
                                         style: TextStyle(
                                           fontSize: 8,
                                           fontWeight: FontWeight.w600,
-                                          color: i == 6
+                                          color: i == todayIdx
                                               ? todayColor
                                               : FigmaColors.textFaint,
                                         ),
@@ -1255,9 +1257,16 @@ class _MetricTile extends StatelessWidget {
 /// Padded min/max scale for the nutrition line chart. Deliberately excludes a
 /// zero baseline so day-to-day variation reads as a dynamic slope rather than
 /// a nearly flat line.
-(double, double) _trendScale(_NutData c) {
+(double, double) _trendScale(_NutData c, int todayIndex) {
   // 데이터와 눈금(ticks)을 모두 포함하도록 스케일을 잡아 눈금선이 항상 보이게 한다.
-  final List<double> all = <double>[...c.cur, ...c.prev, ...c.ticks, c.goal];
+  // 이번 주(cur)는 오늘까지만 반영해 미래 요일의 0값이 축 바닥을 끌어내리지 않게 한다.
+  final int lastIdx = todayIndex.clamp(0, c.cur.length - 1);
+  final List<double> all = <double>[
+    ...c.cur.take(lastIdx + 1),
+    ...c.prev,
+    ...c.ticks,
+    c.goal,
+  ];
   double lo = all.reduce(math.min);
   double hi = all.reduce(math.max);
   final double range = (hi - lo) == 0 ? 1 : (hi - lo);
@@ -1422,6 +1431,11 @@ _demoNutritionHistory = <_NutTabKind, _NutData>{
   ),
 };
 
+/// 오늘 요일 인덱스(월=0 … 일=6). 주간 추이 차트에서 "오늘"을 고정 일요일이
+/// 아니라 실제 오늘로 강조하고, 오늘 이후(미래) 요일의 0값이 실제 급락처럼
+/// 보이지 않도록 렌더 범위를 오늘까지로 제한하는 데 쓴다.
+int _weekTodayIndex() => DateTime.now().weekday - 1;
+
 double _nutritionValue(_NutTabKind kind, NutritionDay day) => switch (kind) {
   _NutTabKind.calories => day.calories.toDouble(),
   _NutTabKind.sodium => day.sodiumMg.toDouble(),
@@ -1448,8 +1462,12 @@ Map<_NutTabKind, _NutData> _nutritionFor(DashboardSummary summary) {
                   _nutritionValue(entry.key, day),
               ]
             : <double>[
-                ...entry.value.cur.take(6),
-                liveValues[entry.key]!.current.toDouble(),
+                // 데모 모드에서도 오늘 실측치는 마지막(일요일)이 아니라 실제
+                // 오늘 요일 슬롯에 놓는다.
+                for (int i = 0; i < entry.value.cur.length; i++)
+                  i == _weekTodayIndex()
+                      ? liveValues[entry.key]!.current.toDouble()
+                      : entry.value.cur[i],
               ],
         prev: hasPrev
             ? <double>[
@@ -1633,6 +1651,7 @@ class _TrendChartPainter extends CustomPainter {
     required this.ticks,
     required this.lo,
     required this.hi,
+    required this.todayIndex,
   });
 
   final List<double> cur;
@@ -1641,6 +1660,9 @@ class _TrendChartPainter extends CustomPainter {
   final List<double> ticks;
   final double lo;
   final double hi;
+
+  /// 이번 주 꺾은선은 오늘까지만 그린다(미래 요일의 0값이 급락처럼 보이지 않도록).
+  final int todayIndex;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -1682,8 +1704,11 @@ class _TrendChartPainter extends CustomPainter {
       );
     }
 
+    // 이번 주 선/점은 오늘까지만 그린다 — 아직 오지 않은 요일(=0)을 실제 급락으로
+    // 오해하지 않도록. x 좌표는 여전히 월~일 7칸 기준이라 지난 주 선과 정렬된다.
+    final int lastIdx = todayIndex.clamp(0, cur.length - 1);
     final List<Offset> pts = <Offset>[
-      for (int i = 0; i < cur.length; i++) Offset(dx(i), dy(cur[i])),
+      for (int i = 0; i <= lastIdx; i++) Offset(dx(i), dy(cur[i])),
     ];
 
     // 이번 주 꺾은선은 회색(얇게), 데이터 포인트는 목표 대비 상태색으로 강조하고
@@ -1702,9 +1727,9 @@ class _TrendChartPainter extends CustomPainter {
         ..strokeCap = StrokeCap.round,
     );
 
-    for (int i = 0; i < cur.length; i++) {
+    for (int i = 0; i <= lastIdx; i++) {
       final Color sc = _nutStatusColor(cur[i], goal);
-      _dot(canvas, pts[i], sc, r: i == cur.length - 1 ? 4.2 : 3.4);
+      _dot(canvas, pts[i], sc, r: i == lastIdx ? 4.2 : 3.4);
       _text(canvas, _fmt(cur[i]), pts[i], w, sc);
     }
   }
@@ -1771,7 +1796,8 @@ class _TrendChartPainter extends CustomPainter {
       old.goal != goal ||
       old.ticks != ticks ||
       old.lo != lo ||
-      old.hi != hi;
+      old.hi != hi ||
+      old.todayIndex != todayIndex;
 }
 
 /// The weekly exercise bar chart. Bars sit on a [lo]/[hi] scale whose baseline

--- a/frontend/flutter/lib/shared/widgets/coaching_sheet.dart
+++ b/frontend/flutter/lib/shared/widgets/coaching_sheet.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare/app/router/routes.dart';
+import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/features/ai_coach/domain/entities/ai_coach_state.dart';
+import 'package:oncare/features/ai_coach/presentation/controllers/ai_coach_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 
 /// "AI 건강 도우미" bottom sheet — the daily coaching digest opened from the
@@ -50,13 +54,49 @@ List<_CoachCard> _cardsOf(AppLocalizations l) => <_CoachCard>[
   ),
 ];
 
-class _CoachingSheet extends StatelessWidget {
+String _suggestionTagLabel(AiSuggestionTag tag) => switch (tag) {
+  AiSuggestionTag.diet => '식단',
+  AiSuggestionTag.exercise => '운동',
+  AiSuggestionTag.sleep => '수면',
+  AiSuggestionTag.hydration => '수분',
+};
+
+Color _suggestionTagColor(AiSuggestionTag tag) => switch (tag) {
+  AiSuggestionTag.diet => FigmaColors.orange,
+  AiSuggestionTag.exercise => FigmaColors.greenTag,
+  AiSuggestionTag.sleep => FigmaColors.sugarPurple,
+  AiSuggestionTag.hydration => FigmaColors.primary,
+};
+
+_CoachCard _cardFromSuggestion(AiSuggestion s) => _CoachCard(
+  tag: _suggestionTagLabel(s.tag),
+  tagColor: _suggestionTagColor(s.tag),
+  title: s.title,
+  body: s.body,
+  done: false,
+);
+
+class _CoachingSheet extends ConsumerWidget {
   const _CoachingSheet();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final AppLocalizations l = AppLocalizations.of(context);
-    final List<_CoachCard> cards = _cardsOf(l);
+    // 데모/목 모드는 기존 하드코딩 카드를 유지(둘러보기 화면 동일). 실모드에서만
+    // /ai-coach/feedback 의 실제 제안을 렌더하고, 로딩/에러/빈 응답은 기존 카드로 폴백.
+    final List<_CoachCard> cards;
+    if (ref.watch(appConfigProvider).useMockApi) {
+      cards = _cardsOf(l);
+    } else {
+      final List<AiSuggestion>? live = ref
+          .watch(aiCoachStateProvider)
+          .asData
+          ?.value
+          .suggestions;
+      cards = (live == null || live.isEmpty)
+          ? _cardsOf(l)
+          : live.map(_cardFromSuggestion).toList();
+    }
 
     return SafeArea(
       top: false,
@@ -142,7 +182,10 @@ class _CoachingSheet extends StatelessWidget {
                         borderRadius: BorderRadius.circular(16),
                       ),
                     ),
-                    icon: const Icon(Icons.chat_bubble_outline_rounded, size: 19),
+                    icon: const Icon(
+                      Icons.chat_bubble_outline_rounded,
+                      size: 19,
+                    ),
                     label: Text(
                       l.coachCtaChat,
                       style: const TextStyle(

--- a/frontend/flutter/test/features/dashboard/dashboard_controller_test.dart
+++ b/frontend/flutter/test/features/dashboard/dashboard_controller_test.dart
@@ -164,4 +164,51 @@ void main() {
     expect(legacy.nutritionWeek, isEmpty);
     expect(legacy.nutritionWeekPrev, isEmpty);
   });
+
+  test('isEmpty stays false when only past weekdays have diet records', () {
+    Map<String, Object?> base(List<Object?> week) => <String, Object?>{
+      'indicators': <Object?>[],
+      'diet_entries': 0,
+      'exercise_minutes': 0,
+      'today_schedule': <Object?>[],
+      'nutrition_week': week,
+      'week_score': 50,
+      'week_score_delta': 0,
+      'sodium_warning': null,
+      'exercise_feedback': null,
+    };
+
+    // 오늘 기록이 없어도(diet_entries=0, 칼로리 지표 0) 이번 주 과거 요일에
+    // 실제 식단 기록이 있으면 홈은 비어 있지 않다 — 주간 추이 차트가 표시돼야 한다.
+    final withPastWeek = DashboardSummary.fromJson(
+      base(<Object?>[
+        <String, Object?>{
+          'label': '월',
+          'calories': 1650,
+          'sodium_mg': 1600,
+          'sugar_g': 30,
+        },
+        <String, Object?>{
+          'label': '화',
+          'calories': 0,
+          'sodium_mg': 0,
+          'sugar_g': 0,
+        },
+      ]),
+    );
+    expect(withPastWeek.isEmpty, isFalse);
+
+    // 주간에도 유효 기록이 하나도 없으면(모두 0) 여전히 비어 있다.
+    final allZero = DashboardSummary.fromJson(
+      base(<Object?>[
+        <String, Object?>{
+          'label': '월',
+          'calories': 0,
+          'sodium_mg': 0,
+          'sugar_g': 0,
+        },
+      ]),
+    );
+    expect(allZero.isEmpty, isTrue);
+  });
 }

--- a/frontend/flutter/test/features/dashboard/dashboard_controller_test.dart
+++ b/frontend/flutter/test/features/dashboard/dashboard_controller_test.dart
@@ -106,4 +106,62 @@ void main() {
     expect(legacy.macros.carbsPct, 0);
     expect(legacy.isEmpty, isTrue);
   });
+
+  test('DashboardSummary parses nutrition_week + burn goal, defaults older', () {
+    final parsed = DashboardSummary.fromJson(<String, Object?>{
+      'indicators': <Object?>[],
+      'diet_entries': 0,
+      'exercise_minutes': 0,
+      'exercise_burn_goal': 700,
+      'nutrition_week': <Object?>[
+        <String, Object?>{
+          'label': '월',
+          'calories': 1650,
+          'sodium_mg': 1600,
+          'sugar_g': 30,
+        },
+        <String, Object?>{
+          'label': '화',
+          'calories': 2100,
+          'sodium_mg': 1900,
+          'sugar_g': 48,
+        },
+      ],
+      'nutrition_week_prev': <Object?>[
+        <String, Object?>{
+          'label': '월',
+          'calories': 1820,
+          'sodium_mg': 1900,
+          'sugar_g': 35,
+        },
+      ],
+      'today_schedule': <Object?>[],
+      'week_score': 70,
+      'week_score_delta': -5,
+      'sodium_warning': null,
+      'exercise_feedback': null,
+    });
+    expect(parsed.exerciseBurnGoal, 700);
+    expect(parsed.nutritionWeek.length, 2);
+    expect(parsed.nutritionWeek.first.label, '월');
+    expect(parsed.nutritionWeek.first.calories, 1650);
+    expect(parsed.nutritionWeek.first.sodiumMg, 1600);
+    expect(parsed.nutritionWeekPrev.length, 1);
+    expect(parsed.weekScoreDelta, -5);
+
+    // 구버전 응답: 새 필드가 없으면 기본값(빈 주간·소모목표 500)으로 폴백.
+    final legacy = DashboardSummary.fromJson(<String, Object?>{
+      'indicators': <Object?>[],
+      'diet_entries': 0,
+      'exercise_minutes': 0,
+      'today_schedule': <Object?>[],
+      'week_score': 50,
+      'week_score_delta': 0,
+      'sodium_warning': null,
+      'exercise_feedback': null,
+    });
+    expect(legacy.exerciseBurnGoal, 500);
+    expect(legacy.nutritionWeek, isEmpty);
+    expect(legacy.nutritionWeekPrev, isEmpty);
+  });
 }


### PR DESCRIPTION
## Summary
#306(대시보드 실데이터) 이후 남아 있던 홈 화면의 잔여 하드코딩·no-op을 한 번에 마무리한다. 홈 4개 이슈(#320/#321/#328/#331)를 함께 처리했다 — 모두 `dashboard_content.dart` 등 같은 파일을 건드려 개별 PR로 나누면 서로 충돌하기 때문이다. **데모 둘러보기(목 모드) 화면은 기존과 동일하게 유지**했다.

## Changes
### #321 — 식단 주간 추이 실 집계
- 백엔드 `/dashboard/summary` 확장: 이번 주/지난 주 **월~일 달력 주** 일별 영양 집계(`nutrition_week`, `nutrition_week_prev`). 차트 x축이 고정 월~일이라 캘린더 주 기준으로 정렬을 맞춤.
- 프론트 주간 추이 차트를 이 실데이터로 연결. 실 집계가 비면(데모/목·기록 없음) 기존 데모 상수로 폴백.

### #331 — 잔여 고정값 실집계
- `week_score_delta`: 지난주 대비 실제 차이로 집계(동일 공식 `_score_for` 재사용, 하드코딩 `5` 제거). *현재 홈 UI에 미표시(#306이 건강점수 카드 제거)라 백엔드 정합성 개선.*
- 운동 소모 목표: 프론트 하드코딩 `500` 제거 → `exercise_burn_goal` 응답 필드 소비.
- 수분 제안: `coach_service`에서 오늘 나트륨/시간대 기반 규칙으로 전환(고정 문구 제거).

### #320 — 전체보기·일정 네비게이션(no-op 수정)
- "이번 주 AI 추천 식단 전체보기" → 식단 탭(`context.go(AppRoutes.diet)`).
- "오늘의 일정 전체보기"·일정 항목 카드 → 일정 캘린더 시트(`showScheduleCalendarSheet`).

### #328 — AI 코칭 시트 실 연결
- `coaching_sheet`를 `ConsumerWidget`으로 전환: 실모드는 `/ai-coach/feedback`(`aiCoachStateProvider`)의 실제 제안을 렌더. 로딩/에러/빈 응답 및 데모/목 모드는 기존 하드코딩 카드로 폴백.

### 계약
- `DashboardSummary`에 `nutritionWeek`/`nutritionWeekPrev`/`exerciseBurnGoal` 필드+파싱 추가(기본값으로 하위호환).

## Verification
- `flutter analyze`(전체) → No issues. `dart format` 적용.
- `flutter test test/features/dashboard` → 12 passed(주간추이·소모목표 파싱 테스트 추가).
- 백엔드 `test_dashboard`: `_score_for` 단위 + 주간추이(월~일 7일)·소모목표·delta 검증 추가.
- 브라우저(데모 둘러보기)로 확인: 홈 주간 추이 차트·AI 배너·운동 카드 소모목표(/500)·코칭 시트가 **기존 데모와 동일**하게 렌더, 하단 네비 탭 정상.

## Notes
- 운동 카드의 **주간 소모 막대**(`_demoExerciseWeekCalories`)는 일별 운동 집계 API가 없어 이번 범위에서 데모 유지(후속).
- 소모 목표는 개인화 소스가 없어 서버 기본값(500). health goals 연동은 후속.

Closes #320
Closes #321
Closes #328
Closes #331


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 대시보드에 이번 주와 지난주의 일별 칼로리·나트륨·당류 추이를 제공합니다.
  * 운동 소모 목표와 지난주 대비 주간 점수 변화를 실제 기록 기반으로 표시합니다.
  * 추천 식단 및 주간 일정 전체보기와 일정 항목 바로가기를 지원합니다.
  * 코칭 화면에서 실시간 AI 추천을 카드 형태로 표시합니다.

* **개선**
  * 운동 달성률이 설정된 소모 목표에 맞춰 정확히 계산됩니다.
  * 나트륨 섭취량과 시간대에 따라 수분 섭취 안내가 달라집니다.
  * 기존 데이터에서도 새 대시보드 정보가 안정적으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->