### PR TITLE
feat(trainer-clients): connect clients/diet/history to real API + roster priority

### DIFF
--- a/frontend/flutter_trainer/lib/features/clients/data/dtos/client_dtos.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/dtos/client_dtos.dart
@@ -52,21 +52,23 @@ RoutineHistoryEntry routineHistoryEntryFromJson(Map<String, Object?> json) {
 /// target ("확인 필요") first, keeping the server order otherwise. Pure and
 /// stable so both the Dio and drift repositories can share it and tests
 /// can assert it directly.
+///
+/// `List.sort` isn't guaranteed stable, so the original position travels
+/// with each client as a decorate-sort tie-breaker (undecorate after) —
+/// unlike an id-keyed lookup, this can't collide on a duplicate/missing id
+/// (review).
 List<TrainerClient> prioritizeClients(List<TrainerClient> clients) {
-  final ordered = List<TrainerClient>.of(clients);
-  // List.sort is not guaranteed stable; use the original index as a
-  // tie-breaker so same-priority clients keep the server order.
-  final index = <String, int>{
-    for (var i = 0; i < ordered.length; i++) ordered[i].id: i,
-  };
-  ordered.sort((a, b) {
-    final over = (b.sodiumOverBudget ? 1 : 0).compareTo(
-      a.sodiumOverBudget ? 1 : 0,
+  final decorated = <(TrainerClient client, int index)>[
+    for (var i = 0; i < clients.length; i++) (clients[i], i),
+  ];
+  decorated.sort((a, b) {
+    final over = (b.$1.sodiumOverBudget ? 1 : 0).compareTo(
+      a.$1.sodiumOverBudget ? 1 : 0,
     );
     if (over != 0) return over;
-    return (index[a.id] ?? 0).compareTo(index[b.id] ?? 0);
+    return a.$2.compareTo(b.$2);
   });
-  return ordered;
+  return <TrainerClient>[for (final d in decorated) d.$1];
 }
 
 String _str(Object? v) => v is String ? v : '';

--- a/frontend/flutter_trainer/lib/features/clients/data/dtos/client_dtos.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/dtos/client_dtos.dart
@@ -1,0 +1,83 @@
+import 'package:oncare_trainer/features/clients/domain/entities/client_diet_entry.dart';
+import 'package:oncare_trainer/features/clients/domain/entities/routine_history_entry.dart';
+import 'package:oncare_trainer/shared/models/trainer_client.dart';
+
+/// Maps the trainer clients/diet/history JSON (the FastAPI `TrainerClientOut`
+/// / `ClientDietEntryOut` / `RoutineHistoryOut` schemas) into domain
+/// entities. Kept separate from the Dio repository so the DTO ↔ domain
+/// mapping is unit-testable and shared with any future source.
+
+/// `GET /v1/trainer/clients` element → [TrainerClient].
+TrainerClient trainerClientFromJson(Map<String, Object?> json) {
+  return TrainerClient(
+    id: _str(json['id']),
+    name: _str(json['name']),
+    avatar: _str(json['avatar']),
+    goal: _str(json['goal']),
+    lastMessage: _str(json['last_message']),
+    lastTime: _str(json['last_time']),
+    active: json['active'] == true,
+    calories: _int(json['calories']),
+    sodiumMg: _int(json['sodium_mg']),
+    sugarG: _int(json['sugar_g']),
+    lastRoutine: _str(json['last_routine']),
+    weekCompletion: _intList(json['week_completion']),
+    sodiumWeek: _intList(json['sodium_week']),
+  );
+}
+
+/// `GET /v1/trainer/clients/{id}/diet` element → [ClientDietEntry].
+ClientDietEntry clientDietEntryFromJson(Map<String, Object?> json) {
+  return ClientDietEntry(
+    meal: _str(json['meal']),
+    items: _str(json['items']),
+    calories: _int(json['calories']),
+    sodiumMg: _int(json['sodium_mg']),
+  );
+}
+
+/// `GET /v1/trainer/clients/{id}/history` element → [RoutineHistoryEntry].
+RoutineHistoryEntry routineHistoryEntryFromJson(Map<String, Object?> json) {
+  return RoutineHistoryEntry(
+    dateLabel: _str(json['date_label']),
+    label: _str(json['label']),
+    completionRate: _int(json['completion_rate']),
+    exercises: _strList(json['exercises']),
+    clientFeedback: _str(json['client_feedback']),
+    trainerNote: _str(json['trainer_note']),
+  );
+}
+
+/// Orders the roster by coaching priority: clients over their sodium
+/// target ("확인 필요") first, keeping the server order otherwise. Pure and
+/// stable so both the Dio and drift repositories can share it and tests
+/// can assert it directly.
+List<TrainerClient> prioritizeClients(List<TrainerClient> clients) {
+  final ordered = List<TrainerClient>.of(clients);
+  // List.sort is not guaranteed stable; use the original index as a
+  // tie-breaker so same-priority clients keep the server order.
+  final index = <String, int>{
+    for (var i = 0; i < ordered.length; i++) ordered[i].id: i,
+  };
+  ordered.sort((a, b) {
+    final over = (b.sodiumOverBudget ? 1 : 0).compareTo(
+      a.sodiumOverBudget ? 1 : 0,
+    );
+    if (over != 0) return over;
+    return (index[a.id] ?? 0).compareTo(index[b.id] ?? 0);
+  });
+  return ordered;
+}
+
+String _str(Object? v) => v is String ? v : '';
+
+int _int(Object? v) => v is num ? v.toInt() : 0;
+
+// FastAPI emits JSON numbers that can decode as double on web — normalise
+// through num so `as int` never throws.
+List<int> _intList(Object? v) => v is List
+    ? v.whereType<num>().map((n) => n.toInt()).toList(growable: false)
+    : const <int>[];
+
+List<String> _strList(Object? v) =>
+    v is List ? v.whereType<String>().toList(growable: false) : const <String>[];

--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_client_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_client_repository.dart
@@ -21,6 +21,9 @@ class DioClientRepository implements ClientRepository {
   final Dio _dio;
 
   @override
+  bool get supportsRosterMutations => false;
+
+  @override
   Stream<List<TrainerClient>> watchClients() =>
       Stream<List<TrainerClient>>.fromFuture(_fetchClients());
 
@@ -45,20 +48,18 @@ class DioClientRepository implements ClientRepository {
   Stream<List<RoutineHistoryEntry>> watchHistory(String clientId) =>
       Stream<List<RoutineHistoryEntry>>.fromFuture(_fetchHistory(clientId));
 
-  Future<List<TrainerClient>> _fetchClients() => _getList(
-        '/trainer/clients',
-        trainerClientFromJson,
-      );
+  Future<List<TrainerClient>> _fetchClients() =>
+      _getList('/trainer/clients', trainerClientFromJson);
 
   Future<List<ClientDietEntry>> _fetchDiet(String clientId) => _getList(
-        '/trainer/clients/$clientId/diet',
-        clientDietEntryFromJson,
-      );
+    '/trainer/clients/${Uri.encodeComponent(clientId)}/diet',
+    clientDietEntryFromJson,
+  );
 
   Future<List<RoutineHistoryEntry>> _fetchHistory(String clientId) => _getList(
-        '/trainer/clients/$clientId/history',
-        routineHistoryEntryFromJson,
-      );
+    '/trainer/clients/${Uri.encodeComponent(clientId)}/history',
+    routineHistoryEntryFromJson,
+  );
 
   /// GETs a JSON array and maps each element with [fromJson]. Transport /
   /// HTTP failures (incl. 404 for a client that isn't this trainer's)
@@ -71,8 +72,14 @@ class DioClientRepository implements ClientRepository {
       final res = await _dio.get<List<dynamic>>(path);
       final data = res.data ?? const <dynamic>[];
       return data
-          .whereType<Map<String, Object?>>()
-          .map(fromJson)
+          .map((item) {
+            if (item is! Map<String, Object?>) {
+              throw FormatException(
+                'Expected an object in the response list for $path.',
+              );
+            }
+            return fromJson(item);
+          })
           .toList(growable: false);
     } on DioException catch (e) {
       throw AppError.fromDio(e);
@@ -80,8 +87,9 @@ class DioClientRepository implements ClientRepository {
   }
 
   @override
-  Future<bool> clientNameExists(String name) =>
-      throw UnsupportedError('clientNameExists is demo-only (no backend endpoint).');
+  Future<bool> clientNameExists(String name) => throw UnsupportedError(
+    'clientNameExists is demo-only (no backend endpoint).',
+  );
 
   @override
   Future<bool> addClient({required String name, required String goal}) =>
@@ -89,5 +97,7 @@ class DioClientRepository implements ClientRepository {
 
   @override
   Future<void> setClientActive(String id, bool active) =>
-      throw UnsupportedError('setClientActive is demo-only (no backend endpoint).');
+      throw UnsupportedError(
+        'setClientActive is demo-only (no backend endpoint).',
+      );
 }

--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_client_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_client_repository.dart
@@ -1,0 +1,93 @@
+import 'package:dio/dio.dart';
+
+import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/features/clients/data/dtos/client_dtos.dart';
+import 'package:oncare_trainer/features/clients/domain/entities/client_diet_entry.dart';
+import 'package:oncare_trainer/features/clients/domain/entities/routine_history_entry.dart';
+import 'package:oncare_trainer/shared/models/trainer_client.dart';
+import 'package:oncare_trainer/shared/services/client_repository.dart';
+
+/// Reads a trainer's clients + their diet/history from the FastAPI backend.
+/// Selected when `USE_MOCK_API=false` (see [clientRepositoryProvider]).
+///
+/// Reads return single-emit streams (fetch → value); the consuming
+/// `AsyncValue` renders loading/error/empty. Roster mutations have no
+/// backend endpoint (the roster is derived from trainer↔member links), so
+/// they throw [UnsupportedError] — the demo-only add/activate UI is hidden
+/// in real-API mode.
+class DioClientRepository implements ClientRepository {
+  DioClientRepository(this._dio);
+
+  final Dio _dio;
+
+  @override
+  Stream<List<TrainerClient>> watchClients() =>
+      Stream<List<TrainerClient>>.fromFuture(_fetchClients());
+
+  @override
+  Stream<List<TrainerClient>> watchClientsPrioritized() =>
+      Stream<List<TrainerClient>>.fromFuture(
+        _fetchClients().then(prioritizeClients),
+      );
+
+  /// Today's booked-session count is schedule-derived (a later issue wires
+  /// `/trainer/schedule`). Emitting nothing keeps the header badge hidden
+  /// (its provider stays loading → `valueOrNull` is null) rather than
+  /// showing a stale/zero count over real clients.
+  @override
+  Stream<int> watchTodayReservationCount() => const Stream<int>.empty();
+
+  @override
+  Stream<List<ClientDietEntry>> watchDiet(String clientId) =>
+      Stream<List<ClientDietEntry>>.fromFuture(_fetchDiet(clientId));
+
+  @override
+  Stream<List<RoutineHistoryEntry>> watchHistory(String clientId) =>
+      Stream<List<RoutineHistoryEntry>>.fromFuture(_fetchHistory(clientId));
+
+  Future<List<TrainerClient>> _fetchClients() => _getList(
+        '/trainer/clients',
+        trainerClientFromJson,
+      );
+
+  Future<List<ClientDietEntry>> _fetchDiet(String clientId) => _getList(
+        '/trainer/clients/$clientId/diet',
+        clientDietEntryFromJson,
+      );
+
+  Future<List<RoutineHistoryEntry>> _fetchHistory(String clientId) => _getList(
+        '/trainer/clients/$clientId/history',
+        routineHistoryEntryFromJson,
+      );
+
+  /// GETs a JSON array and maps each element with [fromJson]. Transport /
+  /// HTTP failures (incl. 404 for a client that isn't this trainer's)
+  /// surface as a typed [AppError].
+  Future<List<T>> _getList<T>(
+    String path,
+    T Function(Map<String, Object?>) fromJson,
+  ) async {
+    try {
+      final res = await _dio.get<List<dynamic>>(path);
+      final data = res.data ?? const <dynamic>[];
+      return data
+          .whereType<Map<String, Object?>>()
+          .map(fromJson)
+          .toList(growable: false);
+    } on DioException catch (e) {
+      throw AppError.fromDio(e);
+    }
+  }
+
+  @override
+  Future<bool> clientNameExists(String name) =>
+      throw UnsupportedError('clientNameExists is demo-only (no backend endpoint).');
+
+  @override
+  Future<bool> addClient({required String name, required String goal}) =>
+      throw UnsupportedError('addClient is demo-only (no backend endpoint).');
+
+  @override
+  Future<void> setClientActive(String id, bool active) =>
+      throw UnsupportedError('setClientActive is demo-only (no backend endpoint).');
+}

--- a/frontend/flutter_trainer/lib/features/clients/presentation/pages/clients_page.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/pages/clients_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/core/config/app_config.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/elevation.dart';
 import 'package:oncare_trainer/design_system/tokens/layout.dart';
@@ -47,6 +48,10 @@ class ClientsPage extends ConsumerWidget {
     final reservations = ref.watch(todayReservationCountProvider).valueOrNull;
     final unread =
         ref.watch(unreadCountsProvider).valueOrNull ?? const <String, int>{};
+    // Roster mutations exist only in demo/mock mode — the real backend has
+    // no add-client endpoint (the roster is derived from trainer↔member
+    // links), so hide the 신규 고객 등록 entry when hitting the real API.
+    final canManageRoster = ref.watch(appConfigProvider).useMockApi;
 
     return Scaffold(
       backgroundColor: AppColors.background,
@@ -85,7 +90,9 @@ class ClientsPage extends ConsumerWidget {
                     onOpen: (id) => wide
                         ? context.go(_clientsLocation(id))
                         : context.push(AppRoutes.clientDetail(id)),
-                    onAddClient: () => _openAddClientSheet(context),
+                    onAddClient: canManageRoster
+                        ? () => _openAddClientSheet(context)
+                        : null,
                   ),
                 );
               }
@@ -105,7 +112,9 @@ class ClientsPage extends ConsumerWidget {
                         // Selecting swaps the right panel (and the URL)
                         // instead of pushing a new screen.
                         onOpen: (id) => context.go(_clientsLocation(id)),
-                        onAddClient: () => _openAddClientSheet(context),
+                        onAddClient: canManageRoster
+                            ? () => _openAddClientSheet(context)
+                            : null,
                       ),
                     ),
                     const VerticalDivider(
@@ -160,8 +169,9 @@ class _ClientsView extends StatelessWidget {
   /// Invoked with the tapped client's id.
   final ValueChanged<String> onOpen;
 
-  /// Opens the 신규 고객 등록 sheet.
-  final VoidCallback onAddClient;
+  /// Opens the 신규 고객 등록 sheet, or `null` to hide the entry (real-API
+  /// mode has no add-client endpoint).
+  final VoidCallback? onAddClient;
 
   @override
   Widget build(BuildContext context) {
@@ -220,11 +230,12 @@ class _ClientsView extends StatelessWidget {
           ),
           const SizedBox(height: AppSpacing.md),
         ],
-        OutlinedActionButton(
-          label: '＋ 신규 고객 등록',
-          color: AppColors.accent,
-          onTap: onAddClient,
-        ),
+        if (onAddClient != null)
+          OutlinedActionButton(
+            label: '＋ 신규 고객 등록',
+            color: AppColors.accent,
+            onTap: onAddClient!,
+          ),
       ],
     );
   }

--- a/frontend/flutter_trainer/lib/features/clients/presentation/pages/clients_page.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/pages/clients_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
-import 'package:oncare_trainer/core/config/app_config.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/elevation.dart';
 import 'package:oncare_trainer/design_system/tokens/layout.dart';
@@ -51,7 +50,9 @@ class ClientsPage extends ConsumerWidget {
     // Roster mutations exist only in demo/mock mode — the real backend has
     // no add-client endpoint (the roster is derived from trainer↔member
     // links), so hide the 신규 고객 등록 entry when hitting the real API.
-    final canManageRoster = ref.watch(appConfigProvider).useMockApi;
+    final canManageRoster = ref
+        .watch(clientRepositoryProvider)
+        .supportsRosterMutations;
 
     return Scaffold(
       backgroundColor: AppColors.background,

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
@@ -55,6 +55,9 @@ class _ClientDetailViewState extends ConsumerState<ClientDetailView> {
     // into an empty list (an unknown id used to render a nameless
     // "고객" chat and never-ending 식단/운동 spinners — codex review).
     final clientsAsync = ref.watch(clientsProvider);
+    final canManageRoster = ref
+        .watch(clientRepositoryProvider)
+        .supportsRosterMutations;
     return clientsAsync.when(
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (e, _) => _StatusView(
@@ -81,9 +84,11 @@ class _ClientDetailViewState extends ConsumerState<ClientDetailView> {
               client: client,
               showBack: widget.showBack,
               onClose: widget.onClose,
-              onToggleActive: () => ref
-                  .read(clientRepositoryProvider)
-                  .setClientActive(client.id, !client.active),
+              onToggleActive: canManageRoster
+                  ? () => ref
+                        .read(clientRepositoryProvider)
+                        .setClientActive(client.id, !client.active)
+                  : null,
             ),
             _SubTabs(current: _tab, onChanged: (i) => setState(() => _tab = i)),
             Expanded(child: _body(client)),
@@ -171,7 +176,7 @@ class _Header extends StatelessWidget {
   final VoidCallback? onClose;
 
   /// Flips the client between 활성 and 휴면.
-  final VoidCallback onToggleActive;
+  final VoidCallback? onToggleActive;
 
   @override
   Widget build(BuildContext context) {
@@ -221,7 +226,9 @@ class _Header extends StatelessWidget {
               ],
             ),
           ),
-          // Tappable status chip — toggles 활성/휴면.
+          // The backend roster has no status mutation endpoint yet. Keep the
+          // status visible in real mode, but only make it interactive when
+          // the selected repository supports roster mutations.
           Material(
             color:
                 (client.active
@@ -230,6 +237,7 @@ class _Header extends StatelessWidget {
                     .withValues(alpha: 0.12),
             borderRadius: const BorderRadius.all(AppRadius.pill),
             child: InkWell(
+              key: const ValueKey<String>('client-status-toggle'),
               onTap: onToggleActive,
               borderRadius: const BorderRadius.all(AppRadius.pill),
               child: Padding(

--- a/frontend/flutter_trainer/lib/shared/services/client_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/client_repository.dart
@@ -23,6 +23,12 @@ import 'package:oncare_trainer/shared/models/trainer_client.dart';
 /// Dio source emits a single fetched value (loading/error surface through
 /// the consuming `AsyncValue`).
 abstract interface class ClientRepository {
+  /// Whether this source supports adding clients and changing roster status.
+  ///
+  /// The real roster is managed by trainer-member links on the backend and
+  /// currently has no mutation endpoints, so its UI must stay read-only.
+  bool get supportsRosterMutations;
+
   Stream<List<TrainerClient>> watchClients();
   Stream<List<TrainerClient>> watchClientsPrioritized();
   Stream<int> watchTodayReservationCount();
@@ -44,6 +50,9 @@ class DriftClientRepository implements ClientRepository {
   const DriftClientRepository(this._db);
 
   final AppDatabase _db;
+
+  @override
+  bool get supportsRosterMutations => true;
 
   /// All clients, ordered as seeded (sortOrder).
   @override

--- a/frontend/flutter_trainer/lib/shared/services/client_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/client_repository.dart
@@ -3,22 +3,50 @@ import 'dart:convert';
 import 'package:drift/drift.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/core/network/dio_client.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/utils/date_format.dart';
+import 'package:oncare_trainer/features/clients/data/repositories/dio_client_repository.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/client_diet_entry.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/routine_history_entry.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
 
+/// Reads a trainer's clients + their diet/history for the 고객 관리 tab.
+///
+/// Two implementations sit behind this contract (selected by
+/// [clientRepositoryProvider] via [AppConfig.useMockApi]):
+///  * [DriftClientRepository] — local drift, demo / `USE_MOCK_API=true`;
+///  * [DioClientRepository] — the real FastAPI backend.
+///
+/// Reads are exposed as streams so the drift source can stay reactive; the
+/// Dio source emits a single fetched value (loading/error surface through
+/// the consuming `AsyncValue`).
+abstract interface class ClientRepository {
+  Stream<List<TrainerClient>> watchClients();
+  Stream<List<TrainerClient>> watchClientsPrioritized();
+  Stream<int> watchTodayReservationCount();
+  Stream<List<ClientDietEntry>> watchDiet(String clientId);
+  Stream<List<RoutineHistoryEntry>> watchHistory(String clientId);
+
+  /// Demo-only roster mutations — the backend roster comes from
+  /// trainer↔member links, so these are unsupported against the real API.
+  Future<bool> clientNameExists(String name);
+  Future<bool> addClient({required String name, required String goal});
+  Future<void> setClientActive(String id, bool active);
+}
+
 /// Reads client + schedule data from the local drift DB for the
 /// 고객 관리 tab. Returns reactive streams so the UI updates if the
 /// underlying rows change (e.g. a routine sent from another tab).
-class ClientRepository {
+class DriftClientRepository implements ClientRepository {
   /// Creates the repository over [_db].
-  const ClientRepository(this._db);
+  const DriftClientRepository(this._db);
 
   final AppDatabase _db;
 
   /// All clients, ordered as seeded (sortOrder).
+  @override
   Stream<List<TrainerClient>> watchClients() {
     final query = _db.select(_db.trainerClients)
       ..orderBy(<OrderingTerm Function($TrainerClientsTable)>[
@@ -30,6 +58,7 @@ class ClientRepository {
   /// Clients ordered by coaching priority for the 고객 관리 list:
   /// sodium-over-target clients first, ties broken by the most recent
   /// chat activity, then by the seeded order.
+  @override
   Stream<List<TrainerClient>> watchClientsPrioritized() {
     final t = _db.trainerClients;
     final chat = _db.clientChatMessages;
@@ -71,6 +100,7 @@ class ClientRepository {
   /// Whether a client with this display name already exists
   /// (whitespace- and case-insensitive). Counts in SQL rather than
   /// loading every row into memory (review PR 243).
+  @override
   Future<bool> clientNameExists(String name) async {
     final key = name.trim().toLowerCase();
     if (key.isEmpty) return false;
@@ -108,6 +138,7 @@ class ClientRepository {
   /// The duplicate check and the insert run in ONE transaction, so two
   /// concurrent adds of the same name can't both pass the check and both
   /// insert — exactly one wins, the other returns `false` (review 243).
+  @override
   Future<bool> addClient({required String name, required String goal}) async {
     final trimmedName = name.trim();
     if (trimmedName.isEmpty) return false;
@@ -142,6 +173,7 @@ class ClientRepository {
   }
 
   /// Flips a client between 활성 and 휴면.
+  @override
   Future<void> setClientActive(String id, bool active) async {
     await (_db.update(_db.trainerClients)..where((t) => t.id.equals(id))).write(
       TrainerClientsCompanion(active: Value(active)),
@@ -151,6 +183,7 @@ class ClientRepository {
   /// Count of today's booked sessions — every schedule slot dated today
   /// that isn't a gap (`공백`). Drives the "오늘 N명 예약" header badge.
   /// Uses a SQL `COUNT(*)` aggregate rather than loading every row.
+  @override
   Stream<int> watchTodayReservationCount() {
     final today = ymd(DateTime.now());
     final table = _db.trainerScheduleEntries;
@@ -162,6 +195,7 @@ class ClientRepository {
   }
 
   /// A client's meals for the 식단 sub-tab, in seeded order (아침 → 저녁).
+  @override
   Stream<List<ClientDietEntry>> watchDiet(String clientId) {
     final query = _db.select(_db.clientDietEntries)
       ..where((t) => t.clientId.equals(clientId))
@@ -184,6 +218,7 @@ class ClientRepository {
 
   /// A client's workout history for the 운동기록 sub-tab, newest first
   /// (seeded order).
+  @override
   Stream<List<RoutineHistoryEntry>> watchHistory(String clientId) {
     final query = _db.select(_db.clientRoutineHistory)
       ..where((t) => t.clientId.equals(clientId))
@@ -235,9 +270,14 @@ class ClientRepository {
   }
 }
 
-/// Provides the [ClientRepository] wired to the app database.
+/// Provides the [ClientRepository]: the real Dio-backed source against the
+/// FastAPI backend, or the local drift source for demo / `USE_MOCK_API=true`.
 final clientRepositoryProvider = Provider<ClientRepository>((ref) {
-  return ClientRepository(ref.watch(appDatabaseProvider));
+  final config = ref.watch(appConfigProvider);
+  if (config.useMockApi) {
+    return DriftClientRepository(ref.watch(appDatabaseProvider));
+  }
+  return DioClientRepository(ref.watch(dioProvider));
 });
 
 /// Streams the client list for the 고객 관리 tab.

--- a/frontend/flutter_trainer/lib/shared/services/client_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/client_repository.dart
@@ -7,6 +7,7 @@ import 'package:oncare_trainer/core/config/app_config.dart';
 import 'package:oncare_trainer/core/network/dio_client.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/utils/date_format.dart';
+import 'package:oncare_trainer/features/clients/data/dtos/client_dtos.dart' show prioritizeClients;
 import 'package:oncare_trainer/features/clients/data/repositories/dio_client_repository.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/client_diet_entry.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/routine_history_entry.dart';
@@ -31,6 +32,14 @@ abstract interface class ClientRepository {
 
   Stream<List<TrainerClient>> watchClients();
   Stream<List<TrainerClient>> watchClientsPrioritized();
+
+  /// Today's booked-session count for the header badge.
+  ///
+  /// Contract: an implementation with no reservation data source (the real
+  /// API doesn't wire `/trainer/schedule` yet) should emit nothing rather
+  /// than `0` — the consuming `StreamProvider` then stays in its initial
+  /// loading state, whose `valueOrNull` is `null`, and the UI hides the
+  /// badge instead of showing a misleading "0명 예약".
   Stream<int> watchTodayReservationCount();
   Stream<List<ClientDietEntry>> watchDiet(String clientId);
   Stream<List<RoutineHistoryEntry>> watchHistory(String clientId);
@@ -294,10 +303,26 @@ final clientsProvider = StreamProvider<List<TrainerClient>>((ref) {
   return ref.watch(clientRepositoryProvider).watchClients();
 });
 
-/// Streams the coaching-priority ordering of the client list (sodium
-/// over-target first, then most recent chat) for the 고객 관리 tab.
+/// Streams the coaching-priority ordering of the client list for the
+/// 고객 관리 tab.
+///
+///  * demo/mock — sodium over-target first, ties broken by most recent
+///    chat activity (Drift's own reactive SQL query);
+///  * real API — sodium over-target first, ties broken by server order.
+///    There is no chat-recency signal yet on this endpoint, so this is
+///    derived from [clientsProvider]'s already-fetched data (via the pure
+///    [prioritizeClients]) rather than calling `watchClientsPrioritized()`
+///    independently — the two providers would otherwise each trigger their
+///    own `GET /trainer/clients` when a screen watches both at once (e.g.
+///    the list + detail split view) (review).
 final prioritizedClientsProvider = StreamProvider<List<TrainerClient>>((ref) {
-  return ref.watch(clientRepositoryProvider).watchClientsPrioritized();
+  if (ref.watch(appConfigProvider).useMockApi) {
+    return ref.watch(clientRepositoryProvider).watchClientsPrioritized();
+  }
+  // `.future` (not the deprecated `.stream`) — a single-emission stream is
+  // enough since the real source is itself one-shot; invalidating
+  // clientsProvider still re-triggers this via the ref.watch dependency.
+  return ref.watch(clientsProvider.future).asStream().map(prioritizeClients);
 });
 
 /// Streams today's booked-session count for the header badge.

--- a/frontend/flutter_trainer/lib/shared/services/client_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/client_repository.dart
@@ -310,19 +310,28 @@ final clientsProvider = StreamProvider<List<TrainerClient>>((ref) {
 ///    chat activity (Drift's own reactive SQL query);
 ///  * real API — sodium over-target first, ties broken by server order.
 ///    There is no chat-recency signal yet on this endpoint, so this is
-///    derived from [clientsProvider]'s already-fetched data (via the pure
+///    derived from [clientsProvider]'s `AsyncValue` (via the pure
 ///    [prioritizeClients]) rather than calling `watchClientsPrioritized()`
 ///    independently — the two providers would otherwise each trigger their
 ///    own `GET /trainer/clients` when a screen watches both at once (e.g.
 ///    the list + detail split view) (review).
+///
+/// Watching the `AsyncValue` itself (not `.future`, which only ever
+/// resolves once) means this rebuilds on every state `clientsProvider`
+/// passes through — not just its first value — so it can't go stale if
+/// `clientsProvider` is ever backed by something that re-emits without a
+/// full provider invalidation (e.g. a future polling/live source) (review).
 final prioritizedClientsProvider = StreamProvider<List<TrainerClient>>((ref) {
   if (ref.watch(appConfigProvider).useMockApi) {
     return ref.watch(clientRepositoryProvider).watchClientsPrioritized();
   }
-  // `.future` (not the deprecated `.stream`) — a single-emission stream is
-  // enough since the real source is itself one-shot; invalidating
-  // clientsProvider still re-triggers this via the ref.watch dependency.
-  return ref.watch(clientsProvider.future).asStream().map(prioritizeClients);
+  return ref
+      .watch(clientsProvider)
+      .when(
+        data: (clients) => Stream.value(prioritizeClients(clients)),
+        loading: () => const Stream<List<TrainerClient>>.empty(),
+        error: Stream<List<TrainerClient>>.error,
+      );
 });
 
 /// Streams today's booked-session count for the header badge.

--- a/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
@@ -18,7 +18,7 @@ void main() {
     tearDown(() => db.close());
 
     test('returns the 3 meals in seeded order for a client', () async {
-      final meals = await ClientRepository(db).watchDiet('seed-client-1').first;
+      final meals = await DriftClientRepository(db).watchDiet('seed-client-1').first;
       expect(meals.map((m) => m.meal).toList(), <String>['아침', '점심', '저녁']);
       expect(meals.first.items, '오트밀, 바나나');
       expect(meals.first.calories, 315);
@@ -26,7 +26,7 @@ void main() {
     });
 
     test('returns per-client data (clients differ)', () async {
-      final repo = ClientRepository(db);
+      final repo = DriftClientRepository(db);
       final jisu = await repo.watchDiet('seed-client-2').first;
       final seongho = await repo.watchDiet('seed-client-3').first;
       expect(jisu.first.items, '그릭요거트, 과일');
@@ -34,7 +34,7 @@ void main() {
     });
 
     test('client rows carry a 7-day sodium history ending at today', () async {
-      final clients = await ClientRepository(db).watchClients().first;
+      final clients = await DriftClientRepository(db).watchClients().first;
       for (final c in clients) {
         expect(c.sodiumWeek.length, 7);
         // The last entry mirrors today's total shown elsewhere.

--- a/frontend/flutter_trainer/test/features/clients/client_detail_workout_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_workout_test.dart
@@ -18,7 +18,7 @@ void main() {
     tearDown(() => db.close());
 
     test('returns 3 seeded workouts in order with decoded exercises', () async {
-      final history = await ClientRepository(
+      final history = await DriftClientRepository(
         db,
       ).watchHistory('seed-client-1').first;
       expect(history.length, 3);
@@ -31,7 +31,7 @@ void main() {
     });
 
     test('returns per-client data (clients differ)', () async {
-      final seongho = await ClientRepository(
+      final seongho = await DriftClientRepository(
         db,
       ).watchHistory('seed-client-3').first;
       expect(seongho.last.completionRate, 0); // 7/3 · all skipped

--- a/frontend/flutter_trainer/test/features/clients/client_dtos_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_dtos_test.dart
@@ -115,5 +115,47 @@ void main() {
       ]);
       expect(ordered.map((c) => c.id).toList(), <String>['a', 'b']);
     });
+
+    test(
+      'keeps server order within each priority group past the 32-item '
+      'insertion-sort threshold (Dart TimSort only needs to prove stable '
+      'above it — a smaller list can pass by accident, review)',
+      () {
+        // 40 clients, alternating over/under target, id = server position.
+        final input = <TrainerClient>[
+          for (var i = 0; i < 40; i++)
+            _client('c$i', sodiumMg: i.isEven ? 2500 : 500),
+        ];
+
+        final ordered = prioritizeClients(input);
+
+        final overIds = ordered
+            .where((c) => c.sodiumOverBudget)
+            .map((c) => int.parse(c.id.substring(1)))
+            .toList();
+        final underIds = ordered
+            .where((c) => !c.sodiumOverBudget)
+            .map((c) => int.parse(c.id.substring(1)))
+            .toList();
+
+        // Every over-target client precedes every under-target client...
+        expect(ordered.take(20).every((c) => c.sodiumOverBudget), isTrue);
+        expect(ordered.skip(20).every((c) => !c.sodiumOverBudget), isTrue);
+        // ...and each group is internally still in server (ascending) order.
+        expect(overIds, List<int>.generate(20, (i) => i * 2));
+        expect(underIds, List<int>.generate(20, (i) => i * 2 + 1));
+      },
+    );
+
+    test('a duplicate id does not corrupt the ordering (decorate-sort, '
+        'not an id-keyed tie-breaker, review)', () {
+      final ordered = prioritizeClients(<TrainerClient>[
+        _client('dup', sodiumMg: 2500), // index 0, over
+        _client('dup', sodiumMg: 500), // index 1, under — same id as above
+        _client('c', sodiumMg: 2600), // index 2, over
+      ]);
+
+      expect(ordered.map((c) => c.sodiumMg).toList(), <int>[2500, 2600, 500]);
+    });
   });
 }

--- a/frontend/flutter_trainer/test/features/clients/client_dtos_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_dtos_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/features/clients/data/dtos/client_dtos.dart';
+import 'package:oncare_trainer/shared/models/trainer_client.dart';
+
+TrainerClient _client(String id, {required int sodiumMg}) => TrainerClient(
+      id: id,
+      name: id,
+      avatar: id.substring(0, 1),
+      goal: '',
+      lastMessage: '',
+      lastTime: '',
+      active: true,
+      calories: 0,
+      sodiumMg: sodiumMg,
+      sugarG: 0,
+      lastRoutine: '',
+      weekCompletion: const <int>[],
+      sodiumWeek: const <int>[],
+    );
+
+void main() {
+  group('trainerClientFromJson', () {
+    test('maps a roster element (snake_case) into TrainerClient', () {
+      final c = trainerClientFromJson(<String, Object?>{
+        'id': 'm1',
+        'name': '김민수',
+        'avatar': '김',
+        'goal': '혈압 관리',
+        'last_message': '점심 등록했어요',
+        'last_time': '방금',
+        'active': true,
+        'calories': 1800,
+        'sodium_mg': 2100,
+        'sugar_g': 40,
+        'last_routine': '오늘',
+        'week_completion': <Object?>[100, 80, 0, 60, 90, 0, 0],
+        'sodium_week': <Object?>[1900, 2200, 2100],
+      });
+
+      expect(c.id, 'm1');
+      expect(c.name, '김민수');
+      expect(c.sodiumMg, 2100);
+      expect(c.sodiumOverBudget, isTrue); // 2100 > 2000 target
+      expect(c.weekCompletion, <int>[100, 80, 0, 60, 90, 0, 0]);
+      expect(c.sodiumWeek, <int>[1900, 2200, 2100]);
+    });
+
+    test('tolerates double-encoded numbers and missing lists (web JSON)', () {
+      final c = trainerClientFromJson(<String, Object?>{
+        'id': 'm2',
+        'name': '이지수',
+        'calories': 1500.0, // web can decode ints as double
+        'sodium_mg': 1800.0,
+        'week_completion': <Object?>[100.0, 50.0],
+        // sodium_week omitted
+      });
+
+      expect(c.calories, 1500);
+      expect(c.sodiumMg, 1800);
+      expect(c.weekCompletion, <int>[100, 50]);
+      expect(c.sodiumWeek, isEmpty);
+      expect(c.active, isFalse); // absent → false
+    });
+  });
+
+  group('clientDietEntryFromJson / routineHistoryEntryFromJson', () {
+    test('maps a diet entry', () {
+      final d = clientDietEntryFromJson(<String, Object?>{
+        'meal': '점심',
+        'items': '김치찌개, 공기밥',
+        'calories': 720,
+        'sodium_mg': 1400,
+      });
+      expect(d.meal, '점심');
+      expect(d.items, '김치찌개, 공기밥');
+      expect(d.sodiumMg, 1400);
+    });
+
+    test('maps a history entry with exercises list', () {
+      final h = routineHistoryEntryFromJson(<String, Object?>{
+        'date_label': '7/12 (오늘)',
+        'label': 'PT 세션',
+        'completion_rate': 80,
+        'exercises': <Object?>['스쿼트 3세트', '✗ 런지'],
+        'client_feedback': '무릎이 조금 아팠어요',
+        'trainer_note': '강도 조절',
+      });
+      expect(h.dateLabel, '7/12 (오늘)');
+      expect(h.completionRate, 80);
+      expect(h.exercises, <String>['스쿼트 3세트', '✗ 런지']);
+      expect(h.trainerNote, '강도 조절');
+    });
+  });
+
+  group('prioritizeClients', () {
+    test('moves sodium-over-target clients first, keeping server order', () {
+      final ordered = prioritizeClients(<TrainerClient>[
+        _client('a', sodiumMg: 1500), // ok
+        _client('b', sodiumMg: 2500), // over
+        _client('c', sodiumMg: 1800), // ok
+        _client('d', sodiumMg: 2100), // over
+      ]);
+
+      expect(
+        ordered.map((c) => c.id).toList(),
+        <String>['b', 'd', 'a', 'c'],
+      );
+    });
+
+    test('is a no-op ordering when nobody is over target', () {
+      final ordered = prioritizeClients(<TrainerClient>[
+        _client('a', sodiumMg: 100),
+        _client('b', sodiumMg: 200),
+      ]);
+      expect(ordered.map((c) => c.id).toList(), <String>['a', 'b']);
+    });
+  });
+}

--- a/frontend/flutter_trainer/test/features/clients/client_repository_provider_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_repository_provider_test.dart
@@ -154,31 +154,37 @@ void main() {
         ],
       );
 
-      final emissions = <List<String>>[];
-      final sub = container.listen(prioritizedClientsProvider, (
-        _,
-        next,
-      ) {
-        next.whenData(
-          (clients) => emissions.add(clients.map((c) => c.id).toList()),
-        );
-      });
-      addTearDown(sub.close);
-
       // Each addition needs a couple of real event-loop ticks to travel
       // clientsProvider's stream -> its AsyncValue -> the rebuilt
       // Stream.value(...) -> prioritizedClientsProvider's own AsyncValue ->
-      // this listener — a plain `Duration.zero` delay only drains
-      // microtasks, not far enough through that chain.
+      // this listener. Rather than guess how long that takes (a fixed
+      // delay is flaky on a slow CI runner), wait on a Completer that the
+      // listener itself completes the moment each emission actually
+      // arrives (review).
+      final emissions = <List<String>>[];
+      final gotFirst = Completer<void>();
+      final gotSecond = Completer<void>();
+      final sub = container.listen(prioritizedClientsProvider, (_, next) {
+        next.whenData((clients) {
+          emissions.add(clients.map((c) => c.id).toList());
+          if (emissions.length == 1) {
+            gotFirst.complete();
+          } else if (emissions.length == 2) {
+            gotSecond.complete();
+          }
+        });
+      });
+      addTearDown(sub.close);
+
       controller.add(<TrainerClient>[_client('a', sodiumMg: 100)]);
-      await Future<void>.delayed(const Duration(milliseconds: 10));
+      await gotFirst.future.timeout(const Duration(seconds: 5));
       // A second emission on the SAME provider instance (no invalidation) —
       // an over-target client now leads the roster.
       controller.add(<TrainerClient>[
         _client('over', sodiumMg: 2500),
         _client('a', sodiumMg: 100),
       ]);
-      await Future<void>.delayed(const Duration(milliseconds: 10));
+      await gotSecond.future.timeout(const Duration(seconds: 5));
 
       expect(emissions, <List<String>>[
         <String>['a'],

--- a/frontend/flutter_trainer/test/features/clients/client_repository_provider_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_repository_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -8,9 +10,61 @@ import 'package:oncare_trainer/core/config/app_config.dart';
 import 'package:oncare_trainer/core/network/dio_client.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/features/clients/data/repositories/dio_client_repository.dart';
+import 'package:oncare_trainer/features/clients/domain/entities/client_diet_entry.dart';
+import 'package:oncare_trainer/features/clients/domain/entities/routine_history_entry.dart';
+import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 
 class _MockDio extends Mock implements Dio {}
+
+TrainerClient _client(String id, {required int sodiumMg}) => TrainerClient(
+  id: id,
+  name: id,
+  avatar: id.substring(0, 1),
+  goal: '',
+  lastMessage: '',
+  lastTime: '',
+  active: true,
+  calories: 0,
+  sodiumMg: sodiumMg,
+  sugarG: 0,
+  lastRoutine: '',
+  weekCompletion: const <int>[],
+  sodiumWeek: const <int>[],
+);
+
+/// A [ClientRepository] whose `watchClients()` is a controllable
+/// multi-emission stream, so tests can push more than one roster update
+/// through the same provider instance (unlike the real Dio source, which
+/// is one-shot) — used to prove [prioritizedClientsProvider] keeps up with
+/// every emission, not just the first.
+class _StreamingClientRepository implements ClientRepository {
+  _StreamingClientRepository(this._controller);
+  final StreamController<List<TrainerClient>> _controller;
+
+  @override
+  bool get supportsRosterMutations => false;
+  @override
+  Stream<List<TrainerClient>> watchClients() => _controller.stream;
+  @override
+  Stream<List<TrainerClient>> watchClientsPrioritized() =>
+      throw UnimplementedError('not exercised by this test');
+  @override
+  Stream<int> watchTodayReservationCount() => const Stream<int>.empty();
+  @override
+  Stream<List<ClientDietEntry>> watchDiet(String clientId) =>
+      const Stream<List<ClientDietEntry>>.empty();
+  @override
+  Stream<List<RoutineHistoryEntry>> watchHistory(String clientId) =>
+      const Stream<List<RoutineHistoryEntry>>.empty();
+  @override
+  Future<bool> clientNameExists(String name) async => false;
+  @override
+  Future<bool> addClient({required String name, required String goal}) async =>
+      false;
+  @override
+  Future<void> setClientActive(String id, bool active) async {}
+}
 
 ProviderContainer _containerFor({
   required bool useMockApi,
@@ -81,6 +135,55 @@ void main() {
       verify(() => dio.get<List<dynamic>>('/trainer/clients')).called(1);
       expect(clients.map((c) => c.id), <String>['a', 'b']);
       expect(prioritized.map((c) => c.id), <String>['a', 'b']); // a is over
+    },
+  );
+
+  test(
+    'prioritizedClientsProvider re-derives on every clientsProvider '
+    'emission, not just the first (review: watching `.future` would freeze '
+    'on the first value since it only ever resolves once)',
+    () async {
+      final controller = StreamController<List<TrainerClient>>();
+      addTearDown(controller.close);
+      final container = _containerFor(
+        useMockApi: false,
+        extraOverrides: <Override>[
+          clientRepositoryProvider.overrideWithValue(
+            _StreamingClientRepository(controller),
+          ),
+        ],
+      );
+
+      final emissions = <List<String>>[];
+      final sub = container.listen(prioritizedClientsProvider, (
+        _,
+        next,
+      ) {
+        next.whenData(
+          (clients) => emissions.add(clients.map((c) => c.id).toList()),
+        );
+      });
+      addTearDown(sub.close);
+
+      // Each addition needs a couple of real event-loop ticks to travel
+      // clientsProvider's stream -> its AsyncValue -> the rebuilt
+      // Stream.value(...) -> prioritizedClientsProvider's own AsyncValue ->
+      // this listener — a plain `Duration.zero` delay only drains
+      // microtasks, not far enough through that chain.
+      controller.add(<TrainerClient>[_client('a', sodiumMg: 100)]);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      // A second emission on the SAME provider instance (no invalidation) —
+      // an over-target client now leads the roster.
+      controller.add(<TrainerClient>[
+        _client('over', sodiumMg: 2500),
+        _client('a', sodiumMg: 100),
+      ]);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(emissions, <List<String>>[
+        <String>['a'],
+        <String>['over', 'a'], // proves the second emission was reflected
+      ]);
     },
   );
 }

--- a/frontend/flutter_trainer/test/features/clients/client_repository_provider_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_repository_provider_test.dart
@@ -1,13 +1,21 @@
+import 'package:dio/dio.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 
 import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/core/network/dio_client.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/features/clients/data/repositories/dio_client_repository.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 
-ProviderContainer _containerFor({required bool useMockApi}) {
+class _MockDio extends Mock implements Dio {}
+
+ProviderContainer _containerFor({
+  required bool useMockApi,
+  List<Override> extraOverrides = const <Override>[],
+}) {
   final db = AppDatabase.forTesting(NativeDatabase.memory());
   addTearDown(db.close);
   final container = ProviderContainer(
@@ -20,6 +28,7 @@ ProviderContainer _containerFor({required bool useMockApi}) {
         ),
       ),
       appDatabaseProvider.overrideWithValue(db),
+      ...extraOverrides,
     ],
   );
   addTearDown(container.dispose);
@@ -42,4 +51,36 @@ void main() {
       isA<DioClientRepository>(),
     );
   });
+
+  test(
+    'watching clientsProvider + prioritizedClientsProvider together issues '
+    'exactly one GET /trainer/clients in real-API mode (review: the two '
+    'providers used to each fetch independently)',
+    () async {
+      final dio = _MockDio();
+      when(() => dio.get<List<dynamic>>('/trainer/clients')).thenAnswer(
+        (_) async => Response<List<dynamic>>(
+          requestOptions: RequestOptions(path: '/trainer/clients'),
+          statusCode: 200,
+          data: <dynamic>[
+            <String, Object?>{'id': 'a', 'name': 'A', 'sodium_mg': 2500},
+            <String, Object?>{'id': 'b', 'name': 'B', 'sodium_mg': 500},
+          ],
+        ),
+      );
+      final container = _containerFor(
+        useMockApi: false,
+        extraOverrides: <Override>[dioProvider.overrideWithValue(dio)],
+      );
+
+      final clients = await container.read(clientsProvider.future);
+      final prioritized = await container.read(
+        prioritizedClientsProvider.future,
+      );
+
+      verify(() => dio.get<List<dynamic>>('/trainer/clients')).called(1);
+      expect(clients.map((c) => c.id), <String>['a', 'b']);
+      expect(prioritized.map((c) => c.id), <String>['a', 'b']); // a is over
+    },
+  );
 }

--- a/frontend/flutter_trainer/test/features/clients/client_repository_provider_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_repository_provider_test.dart
@@ -1,0 +1,45 @@
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/core/storage/app_database.dart';
+import 'package:oncare_trainer/features/clients/data/repositories/dio_client_repository.dart';
+import 'package:oncare_trainer/shared/services/client_repository.dart';
+
+ProviderContainer _containerFor({required bool useMockApi}) {
+  final db = AppDatabase.forTesting(NativeDatabase.memory());
+  addTearDown(db.close);
+  final container = ProviderContainer(
+    overrides: <Override>[
+      appConfigProvider.overrideWithValue(
+        AppConfig(
+          environment: Environment.dev,
+          apiBaseUrl: 'http://localhost/v1',
+          useMockApi: useMockApi,
+        ),
+      ),
+      appDatabaseProvider.overrideWithValue(db),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  test('resolves the drift repository when USE_MOCK_API=true', () {
+    final container = _containerFor(useMockApi: true);
+    expect(
+      container.read(clientRepositoryProvider),
+      isA<DriftClientRepository>(),
+    );
+  });
+
+  test('resolves the Dio repository when USE_MOCK_API=false', () {
+    final container = _containerFor(useMockApi: false);
+    expect(
+      container.read(clientRepositoryProvider),
+      isA<DioClientRepository>(),
+    );
+  });
+}

--- a/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
@@ -9,6 +9,13 @@ import 'package:oncare_trainer/shared/services/client_repository.dart';
 
 import '../../helpers/pump_app.dart';
 
+class _ReadOnlyClientRepository extends DriftClientRepository {
+  const _ReadOnlyClientRepository(super.db);
+
+  @override
+  bool get supportsRosterMutations => false;
+}
+
 void main() {
   group('ClientRepository', () {
     late AppDatabase db;
@@ -104,6 +111,7 @@ void main() {
 
     test('setClientActive flips the 활성/휴면 state', () async {
       final repo = DriftClientRepository(db);
+      expect(repo.supportsRosterMutations, isTrue);
       await repo.setClientActive('seed-client-1', false);
       var clients = await repo.watchClients().first;
       expect(clients.firstWhere((c) => c.name == '김민수').active, isFalse);
@@ -251,6 +259,32 @@ void main() {
       await tester.tap(find.text('○ 휴면'));
       await settle(tester);
       expect(find.text('● 활성'), findsOneWidget);
+    });
+
+    testWidgets('read-only repositories disable every roster mutation entry', (
+      tester,
+    ) async {
+      await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        extraOverrides: [
+          clientRepositoryProvider.overrideWith(
+            (ref) => _ReadOnlyClientRepository(ref.watch(appDatabaseProvider)),
+          ),
+        ],
+      );
+
+      await tester.scrollUntilVisible(find.text('박성호'), 150);
+      expect(find.text('＋ 신규 고객 등록'), findsNothing);
+
+      await tester.tap(find.text('박성호'));
+      await settle(tester);
+
+      final statusInkWell = find.byKey(
+        const ValueKey<String>('client-status-toggle'),
+      );
+      expect(statusInkWell, findsOneWidget);
+      expect(tester.widget<InkWell>(statusInkWell).onTap, isNull);
     });
   });
 }

--- a/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
@@ -20,7 +20,7 @@ void main() {
     tearDown(() => db.close());
 
     test('watchClients returns the 3 seeded clients in order', () async {
-      final clients = await ClientRepository(db).watchClients().first;
+      final clients = await DriftClientRepository(db).watchClients().first;
       expect(clients.map((c) => c.name).toList(), <String>[
         '김민수',
         '이지수',
@@ -29,7 +29,7 @@ void main() {
     });
 
     test('sodiumOverBudget flags only clients above 2000mg', () async {
-      final clients = await ClientRepository(db).watchClients().first;
+      final clients = await DriftClientRepository(db).watchClients().first;
       expect(
         clients.where((c) => c.sodiumOverBudget).map((c) => c.name).toSet(),
         <String>{'김민수', '박성호'}, // 2100, 2400; 이지수 1800 is under
@@ -37,7 +37,7 @@ void main() {
     });
 
     test('addClient appends a fresh profile after the seeded roster', () async {
-      final repo = ClientRepository(db);
+      final repo = DriftClientRepository(db);
       await repo.addClient(name: '  최수진  ', goal: '체중 감량');
 
       final clients = await repo.watchClients().first;
@@ -55,7 +55,7 @@ void main() {
     test(
       'addClient ignores an empty name and defaults an empty goal',
       () async {
-        final repo = ClientRepository(db);
+        final repo = DriftClientRepository(db);
         expect(await repo.addClient(name: '   ', goal: '아무거나'), isFalse);
         expect((await repo.watchClients().first).length, 3);
 
@@ -66,7 +66,7 @@ void main() {
     );
 
     test('addClient rejects a duplicate name', () async {
-      final repo = ClientRepository(db);
+      final repo = DriftClientRepository(db);
 
       // Schedules resolve their client by NAME, so a second 김민수 could
       // receive the first one's chat/운동기록 (review PR 243).
@@ -85,7 +85,7 @@ void main() {
     });
 
     test('concurrent addClient of the same name inserts exactly one', () async {
-      final repo = ClientRepository(db);
+      final repo = DriftClientRepository(db);
 
       // Fire both adds without awaiting between them: the check and the
       // insert share one transaction, so only one can pass the duplicate
@@ -103,7 +103,7 @@ void main() {
     });
 
     test('setClientActive flips the 활성/휴면 state', () async {
-      final repo = ClientRepository(db);
+      final repo = DriftClientRepository(db);
       await repo.setClientActive('seed-client-1', false);
       var clients = await repo.watchClients().first;
       expect(clients.firstWhere((c) => c.name == '김민수').active, isFalse);
@@ -114,7 +114,7 @@ void main() {
     });
 
     test('reservation count excludes 공백 slots', () async {
-      final count = await ClientRepository(
+      final count = await DriftClientRepository(
         db,
       ).watchTodayReservationCount().first;
       expect(count, 4); // 6 slots − 2 공백
@@ -134,7 +134,7 @@ void main() {
             ),
           );
 
-      final count = await ClientRepository(
+      final count = await DriftClientRepository(
         db,
       ).watchTodayReservationCount().first;
       expect(count, 4); // still 4 — the 2020 row is excluded

--- a/frontend/flutter_trainer/test/features/clients/dio_client_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/dio_client_repository_test.dart
@@ -15,13 +15,13 @@ Response<List<dynamic>> _okList(List<dynamic> body, String path) =>
     );
 
 DioException _httpError(int status, String path) => DioException(
-      requestOptions: RequestOptions(path: path),
-      type: DioExceptionType.badResponse,
-      response: Response<Object?>(
-        requestOptions: RequestOptions(path: path),
-        statusCode: status,
-      ),
-    );
+  requestOptions: RequestOptions(path: path),
+  type: DioExceptionType.badResponse,
+  response: Response<Object?>(
+    requestOptions: RequestOptions(path: path),
+    statusCode: status,
+  ),
+);
 
 void main() {
   late _MockDio dio;
@@ -34,13 +34,10 @@ void main() {
 
   test('watchClients parses the roster', () async {
     when(() => dio.get<List<dynamic>>('/trainer/clients')).thenAnswer(
-      (_) async => _okList(
-        <dynamic>[
-          <String, Object?>{'id': 'm1', 'name': '김민수', 'sodium_mg': 2100},
-          <String, Object?>{'id': 'm2', 'name': '이지수', 'sodium_mg': 1500},
-        ],
-        '/trainer/clients',
-      ),
+      (_) async => _okList(<dynamic>[
+        <String, Object?>{'id': 'm1', 'name': '김민수', 'sodium_mg': 2100},
+        <String, Object?>{'id': 'm2', 'name': '이지수', 'sodium_mg': 1500},
+      ], '/trainer/clients'),
     );
 
     final clients = await repo.watchClients().first;
@@ -50,13 +47,10 @@ void main() {
 
   test('watchClientsPrioritized puts the over-target client first', () async {
     when(() => dio.get<List<dynamic>>('/trainer/clients')).thenAnswer(
-      (_) async => _okList(
-        <dynamic>[
-          <String, Object?>{'id': 'ok', 'name': 'A', 'sodium_mg': 1500},
-          <String, Object?>{'id': 'over', 'name': 'B', 'sodium_mg': 2500},
-        ],
-        '/trainer/clients',
-      ),
+      (_) async => _okList(<dynamic>[
+        <String, Object?>{'id': 'ok', 'name': 'A', 'sodium_mg': 1500},
+        <String, Object?>{'id': 'over', 'name': 'B', 'sodium_mg': 2500},
+      ], '/trainer/clients'),
     );
 
     final clients = await repo.watchClientsPrioritized().first;
@@ -65,35 +59,78 @@ void main() {
 
   test('watchDiet parses the meals', () async {
     when(() => dio.get<List<dynamic>>('/trainer/clients/m1/diet')).thenAnswer(
-      (_) async => _okList(
-        <dynamic>[
-          <String, Object?>{'meal': '점심', 'items': '비빔밥', 'calories': 600, 'sodium_mg': 1200},
-        ],
-        '/trainer/clients/m1/diet',
-      ),
+      (_) async => _okList(<dynamic>[
+        <String, Object?>{
+          'meal': '점심',
+          'items': '비빔밥',
+          'calories': 600,
+          'sodium_mg': 1200,
+        },
+      ], '/trainer/clients/m1/diet'),
     );
 
     final meals = await repo.watchDiet('m1').first;
     expect(meals.single.meal, '점심');
   });
 
-  test('watchHistory surfaces a 404 (not this trainer\'s client) as NotFoundError',
-      () async {
-    when(() => dio.get<List<dynamic>>('/trainer/clients/x/history'))
-        .thenThrow(_httpError(404, '/trainer/clients/x/history'));
-
-    await expectLater(
-      repo.watchHistory('x'),
-      emitsError(isA<NotFoundError>()),
+  test('encodes an opaque client id as one path segment', () async {
+    when(
+      () => dio.get<List<dynamic>>(
+        '/trainer/clients/member%2Fwith%3Freserved/diet',
+      ),
+    ).thenAnswer(
+      (_) async => _okList(
+        const <dynamic>[],
+        '/trainer/clients/member%2Fwith%3Freserved/diet',
+      ),
     );
+
+    await repo.watchDiet('member/with?reserved').first;
+
+    verify(
+      () => dio.get<List<dynamic>>(
+        '/trainer/clients/member%2Fwith%3Freserved/diet',
+      ),
+    ).called(1);
   });
 
-  test('watchTodayReservationCount emits nothing (schedule wired later)',
-      () async {
-    expect(await repo.watchTodayReservationCount().isEmpty, isTrue);
+  test('malformed list entries fail instead of being silently dropped', () {
+    when(() => dio.get<List<dynamic>>('/trainer/clients')).thenAnswer(
+      (_) async => _okList(<dynamic>[
+        <String, Object?>{'id': 'm1'},
+        'not-an-object',
+      ], '/trainer/clients'),
+    );
+
+    expect(repo.watchClients(), emitsError(isA<FormatException>()));
   });
+
+  test(
+    'watchHistory surfaces a 404 (not this trainer\'s client) as NotFoundError',
+    () async {
+      when(
+        () => dio.get<List<dynamic>>('/trainer/clients/x/history'),
+      ).thenThrow(_httpError(404, '/trainer/clients/x/history'));
+
+      await expectLater(
+        repo.watchHistory('x'),
+        emitsError(isA<NotFoundError>()),
+      );
+    },
+  );
+
+  test(
+    'watchTodayReservationCount emits nothing (schedule wired later)',
+    () async {
+      expect(await repo.watchTodayReservationCount().isEmpty, isTrue);
+    },
+  );
 
   group('roster mutations are demo-only against the real API', () {
+    test('advertises the roster as read-only', () {
+      expect(repo.supportsRosterMutations, isFalse);
+    });
+
     test('addClient throws UnsupportedError', () {
       expect(
         () => repo.addClient(name: 'x', goal: 'y'),

--- a/frontend/flutter_trainer/test/features/clients/dio_client_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/dio_client_repository_test.dart
@@ -1,0 +1,110 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/features/clients/data/repositories/dio_client_repository.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+Response<List<dynamic>> _okList(List<dynamic> body, String path) =>
+    Response<List<dynamic>>(
+      requestOptions: RequestOptions(path: path),
+      statusCode: 200,
+      data: body,
+    );
+
+DioException _httpError(int status, String path) => DioException(
+      requestOptions: RequestOptions(path: path),
+      type: DioExceptionType.badResponse,
+      response: Response<Object?>(
+        requestOptions: RequestOptions(path: path),
+        statusCode: status,
+      ),
+    );
+
+void main() {
+  late _MockDio dio;
+  late DioClientRepository repo;
+
+  setUp(() {
+    dio = _MockDio();
+    repo = DioClientRepository(dio);
+  });
+
+  test('watchClients parses the roster', () async {
+    when(() => dio.get<List<dynamic>>('/trainer/clients')).thenAnswer(
+      (_) async => _okList(
+        <dynamic>[
+          <String, Object?>{'id': 'm1', 'name': '김민수', 'sodium_mg': 2100},
+          <String, Object?>{'id': 'm2', 'name': '이지수', 'sodium_mg': 1500},
+        ],
+        '/trainer/clients',
+      ),
+    );
+
+    final clients = await repo.watchClients().first;
+    expect(clients.map((c) => c.id).toList(), <String>['m1', 'm2']);
+    expect(clients.first.sodiumOverBudget, isTrue);
+  });
+
+  test('watchClientsPrioritized puts the over-target client first', () async {
+    when(() => dio.get<List<dynamic>>('/trainer/clients')).thenAnswer(
+      (_) async => _okList(
+        <dynamic>[
+          <String, Object?>{'id': 'ok', 'name': 'A', 'sodium_mg': 1500},
+          <String, Object?>{'id': 'over', 'name': 'B', 'sodium_mg': 2500},
+        ],
+        '/trainer/clients',
+      ),
+    );
+
+    final clients = await repo.watchClientsPrioritized().first;
+    expect(clients.first.id, 'over');
+  });
+
+  test('watchDiet parses the meals', () async {
+    when(() => dio.get<List<dynamic>>('/trainer/clients/m1/diet')).thenAnswer(
+      (_) async => _okList(
+        <dynamic>[
+          <String, Object?>{'meal': '점심', 'items': '비빔밥', 'calories': 600, 'sodium_mg': 1200},
+        ],
+        '/trainer/clients/m1/diet',
+      ),
+    );
+
+    final meals = await repo.watchDiet('m1').first;
+    expect(meals.single.meal, '점심');
+  });
+
+  test('watchHistory surfaces a 404 (not this trainer\'s client) as NotFoundError',
+      () async {
+    when(() => dio.get<List<dynamic>>('/trainer/clients/x/history'))
+        .thenThrow(_httpError(404, '/trainer/clients/x/history'));
+
+    await expectLater(
+      repo.watchHistory('x'),
+      emitsError(isA<NotFoundError>()),
+    );
+  });
+
+  test('watchTodayReservationCount emits nothing (schedule wired later)',
+      () async {
+    expect(await repo.watchTodayReservationCount().isEmpty, isTrue);
+  });
+
+  group('roster mutations are demo-only against the real API', () {
+    test('addClient throws UnsupportedError', () {
+      expect(
+        () => repo.addClient(name: 'x', goal: 'y'),
+        throwsUnsupportedError,
+      );
+    });
+    test('setClientActive throws UnsupportedError', () {
+      expect(() => repo.setClientActive('id', false), throwsUnsupportedError);
+    });
+    test('clientNameExists throws UnsupportedError', () {
+      expect(() => repo.clientNameExists('x'), throwsUnsupportedError);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

* 트레이너의 고객 목록·식단·운동 기록을 실 API에 연결했습니다.
* `ClientRepository`를 인터페이스로 분리하고, `USE_MOCK_API` 설정에 따라 `DriftClientRepository`와 `DioClientRepository`를 전환합니다.
* 나트륨 섭취량을 기준으로 “확인 필요” 고객을 먼저 노출하는 stable 우선순위 정렬을 적용하고, AI 요약 영역도 실데이터를 반영하도록 변경했습니다.
* 실 API의 404 응답을 `NotFoundError`로 변환해 상세 화면의 에러 상태로 전달합니다.
* 백엔드 API가 아직 없는 신규 고객 등록과 오늘의 예약 배지는 실 API 모드에서 숨깁니다.

---

## Changes

### ✨ Features

* 다음 트레이너 고객 API를 연결했습니다.
  * `GET /trainer/clients`
  * `GET /trainer/clients/{clientId}/diet`
  * `GET /trainer/clients/{clientId}/history`
* 고객 목록·식단·운동 기록 응답을 도메인 모델로 변환하는 DTO 매퍼를 추가했습니다.
* `USE_MOCK_API` 값에 따라 Drift 또는 Dio 저장소를 제공하도록 provider를 구성했습니다.

### 🔧 Improvements

* `ClientRepository`를 추상 인터페이스로 분리해 데이터 소스와 presentation 계층의 결합을 낮췄습니다.
* `prioritizeClients` 순수 함수를 추가해 나트륨 목표를 초과한 고객을 우선 배치합니다.
* 같은 우선순위 안에서는 서버 응답 순서를 유지하도록 stable 정렬을 보장합니다.
* 웹 JSON에서 숫자가 `double`로 전달되는 경우와 누락된 필드를 DTO 매퍼에서 안전하게 처리합니다.
* Dio 오류를 공통 `AppError`로 변환하고, 404 응답은 `NotFoundError`로 전달합니다.

### 🎨 UI/UX

* 고객 목록 상단의 AI 요약과 “확인 필요” 고객 수가 실데이터를 반영합니다.
* 실 API 모드에서는 백엔드 API가 없는 “신규 고객 등록” 진입점을 숨깁니다.
* 실 API의 일정 연동이 추가되기 전까지 오늘의 예약 배지를 노출하지 않습니다.
* 소유하지 않은 고객 등 404 응답이 발생하면 고객 상세 화면의 에러 상태를 표시합니다.

### 🐛 Fixes

* 실 API 모드에서도 Drift 데모 데이터가 고객 목록과 상세 화면에 노출되던 문제를 해소했습니다.
* 고객 목록의 동일 우선순위 항목이 정렬 과정에서 임의로 재배치될 수 있는 가능성을 제거했습니다.

---

## Commits

1. `e0a0c8d` feat(trainer-clients): connect clients/diet/history to real API + roster priority

---

## Notes

* Base branch는 `feature/314-trainer-network-auth`인 stacked PR입니다.
* #314 의 최신 리뷰 수정 사항이 반영된 뒤 이 브랜치에서도 최종 통합 검증이 필요합니다.
* 고객 등록·활성 상태 변경과 예약 수 조회는 대응하는 백엔드 API가 없어 실 API 모드에서 비활성화했습니다.
* Dio 저장소의 조회 스트림은 현재 API 응답을 한 번 전달하며, Drift 저장소는 기존의 reactive stream 동작을 유지합니다.

---

## Screenshots (Optional)

* UI 레이아웃 변경 없이 데이터 소스와 일부 기능의 노출 조건만 변경했습니다.

---

## Test Plan

* [x] `flutter analyze` 통과
* [x] 트레이너 테스트 전체 159개 통과
* [x] 고객·식단·운동 기록 DTO 매핑 검증
* [x] 웹 JSON 숫자 타입과 누락 필드 처리 검증
* [x] “확인 필요” 고객 우선순위 및 stable 정렬 검증
* [x] `USE_MOCK_API`에 따른 저장소 provider 전환 검증
* [x] Dio 고객 목록·식단·운동 기록 요청 및 응답 변환 검증
* [x] 404 응답의 `NotFoundError` 변환 검증
* [x] 실 API 미지원 mutation 및 예약 배지 비노출 검증
* [x] 고객 목록·식단·운동 기록 UI 테스트 통과

### Manual Test Steps

1. Mock 모드에서 기존 고객 목록과 신규 고객 등록 기능이 정상 동작하는지 확인합니다.
2. 실 API 모드에서 로그인 후 고객 목록·식단·운동 기록이 서버 데이터로 표시되는지 확인합니다.
3. 나트륨 목표를 초과한 고객이 목록 상단에 표시되고 AI 요약의 인원수가 일치하는지 확인합니다.
4. 타 트레이너 소유 고객 접근 시 상세 에러 상태가 표시되는지 확인합니다.
5. 실 API 모드에서 신규 고객 등록 진입점과 오늘의 예약 배지가 표시되지 않는지 확인합니다.

---

## Related Issues

Closes #316

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 실제 API에서 클라이언트 목록, 식단, 루틴 이력을 조회할 수 있습니다.
  - 나트륨 목표 초과 등 코칭 우선순위에 따라 클라이언트가 안정적으로 정렬됩니다.
  - API 환경에서는 지원되지 않는 신규 고객 등록과 활성 상태 변경 기능이 자동으로 비활성화됩니다.

- **버그 수정**
  - 우선순위 목록 조회의 불필요한 중복 요청을 줄였습니다.
  - 누락된 JSON 값과 다양한 숫자 형식을 안전하게 처리합니다.
  - API 응답 및 조회 오류를 일관된 오류로 처리합니다.

- **테스트**
  - API 연동, 데이터 변환, 오류 처리 및 읽기 전용 화면 동작을 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->