### PR TITLE
feat(trainer): connect trainer<->member chat and routine delivery to the real API

### DIFF
--- a/frontend/flutter_trainer/lib/features/ai_routine/data/dtos/routine_dtos.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/data/dtos/routine_dtos.dart
@@ -33,3 +33,34 @@ String _str(Object? v) => v is String ? v : '';
 
 String _truncate(String s, int max) =>
     s.length <= max ? s : s.substring(0, max);
+
+/// Picks the dominant exercise type and the routine `source` for a
+/// composed send (AI-suggested items still on screen + trainer-added
+/// custom exercises). Pure so the "all-custom falls back to 근력/ai" class
+/// of bug is directly unit-testable (review), matching the [assignRoutine]
+/// summary the trainer sees before sending.
+///
+///  * `type` — the most frequent type across both lists (ties keep the
+///    first-seen type via a strict `>` comparison), defaulting to '근력'
+///    when there are no exercises at all.
+///  * `source` — `'trainer'` when every AI suggestion was removed (an
+///    all-custom routine is trainer-authored, not AI-generated), `'ai'`
+///    otherwise.
+({String type, String source}) summaryTypeAndSource({
+  required List<String> aiItemTypes,
+  required List<String> customItemTypes,
+}) {
+  final counts = <String, int>{};
+  for (final t in <String>[...aiItemTypes, ...customItemTypes]) {
+    counts[t] = (counts[t] ?? 0) + 1;
+  }
+  var type = '근력';
+  var best = 0;
+  counts.forEach((t, c) {
+    if (c > best) {
+      best = c;
+      type = t;
+    }
+  });
+  return (type: type, source: aiItemTypes.isEmpty ? 'trainer' : 'ai');
+}

--- a/frontend/flutter_trainer/lib/features/ai_routine/data/dtos/routine_dtos.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/data/dtos/routine_dtos.dart
@@ -1,0 +1,35 @@
+import 'package:oncare_trainer/features/ai_routine/domain/entities/assigned_routine.dart';
+
+/// Valid routine types accepted by the backend (`RoutineType` literal).
+const List<String> kRoutineTypes = <String>['유산소', '근력', '스트레칭'];
+
+/// `RoutineOut` JSON → [AssignedRoutine].
+AssignedRoutine assignedRoutineFromJson(Map<String, Object?> json) {
+  return AssignedRoutine(
+    id: _str(json['id']),
+    name: _str(json['name']),
+    minutes: json['minutes'] is num ? (json['minutes']! as num).toInt() : 0,
+    type: _str(json['type']),
+    reason: _str(json['reason']),
+    source: _str(json['source']),
+  );
+}
+
+/// [AssignedRoutine] → `RoutineAssignRequest` JSON. Clamps/normalises so the
+/// backend's validators (minutes 0–600, type literal, lengths) never 422.
+Map<String, Object?> assignRoutineToJson(AssignedRoutine r) {
+  return <String, Object?>{
+    'name': r.name.trim().isEmpty
+        ? 'AI 맞춤 루틴'
+        : _truncate(r.name.trim(), 100),
+    'minutes': r.minutes.clamp(0, 600),
+    'type': kRoutineTypes.contains(r.type) ? r.type : '근력',
+    'reason': _truncate(r.reason, 200),
+    'source': r.source == 'trainer' ? 'trainer' : 'ai',
+  };
+}
+
+String _str(Object? v) => v is String ? v : '';
+
+String _truncate(String s, int max) =>
+    s.length <= max ? s : s.substring(0, max);

--- a/frontend/flutter_trainer/lib/features/ai_routine/data/repositories/ai_routine_repository.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/data/repositories/ai_routine_repository.dart
@@ -15,14 +15,33 @@ class AiRoutineRepository {
   final AppDatabase _db;
 
   /// The AI suggestions for [clientId], in seeded order.
-  Stream<List<AiRoutineItem>> watchRoutine(String clientId) {
-    final query = _db.select(_db.clientAiRoutines)
-      ..where((t) => t.clientId.equals(clientId))
-      ..orderBy(<OrderingTerm Function($ClientAiRoutinesTable)>[
-        (t) => OrderingTerm(expression: t.sortOrder),
-      ]);
-    return query.watch().map(
-      (rows) => rows
+  ///
+  /// Real API clients use backend ids (`user-demo`) while the bundled
+  /// suggestions use demo ids (`seed-client-1`). [clientName] lets a live
+  /// roster resolve the corresponding local suggestion set.
+  Stream<List<AiRoutineItem>> watchRoutine(
+    String clientId, {
+    String? clientName,
+  }) {
+    final routines = _db.clientAiRoutines;
+    final clients = _db.trainerClients;
+    final query = _db.select(routines).join(<Join>[
+      innerJoin(
+        clients,
+        clients.id.equalsExp(routines.clientId),
+        useColumns: false,
+      ),
+    ]);
+    query.where(
+      routines.clientId.equals(clientId) |
+          (clientName == null
+              ? const Constant<bool>(false)
+              : clients.name.equals(clientName)),
+    );
+    return query.watch().map((rows) {
+      final localRows = rows.map((row) => row.readTable(routines)).toList()
+        ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
+      return localRows
           .map(
             (row) => AiRoutineItem(
               id: row.id,
@@ -32,8 +51,8 @@ class AiRoutineRepository {
               reason: row.reason,
             ),
           )
-          .toList(),
-    );
+          .toList();
+    });
   }
 
   /// Registers the composed routine as [clientName]'s PT program on
@@ -105,10 +124,13 @@ final aiRoutineRepositoryProvider = Provider<AiRoutineRepository>((ref) {
   return AiRoutineRepository(ref.watch(appDatabaseProvider));
 });
 
+/// A stable key for local suggestions when the live and demo ids differ.
+typedef AiRoutineClientKey = ({String id, String name});
+
 /// Streams a client's AI routine suggestions.
-final aiRoutineProvider = StreamProvider.family<List<AiRoutineItem>, String>((
-  ref,
-  clientId,
-) {
-  return ref.watch(aiRoutineRepositoryProvider).watchRoutine(clientId);
-});
+final aiRoutineProvider =
+    StreamProvider.family<List<AiRoutineItem>, AiRoutineClientKey>((ref, key) {
+      return ref
+          .watch(aiRoutineRepositoryProvider)
+          .watchRoutine(key.id, clientName: key.name);
+    });

--- a/frontend/flutter_trainer/lib/features/ai_routine/data/repositories/dio_trainer_routine_repository.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/data/repositories/dio_trainer_routine_repository.dart
@@ -15,9 +15,10 @@ class DioTrainerRoutineRepository implements TrainerRoutineRepository {
 
   @override
   Future<void> assignRoutine(String memberId, AssignedRoutine routine) async {
+    final encodedId = Uri.encodeComponent(memberId);
     try {
       await _dio.post<Map<String, Object?>>(
-        '/trainer/clients/$memberId/routines',
+        '/trainer/clients/$encodedId/routines',
         data: assignRoutineToJson(routine),
       );
     } on DioException catch (e) {
@@ -30,14 +31,21 @@ class DioTrainerRoutineRepository implements TrainerRoutineRepository {
       Stream<List<AssignedRoutine>>.fromFuture(_fetch(memberId));
 
   Future<List<AssignedRoutine>> _fetch(String memberId) async {
+    final encodedId = Uri.encodeComponent(memberId);
     try {
       final res = await _dio.get<List<dynamic>>(
-        '/trainer/clients/$memberId/routines',
+        '/trainer/clients/$encodedId/routines',
       );
       final data = res.data ?? const <dynamic>[];
       return data
-          .whereType<Map<String, Object?>>()
-          .map(assignedRoutineFromJson)
+          .map((item) {
+            if (item is! Map<String, Object?>) {
+              throw const FormatException(
+                'Expected an object in the assigned-routine response.',
+              );
+            }
+            return assignedRoutineFromJson(item);
+          })
           .toList(growable: false);
     } on DioException catch (e) {
       throw AppError.fromDio(e);

--- a/frontend/flutter_trainer/lib/features/ai_routine/data/repositories/dio_trainer_routine_repository.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/data/repositories/dio_trainer_routine_repository.dart
@@ -1,0 +1,46 @@
+import 'package:dio/dio.dart';
+
+import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/features/ai_routine/data/dtos/routine_dtos.dart';
+import 'package:oncare_trainer/features/ai_routine/domain/entities/assigned_routine.dart';
+import 'package:oncare_trainer/features/ai_routine/data/repositories/trainer_routine_repository.dart';
+
+/// Assigns/reads a member's routines against the FastAPI backend. A routine
+/// assigned here is what the member app receives via `/me/coach/routines`.
+/// Selected when `USE_MOCK_API=false` (see [trainerRoutineRepositoryProvider]).
+class DioTrainerRoutineRepository implements TrainerRoutineRepository {
+  DioTrainerRoutineRepository(this._dio);
+
+  final Dio _dio;
+
+  @override
+  Future<void> assignRoutine(String memberId, AssignedRoutine routine) async {
+    try {
+      await _dio.post<Map<String, Object?>>(
+        '/trainer/clients/$memberId/routines',
+        data: assignRoutineToJson(routine),
+      );
+    } on DioException catch (e) {
+      throw AppError.fromDio(e);
+    }
+  }
+
+  @override
+  Stream<List<AssignedRoutine>> watchAssignedRoutines(String memberId) =>
+      Stream<List<AssignedRoutine>>.fromFuture(_fetch(memberId));
+
+  Future<List<AssignedRoutine>> _fetch(String memberId) async {
+    try {
+      final res = await _dio.get<List<dynamic>>(
+        '/trainer/clients/$memberId/routines',
+      );
+      final data = res.data ?? const <dynamic>[];
+      return data
+          .whereType<Map<String, Object?>>()
+          .map(assignedRoutineFromJson)
+          .toList(growable: false);
+    } on DioException catch (e) {
+      throw AppError.fromDio(e);
+    }
+  }
+}

--- a/frontend/flutter_trainer/lib/features/ai_routine/data/repositories/dio_trainer_routine_repository.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/data/repositories/dio_trainer_routine_repository.dart
@@ -13,6 +13,16 @@ class DioTrainerRoutineRepository implements TrainerRoutineRepository {
 
   final Dio _dio;
 
+  /// Assigns [routine] to [memberId].
+  ///
+  /// NOT idempotent: `POST /trainer/clients/{id}/routines` inserts a fresh
+  /// `rt-{uuid}` row on every call, with no client-request-id/dedup key
+  /// today. If this throws after a network timeout, the backend may have
+  /// already committed the assign before the client gave up waiting —
+  /// blindly retrying can leave the member with two copies of the same
+  /// routine. Callers that retry on failure should special-case a network/
+  /// timeout error (ambiguous outcome) rather than assume a clean retry is
+  /// always safe (review; a full fix needs a backend idempotency key).
   @override
   Future<void> assignRoutine(String memberId, AssignedRoutine routine) async {
     final encodedId = Uri.encodeComponent(memberId);

--- a/frontend/flutter_trainer/lib/features/ai_routine/data/repositories/trainer_routine_repository.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/data/repositories/trainer_routine_repository.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/core/network/dio_client.dart';
+import 'package:oncare_trainer/features/ai_routine/data/repositories/dio_trainer_routine_repository.dart';
+import 'package:oncare_trainer/features/ai_routine/domain/entities/assigned_routine.dart';
+
+/// Assigns a routine to a member and reads their assigned routines.
+///
+/// Assigning is how a member *receives* a routine (the same record the
+/// member app reads via `/me/coach/routines`). Two implementations sit
+/// behind this contract, selected by [trainerRoutineRepositoryProvider] via
+/// [AppConfig.useMockApi]:
+///  * [MockTrainerRoutineRepository] — demo / `USE_MOCK_API=true` (no-op
+///    send; the demo has no member app to receive it);
+///  * [DioTrainerRoutineRepository] — the real FastAPI backend.
+abstract interface class TrainerRoutineRepository {
+  /// Assigns [routine] to [memberId] (POST /trainer/clients/{id}/routines).
+  Future<void> assignRoutine(String memberId, AssignedRoutine routine);
+
+  /// The member's currently assigned routines (newest first).
+  Stream<List<AssignedRoutine>> watchAssignedRoutines(String memberId);
+}
+
+/// Demo no-op: the mock/demo build has no member backend to deliver to, so
+/// assignment succeeds silently and the assigned list is empty. The visible
+/// "전송됨" feedback in demo comes from the local chat/schedule writes.
+class MockTrainerRoutineRepository implements TrainerRoutineRepository {
+  const MockTrainerRoutineRepository();
+
+  @override
+  Future<void> assignRoutine(String memberId, AssignedRoutine routine) async {}
+
+  @override
+  Stream<List<AssignedRoutine>> watchAssignedRoutines(String memberId) =>
+      Stream<List<AssignedRoutine>>.value(const <AssignedRoutine>[]);
+}
+
+/// Selects the real Dio-backed routine repository against the FastAPI
+/// backend, or the demo no-op for `USE_MOCK_API=true`.
+final trainerRoutineRepositoryProvider = Provider<TrainerRoutineRepository>((
+  ref,
+) {
+  final config = ref.watch(appConfigProvider);
+  if (config.useMockApi) {
+    return const MockTrainerRoutineRepository();
+  }
+  return DioTrainerRoutineRepository(ref.watch(dioProvider));
+}, name: 'trainerRoutineRepository');

--- a/frontend/flutter_trainer/lib/features/ai_routine/domain/entities/assigned_routine.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/domain/entities/assigned_routine.dart
@@ -1,0 +1,31 @@
+/// A routine assigned to a member (the `RoutineOut` shape shared with the
+/// member app's `/me/coach/routines`). Sending one from the trainer app is
+/// how a member receives a routine.
+class AssignedRoutine {
+  const AssignedRoutine({
+    required this.id,
+    required this.name,
+    required this.minutes,
+    required this.type,
+    required this.reason,
+    required this.source,
+  });
+
+  /// Server id (empty before assignment).
+  final String id;
+
+  /// Routine label (e.g. "AI 맞춤 루틴").
+  final String name;
+
+  /// Total minutes.
+  final int minutes;
+
+  /// One of 유산소 | 근력 | 스트레칭.
+  final String type;
+
+  /// Why this routine — surfaced to the member.
+  final String reason;
+
+  /// `ai` (AI-suggested) or `trainer` (hand-assigned).
+  final String source;
+}

--- a/frontend/flutter_trainer/lib/features/ai_routine/presentation/pages/ai_routine_page.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/presentation/pages/ai_routine_page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:oncare_trainer/core/config/app_config.dart';
 import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/elevation.dart';
@@ -10,7 +11,9 @@ import 'package:oncare_trainer/design_system/tokens/layout.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/features/ai_routine/data/repositories/ai_routine_repository.dart';
+import 'package:oncare_trainer/features/ai_routine/data/repositories/trainer_routine_repository.dart';
 import 'package:oncare_trainer/features/ai_routine/domain/entities/ai_routine_item.dart';
+import 'package:oncare_trainer/features/ai_routine/domain/entities/assigned_routine.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/services/chat_repository.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
@@ -124,16 +127,33 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
     // the starting client, not whoever is on screen when it resolves
     // (review PR 239).
     final sentFor = client.id;
+    final noteText =
+        '📋 AI 루틴 숙제를 보냈어요 · ${program.length}개 운동 · 총 ${total + custom}분';
     setState(() => _sending = true);
     try {
-      await ref
-          .read(chatRepositoryProvider)
-          .sendTrainerMessage(
-            clientId: client.id,
-            text:
-                '📋 AI 루틴 숙제를 보냈어요 · ${program.length}개 운동 · '
-                '총 ${total + custom}분',
-          );
+      if (!ref.read(appConfigProvider).useMockApi) {
+        // Real API: assigning the routine IS the delivery — the member
+        // receives it via /me/coach/routines. This is fatal (its failure
+        // blocks the "전송 완료" claim). The chat summary note is cosmetic,
+        // so a failed note must NOT report a failed send — otherwise the
+        // trainer re-sends and assigns a duplicate routine.
+        await ref
+            .read(trainerRoutineRepositoryProvider)
+            .assignRoutine(client.id, _summaryRoutine(items, total + custom));
+        try {
+          await ref
+              .read(chatRepositoryProvider)
+              .sendTrainerMessage(clientId: client.id, text: noteText);
+        } catch (_) {
+          // Routine already delivered — swallow the note failure.
+        }
+      } else {
+        // Demo/mock: no member backend, so the chat note is the visible
+        // "sent" feedback and stays fatal.
+        await ref
+            .read(chatRepositoryProvider)
+            .sendTrainerMessage(clientId: client.id, text: noteText);
+      }
     } catch (_) {
       if (!mounted || !_isStillSelected(sentFor)) return;
       setState(() => _sending = false);
@@ -185,6 +205,37 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
           'weight': '-',
         },
     ];
+  }
+
+  /// A single summary [AssignedRoutine] for the real routine-assign API
+  /// (`RoutineOut` is one routine, not a per-exercise program): [type] is
+  /// the dominant AI-item type and the reason lists the exercise names.
+  AssignedRoutine _summaryRoutine(List<AiRoutineItem> items, int totalMinutes) {
+    final active = items.where((i) => !_removed.contains(i.id)).toList();
+    final counts = <String, int>{};
+    for (final i in active) {
+      counts[i.type] = (counts[i.type] ?? 0) + 1;
+    }
+    var type = '근력';
+    var best = 0;
+    counts.forEach((t, c) {
+      if (c > best) {
+        best = c;
+        type = t;
+      }
+    });
+    final names = <String>[
+      for (final i in active) _nameEdits[i.id] ?? i.name,
+      for (final c in _custom) c.name,
+    ];
+    return AssignedRoutine(
+      id: '',
+      name: 'AI 맞춤 루틴',
+      minutes: totalMinutes,
+      type: type,
+      reason: names.join(', '),
+      source: 'ai',
+    );
   }
 
   /// Writes the routine onto today's schedule (attach to the client's

--- a/frontend/flutter_trainer/lib/features/ai_routine/presentation/pages/ai_routine_page.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/presentation/pages/ai_routine_page.dart
@@ -216,6 +216,9 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
     for (final i in active) {
       counts[i.type] = (counts[i.type] ?? 0) + 1;
     }
+    for (final c in _custom) {
+      counts[c.type] = (counts[c.type] ?? 0) + 1;
+    }
     var type = '근력';
     var best = 0;
     counts.forEach((t, c) {
@@ -449,7 +452,9 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
 
   /// The routine editor column (right column on wide).
   List<Widget> _editorChildren(TrainerClient client) {
-    final routineAsync = ref.watch(aiRoutineProvider(client.id));
+    final routineAsync = ref.watch(
+      aiRoutineProvider((id: client.id, name: client.name)),
+    );
 
     return <Widget>[
       Row(

--- a/frontend/flutter_trainer/lib/features/ai_routine/presentation/pages/ai_routine_page.dart
+++ b/frontend/flutter_trainer/lib/features/ai_routine/presentation/pages/ai_routine_page.dart
@@ -4,12 +4,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/core/errors/app_error.dart';
 import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/elevation.dart';
 import 'package:oncare_trainer/design_system/tokens/layout.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/features/ai_routine/data/dtos/routine_dtos.dart';
 import 'package:oncare_trainer/features/ai_routine/data/repositories/ai_routine_repository.dart';
 import 'package:oncare_trainer/features/ai_routine/data/repositories/trainer_routine_repository.dart';
 import 'package:oncare_trainer/features/ai_routine/domain/entities/ai_routine_item.dart';
@@ -154,11 +156,25 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
             .read(chatRepositoryProvider)
             .sendTrainerMessage(clientId: client.id, text: noteText);
       }
-    } catch (_) {
+    } catch (e) {
       if (!mounted || !_isStillSelected(sentFor)) return;
       setState(() => _sending = false);
+      // A network/timeout failure is AMBIGUOUS: the backend may already
+      // have committed the assign before the client gave up waiting for a
+      // response (POST /routines is not idempotent — every attempt inserts
+      // a new row). Blindly telling the trainer to "다시 시도" risks a
+      // duplicate routine landing on the member's app, so this case gets a
+      // different message asking them to verify first (review; a real
+      // fix needs a backend idempotency/dedup key — tracked separately).
+      final ambiguousOutcome = e is NetworkError;
       messenger.showSnackBar(
-        const SnackBar(content: Text('전송에 실패했어요. 다시 시도해 주세요')),
+        SnackBar(
+          content: Text(
+            ambiguousOutcome
+                ? '응답을 받지 못했어요. 고객의 받은 루틴을 확인한 뒤 필요한 경우에만 다시 보내주세요'
+                : '전송에 실패했어요. 다시 시도해 주세요',
+          ),
+        ),
       );
       return;
     }
@@ -208,25 +224,16 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
   }
 
   /// A single summary [AssignedRoutine] for the real routine-assign API
-  /// (`RoutineOut` is one routine, not a per-exercise program): [type] is
-  /// the dominant AI-item type and the reason lists the exercise names.
+  /// (`RoutineOut` is one routine, not a per-exercise program): [type] and
+  /// [source] come from [summaryTypeAndSource] (extracted so the
+  /// all-custom-exercises path is directly unit-testable — review) and the
+  /// reason lists the exercise names.
   AssignedRoutine _summaryRoutine(List<AiRoutineItem> items, int totalMinutes) {
     final active = items.where((i) => !_removed.contains(i.id)).toList();
-    final counts = <String, int>{};
-    for (final i in active) {
-      counts[i.type] = (counts[i.type] ?? 0) + 1;
-    }
-    for (final c in _custom) {
-      counts[c.type] = (counts[c.type] ?? 0) + 1;
-    }
-    var type = '근력';
-    var best = 0;
-    counts.forEach((t, c) {
-      if (c > best) {
-        best = c;
-        type = t;
-      }
-    });
+    final result = summaryTypeAndSource(
+      aiItemTypes: <String>[for (final i in active) i.type],
+      customItemTypes: <String>[for (final c in _custom) c.type],
+    );
     final names = <String>[
       for (final i in active) _nameEdits[i.id] ?? i.name,
       for (final c in _custom) c.name,
@@ -235,9 +242,9 @@ class _AiRoutinePageState extends ConsumerState<AiRoutinePage> {
       id: '',
       name: 'AI 맞춤 루틴',
       minutes: totalMinutes,
-      type: type,
+      type: result.type,
       reason: names.join(', '),
-      source: 'ai',
+      source: result.source,
     );
   }
 

--- a/frontend/flutter_trainer/lib/features/clients/data/dtos/chat_dtos.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/dtos/chat_dtos.dart
@@ -5,24 +5,32 @@ import 'package:oncare_trainer/shared/models/client_chat_message.dart';
 /// DTO ↔ domain mapping is unit-testable.
 ///
 /// Shape: `{ id, sender, body, time_label, created_at }`. From the trainer's
-/// viewpoint `sender` is `trainer` | `client`; anything that isn't
-/// `trainer` maps to [ChatSender.client].
+/// viewpoint `sender` is `trainer` | `client`.
 ClientChatMessage chatMessageFromJson(Map<String, Object?> json) {
+  final sender = switch (json['sender']) {
+    'trainer' => ChatSender.trainer,
+    'client' => ChatSender.client,
+    _ => throw const FormatException('Invalid trainer chat sender.'),
+  };
   return ClientChatMessage(
-    id: json['id'] is String ? json['id']! as String : '',
-    sender: json['sender'] == 'trainer' ? ChatSender.trainer : ChatSender.client,
-    body: json['body'] is String ? json['body']! as String : '',
-    timeLabel: json['time_label'] is String ? json['time_label']! as String : '',
+    id: _requiredString(json, 'id'),
+    sender: sender,
+    body: _requiredString(json, 'body'),
+    timeLabel: _requiredString(json, 'time_label'),
     createdAt: _parseTime(json['created_at']),
   );
 }
 
-/// Parses the ISO `created_at` cursor; falls back to epoch so a malformed
-/// value sorts oldest rather than throwing.
 DateTime _parseTime(Object? v) {
   if (v is String) {
     final parsed = DateTime.tryParse(v);
     if (parsed != null) return parsed;
   }
-  return DateTime.fromMillisecondsSinceEpoch(0);
+  throw const FormatException('Invalid trainer chat created_at.');
+}
+
+String _requiredString(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is String) return value;
+  throw FormatException('Invalid trainer chat $key.');
 }

--- a/frontend/flutter_trainer/lib/features/clients/data/dtos/chat_dtos.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/dtos/chat_dtos.dart
@@ -1,0 +1,28 @@
+import 'package:oncare_trainer/shared/models/client_chat_message.dart';
+
+/// Maps a `ChatMessageOut` JSON element (trainer chat endpoints) into the
+/// domain [ClientChatMessage]. Kept separate from the Dio repository so the
+/// DTO ↔ domain mapping is unit-testable.
+///
+/// Shape: `{ id, sender, body, time_label, created_at }`. From the trainer's
+/// viewpoint `sender` is `trainer` | `client`; anything that isn't
+/// `trainer` maps to [ChatSender.client].
+ClientChatMessage chatMessageFromJson(Map<String, Object?> json) {
+  return ClientChatMessage(
+    id: json['id'] is String ? json['id']! as String : '',
+    sender: json['sender'] == 'trainer' ? ChatSender.trainer : ChatSender.client,
+    body: json['body'] is String ? json['body']! as String : '',
+    timeLabel: json['time_label'] is String ? json['time_label']! as String : '',
+    createdAt: _parseTime(json['created_at']),
+  );
+}
+
+/// Parses the ISO `created_at` cursor; falls back to epoch so a malformed
+/// value sorts oldest rather than throwing.
+DateTime _parseTime(Object? v) {
+  if (v is String) {
+    final parsed = DateTime.tryParse(v);
+    if (parsed != null) return parsed;
+  }
+  return DateTime.fromMillisecondsSinceEpoch(0);
+}

--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_chat_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_chat_repository.dart
@@ -23,14 +23,21 @@ class DioChatRepository implements ChatRepository {
       Stream<List<ClientChatMessage>>.fromFuture(_fetchThread(clientId));
 
   Future<List<ClientChatMessage>> _fetchThread(String clientId) async {
+    final encodedId = Uri.encodeComponent(clientId);
     try {
       final res = await _dio.get<List<dynamic>>(
-        '/trainer/clients/$clientId/chat',
+        '/trainer/clients/$encodedId/chat',
       );
       final data = res.data ?? const <dynamic>[];
       return data
-          .whereType<Map<String, Object?>>()
-          .map(chatMessageFromJson)
+          .map((item) {
+            if (item is! Map<String, Object?>) {
+              throw const FormatException(
+                'Expected an object in the trainer chat response.',
+              );
+            }
+            return chatMessageFromJson(item);
+          })
           .toList(growable: false);
     } on DioException catch (e) {
       throw AppError.fromDio(e);
@@ -44,9 +51,10 @@ class DioChatRepository implements ChatRepository {
   }) async {
     final trimmed = text.trim();
     if (trimmed.isEmpty) return;
+    final encodedId = Uri.encodeComponent(clientId);
     try {
       await _dio.post<Map<String, Object?>>(
-        '/trainer/clients/$clientId/chat',
+        '/trainer/clients/$encodedId/chat',
         data: <String, Object?>{'text': trimmed},
       );
     } on DioException catch (e) {
@@ -73,9 +81,10 @@ class DioChatRepository implements ChatRepository {
 
   @override
   Future<void> markThreadRead(String clientId) async {
+    final encodedId = Uri.encodeComponent(clientId);
     try {
       await _dio.post<Map<String, Object?>>(
-        '/trainer/clients/$clientId/chat/read',
+        '/trainer/clients/$encodedId/chat/read',
       );
     } on DioException catch (e) {
       throw AppError.fromDio(e);

--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_chat_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_chat_repository.dart
@@ -72,7 +72,16 @@ class DioChatRepository implements ChatRepository {
       final data = res.data ?? const <String, Object?>{};
       return <String, int>{
         for (final entry in data.entries)
-          if (entry.value is num) entry.key: (entry.value! as num).toInt(),
+          // Fail loud on a non-numeric count instead of silently dropping
+          // it, matching every other response parser in this class —
+          // a malformed entry here previously vanished from the roster
+          // badges with no signal (review).
+          entry.key: switch (entry.value) {
+            final num n => n.toInt(),
+            _ => throw FormatException(
+              'Expected a numeric unread count for "${entry.key}".',
+            ),
+          },
       };
     } on DioException catch (e) {
       throw AppError.fromDio(e);

--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_chat_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_chat_repository.dart
@@ -1,0 +1,84 @@
+import 'package:dio/dio.dart';
+
+import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/features/clients/data/dtos/chat_dtos.dart';
+import 'package:oncare_trainer/shared/models/client_chat_message.dart';
+import 'package:oncare_trainer/shared/services/chat_repository.dart';
+
+/// Trainer↔member chat against the FastAPI backend. The thread is the same
+/// row set the member app reads via `/me/coach/chat`, so a trainer message
+/// is received in the member app and vice versa.
+///
+/// Reads return single-emit streams (fetch → value); [ChatView] invalidates
+/// the thread/unread providers after a send or read so the next fetch shows
+/// the change. Selected when `USE_MOCK_API=false` (see
+/// [chatRepositoryProvider]).
+class DioChatRepository implements ChatRepository {
+  DioChatRepository(this._dio);
+
+  final Dio _dio;
+
+  @override
+  Stream<List<ClientChatMessage>> watchThread(String clientId) =>
+      Stream<List<ClientChatMessage>>.fromFuture(_fetchThread(clientId));
+
+  Future<List<ClientChatMessage>> _fetchThread(String clientId) async {
+    try {
+      final res = await _dio.get<List<dynamic>>(
+        '/trainer/clients/$clientId/chat',
+      );
+      final data = res.data ?? const <dynamic>[];
+      return data
+          .whereType<Map<String, Object?>>()
+          .map(chatMessageFromJson)
+          .toList(growable: false);
+    } on DioException catch (e) {
+      throw AppError.fromDio(e);
+    }
+  }
+
+  @override
+  Future<void> sendTrainerMessage({
+    required String clientId,
+    required String text,
+  }) async {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) return;
+    try {
+      await _dio.post<Map<String, Object?>>(
+        '/trainer/clients/$clientId/chat',
+        data: <String, Object?>{'text': trimmed},
+      );
+    } on DioException catch (e) {
+      throw AppError.fromDio(e);
+    }
+  }
+
+  @override
+  Stream<Map<String, int>> watchUnreadCounts() =>
+      Stream<Map<String, int>>.fromFuture(_fetchUnread());
+
+  Future<Map<String, int>> _fetchUnread() async {
+    try {
+      final res = await _dio.get<Map<String, Object?>>('/trainer/chat/unread');
+      final data = res.data ?? const <String, Object?>{};
+      return <String, int>{
+        for (final entry in data.entries)
+          if (entry.value is num) entry.key: (entry.value! as num).toInt(),
+      };
+    } on DioException catch (e) {
+      throw AppError.fromDio(e);
+    }
+  }
+
+  @override
+  Future<void> markThreadRead(String clientId) async {
+    try {
+      await _dio.post<Map<String, Object?>>(
+        '/trainer/clients/$clientId/chat/read',
+      );
+    } on DioException catch (e) {
+      throw AppError.fromDio(e);
+    }
+  }
+}

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
@@ -103,6 +103,7 @@ class _ChatViewState extends ConsumerState<ChatView> {
   @override
   Widget build(BuildContext context) {
     final messages = ref.watch(chatThreadProvider(widget.clientId));
+    final showDemoBanners = ref.watch(appConfigProvider).useMockApi;
 
     return Column(
       children: <Widget>[
@@ -126,23 +127,34 @@ class _ChatViewState extends ConsumerState<ChatView> {
                 final repo = ref.read(chatRepositoryProvider);
                 final realApi = !ref.read(appConfigProvider).useMockApi;
                 Future<void>.microtask(() async {
-                  await repo.markThreadRead(widget.clientId);
-                  // Drift updates unread via its stream; the Dio source
-                  // needs an explicit refetch of the badge counts.
-                  if (realApi && mounted) ref.invalidate(unreadCountsProvider);
+                  try {
+                    await repo.markThreadRead(widget.clientId);
+                    // Drift updates unread via its stream; the Dio source
+                    // needs an explicit refetch of the badge counts.
+                    if (realApi && mounted) {
+                      ref.invalidate(unreadCountsProvider);
+                    }
+                  } catch (_) {
+                    // Reading the thread still succeeded. A transient read
+                    // receipt failure may leave the badge visible, but must
+                    // not escape as an unhandled async error.
+                  }
                 });
               }
               return ListView(
                 controller: _scroll,
                 padding: const EdgeInsets.all(AppSpacing.lg),
                 children: <Widget>[
-                  _SystemBanner(clientName: widget.clientName),
-                  const SizedBox(height: AppSpacing.md),
+                  if (showDemoBanners) ...<Widget>[
+                    _SystemBanner(clientName: widget.clientName),
+                    const SizedBox(height: AppSpacing.md),
+                  ],
                   for (final m in list) ...<Widget>[
                     _Bubble(message: m, avatar: widget.clientAvatar),
                     const SizedBox(height: AppSpacing.md),
                   ],
-                  _SentBanner(clientName: widget.clientName),
+                  if (showDemoBanners)
+                    _SentBanner(clientName: widget.clientName),
                 ],
               );
             },

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
@@ -38,6 +38,11 @@ class _ChatViewState extends ConsumerState<ChatView> {
   final TextEditingController _input = TextEditingController();
   final ScrollController _scroll = ScrollController();
 
+  /// Mirrors the backend's `ChatSendRequest.text` cap (`max_length=2000`)
+  /// so an over-long message is rejected here, with a clear message,
+  /// instead of round-tripping to the server for a 422 (review).
+  static const int _maxMessageLength = 2000;
+
   /// A send is in flight — blocks re-entry (button mash / IME send)
   /// from inserting the same message twice.
   bool _sending = false;
@@ -58,6 +63,12 @@ class _ChatViewState extends ConsumerState<ChatView> {
     final text = _input.text;
     if (text.trim().isEmpty) return;
     final messenger = ScaffoldMessenger.of(context);
+    if (text.trim().length > _maxMessageLength) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('메시지가 너무 길어요 (최대 2000자)')),
+      );
+      return;
+    }
     setState(() => _sending = true);
     try {
       await ref

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
@@ -81,12 +81,16 @@ class _ChatViewState extends ConsumerState<ChatView> {
     // Clear only after the insert succeeds so the text isn't lost on error.
     _input.clear();
     // Drift streams re-emit on write; the Dio source is a single fetch, so
-    // refetch the thread + unread badges after a real-API send.
+    // refetch the thread + unread badges after a real-API send. NOTE: don't
+    // scroll here — `ref.invalidate` only *starts* an async refetch, so the
+    // list the user is looking at right now is still the pre-send one; the
+    // `data:` branch below already scrolls to bottom once the new message
+    // actually renders (it fires on every list-length change, which covers
+    // both the reactive Drift path and this refetch) (review).
     if (!ref.read(appConfigProvider).useMockApi) {
       ref.invalidate(chatThreadProvider(widget.clientId));
       ref.invalidate(unreadCountsProvider);
     }
-    _scrollToBottom();
   }
 
   void _scrollToBottom() {

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:oncare_trainer/core/config/app_config.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
@@ -79,6 +80,12 @@ class _ChatViewState extends ConsumerState<ChatView> {
     if (!mounted) return;
     // Clear only after the insert succeeds so the text isn't lost on error.
     _input.clear();
+    // Drift streams re-emit on write; the Dio source is a single fetch, so
+    // refetch the thread + unread badges after a real-API send.
+    if (!ref.read(appConfigProvider).useMockApi) {
+      ref.invalidate(chatThreadProvider(widget.clientId));
+      ref.invalidate(unreadCountsProvider);
+    }
     _scrollToBottom();
   }
 
@@ -117,9 +124,13 @@ class _ChatViewState extends ConsumerState<ChatView> {
                 // messages that arrive while it stays open. Deferred so
                 // the write never runs inside build.
                 final repo = ref.read(chatRepositoryProvider);
-                Future<void>.microtask(
-                  () => repo.markThreadRead(widget.clientId),
-                );
+                final realApi = !ref.read(appConfigProvider).useMockApi;
+                Future<void>.microtask(() async {
+                  await repo.markThreadRead(widget.clientId);
+                  // Drift updates unread via its stream; the Dio source
+                  // needs an explicit refetch of the badge counts.
+                  if (realApi && mounted) ref.invalidate(unreadCountsProvider);
+                });
               }
               return ListView(
                 controller: _scroll,

--- a/frontend/flutter_trainer/lib/shared/services/chat_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/chat_repository.dart
@@ -1,17 +1,42 @@
 import 'package:drift/drift.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/core/network/dio_client.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
+import 'package:oncare_trainer/features/clients/data/repositories/dio_chat_repository.dart';
 import 'package:oncare_trainer/shared/models/client_chat_message.dart';
 
+/// Reads and sends messages in a trainer↔member chat thread.
+///
+/// Two implementations sit behind this contract (selected by
+/// [chatRepositoryProvider] via [AppConfig.useMockApi]):
+///  * [DriftChatRepository] — local drift, demo / `USE_MOCK_API=true`;
+///  * [DioChatRepository] — the real FastAPI backend (thread shared with
+///    the member app).
+///
+/// The drift source is reactive (streams re-emit on write); the Dio source
+/// emits a single fetch, so callers invalidate the thread/unread providers
+/// after send/read (see [ChatView]).
+abstract interface class ChatRepository {
+  Stream<List<ClientChatMessage>> watchThread(String clientId);
+  Future<void> sendTrainerMessage({
+    required String clientId,
+    required String text,
+  });
+  Stream<Map<String, int>> watchUnreadCounts();
+  Future<void> markThreadRead(String clientId);
+}
+
 /// Reads and appends messages in a client's chat thread (drift-backed).
-class ChatRepository {
+class DriftChatRepository implements ChatRepository {
   /// Creates the repository over [_db].
-  const ChatRepository(this._db);
+  const DriftChatRepository(this._db);
 
   final AppDatabase _db;
 
   /// Streams a client's messages in chronological order.
+  @override
   Stream<List<ClientChatMessage>> watchThread(String clientId) {
     final query = _db.select(_db.clientChatMessages)
       ..where((t) => t.clientId.equals(clientId))
@@ -25,6 +50,7 @@ class ChatRepository {
   /// preview (`lastMessage`/`lastTime`) in one transaction. The `chat-`
   /// id (no `seed-` prefix) means it survives re-seeding, and `now()`
   /// sorts it after the seed thread.
+  @override
   Future<void> sendTrainerMessage({
     required String clientId,
     required String text,
@@ -59,6 +85,7 @@ class ChatRepository {
   /// Per-client unread counts — client-sent messages after the trainer's
   /// last-read marker (an `AppKeyValues` row per client, so no schema
   /// migration). Clients with zero unread are absent.
+  @override
   Stream<Map<String, int>> watchUnreadCounts() {
     // The marker is a monotonic `rowid`, not an epoch second: two client
     // messages that land in the same second share a `created_at` value,
@@ -92,6 +119,7 @@ class ChatRepository {
   /// write entirely. That matters because `watchUnreadCounts` watches
   /// `app_key_values` — an unconditional write would emit on that stream
   /// and rebuild the list on every call (review PR 241).
+  @override
   Future<void> markThreadRead(String clientId) async {
     final row =
         await _db
@@ -132,9 +160,14 @@ class ChatRepository {
       '${t.minute.toString().padLeft(2, '0')}';
 }
 
-/// Provides the [ChatRepository].
+/// Provides the [ChatRepository]: the real Dio-backed source (thread shared
+/// with the member app) or the local drift source for demo / `USE_MOCK_API`.
 final chatRepositoryProvider = Provider<ChatRepository>((ref) {
-  return ChatRepository(ref.watch(appDatabaseProvider));
+  final config = ref.watch(appConfigProvider);
+  if (config.useMockApi) {
+    return DriftChatRepository(ref.watch(appDatabaseProvider));
+  }
+  return DioChatRepository(ref.watch(dioProvider));
 });
 
 /// Streams per-client unread message counts for the 고객 list badges.

--- a/frontend/flutter_trainer/lib/shared/services/chat_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/chat_repository.dart
@@ -121,17 +121,16 @@ class DriftChatRepository implements ChatRepository {
   /// and rebuild the list on every call (review PR 241).
   @override
   Future<void> markThreadRead(String clientId) async {
-    final row =
-        await _db
-            .customSelect(
-              'SELECT MAX(rowid) AS r FROM client_chat_messages '
-              "WHERE client_id = ?1 AND sender = 'client'",
-              variables: <Variable<Object>>[Variable<String>(clientId)],
-              readsFrom: <ResultSetImplementation<Object?, Object?>>{
-                _db.clientChatMessages,
-              },
-            )
-            .getSingleOrNull();
+    final row = await _db
+        .customSelect(
+          'SELECT MAX(rowid) AS r FROM client_chat_messages '
+          "WHERE client_id = ?1 AND sender = 'client'",
+          variables: <Variable<Object>>[Variable<String>(clientId)],
+          readsFrom: <ResultSetImplementation<Object?, Object?>>{
+            _db.clientChatMessages,
+          },
+        )
+        .getSingleOrNull();
     // MAX over no client message returns NULL — nothing could be unread.
     final marker = row?.read<int?>('r');
     if (marker == null) return;
@@ -176,7 +175,7 @@ final unreadCountsProvider = StreamProvider<Map<String, int>>((ref) {
 });
 
 /// Streams a client's chat thread by client id.
-final chatThreadProvider =
-    StreamProvider.family<List<ClientChatMessage>, String>((ref, clientId) {
+final chatThreadProvider = StreamProvider.autoDispose
+    .family<List<ClientChatMessage>, String>((ref, clientId) {
       return ref.watch(chatRepositoryProvider).watchThread(clientId);
     });

--- a/frontend/flutter_trainer/test/features/ai_routine/ai_routine_page_test.dart
+++ b/frontend/flutter_trainer/test/features/ai_routine/ai_routine_page_test.dart
@@ -3,12 +3,26 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/core/errors/app_error.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/storage/seed_data.dart';
 import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/features/ai_routine/data/repositories/ai_routine_repository.dart';
+import 'package:oncare_trainer/features/ai_routine/data/repositories/trainer_routine_repository.dart';
+import 'package:oncare_trainer/features/ai_routine/domain/entities/assigned_routine.dart';
+import 'package:oncare_trainer/features/auth/data/repositories/dio_trainer_auth_repository.dart'
+    show trainerAuthRepositoryProvider;
+import 'package:oncare_trainer/features/auth/domain/entities/auth_tokens.dart';
+import 'package:oncare_trainer/features/auth/domain/repositories/trainer_auth_repository.dart';
+import 'package:oncare_trainer/features/clients/domain/entities/client_diet_entry.dart';
+import 'package:oncare_trainer/features/clients/domain/entities/routine_history_entry.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
+import 'package:oncare_trainer/shared/models/client_chat_message.dart';
+import 'package:oncare_trainer/shared/models/trainer_client.dart';
+import 'package:oncare_trainer/shared/models/trainer_profile.dart';
 import 'package:oncare_trainer/shared/services/chat_repository.dart';
+import 'package:oncare_trainer/shared/services/client_repository.dart';
 
 import '../../helpers/pump_app.dart';
 
@@ -59,6 +73,131 @@ class _SlowCountingRoutineRepository extends AiRoutineRepository {
       program: program,
     );
   }
+}
+
+/// A fixed one-client roster for real-API-mode tests (real
+/// `ClientRepository` has no roster mutations and a single fetch, unlike
+/// the reactive drift source).
+class _FixedClientRepository implements ClientRepository {
+  const _FixedClientRepository(this._clients);
+
+  final List<TrainerClient> _clients;
+
+  @override
+  bool get supportsRosterMutations => false;
+
+  @override
+  Stream<List<TrainerClient>> watchClients() => Stream.value(_clients);
+
+  @override
+  Stream<List<TrainerClient>> watchClientsPrioritized() =>
+      Stream.value(_clients);
+
+  @override
+  Stream<int> watchTodayReservationCount() => const Stream<int>.empty();
+
+  @override
+  Stream<List<ClientDietEntry>> watchDiet(String clientId) =>
+      Stream.value(const <ClientDietEntry>[]);
+
+  @override
+  Stream<List<RoutineHistoryEntry>> watchHistory(String clientId) =>
+      Stream.value(const <RoutineHistoryEntry>[]);
+
+  @override
+  Future<bool> clientNameExists(String name) async => false;
+
+  @override
+  Future<bool> addClient({required String name, required String goal}) async =>
+      false;
+
+  @override
+  Future<void> setClientActive(String id, bool active) async {}
+}
+
+/// Spies on `assignRoutine` (captures the [AssignedRoutine] sent) and can
+/// be configured to throw a specific error, so tests can distinguish the
+/// ambiguous (network) failure message from the generic one (subin21cc
+/// review Major#2a).
+class _SpyTrainerRoutineRepository implements TrainerRoutineRepository {
+  _SpyTrainerRoutineRepository({this.throwOnAssign});
+
+  final Object? throwOnAssign;
+  AssignedRoutine? lastAssigned;
+
+  @override
+  Future<void> assignRoutine(String memberId, AssignedRoutine routine) async {
+    if (throwOnAssign != null) throw throwOnAssign!;
+    lastAssigned = routine;
+  }
+
+  @override
+  Stream<List<AssignedRoutine>> watchAssignedRoutines(String memberId) =>
+      Stream.value(const <AssignedRoutine>[]);
+}
+
+/// A real-API-mode chat repository whose note send can be made to fail,
+/// to prove a failed note doesn't block the "전송 완료" claim once the
+/// routine itself was assigned (subin21cc review Major#2a).
+class _FakeRealChatRepository implements ChatRepository {
+  _FakeRealChatRepository({this.failSend = false});
+
+  final bool failSend;
+
+  @override
+  Stream<List<ClientChatMessage>> watchThread(String clientId) =>
+      Stream.value(const <ClientChatMessage>[]);
+
+  @override
+  Future<void> sendTrainerMessage({
+    required String clientId,
+    required String text,
+  }) async {
+    if (failSend) throw Exception('note failed');
+  }
+
+  @override
+  Stream<Map<String, int>> watchUnreadCounts() =>
+      Stream.value(const <String, int>{});
+
+  @override
+  Future<void> markThreadRead(String clientId) async {}
+}
+
+/// Resolves `fetchProfile` immediately with the seed trainer profile, so
+/// `SessionController._restore()` doesn't hit a real Dio call during
+/// real-API-mode tests (the persisted token would otherwise trigger
+/// `DioTrainerAuthRepository.fetchProfile`).
+class _FakeTrainerAuthRepository implements TrainerAuthRepository {
+  const _FakeTrainerAuthRepository();
+
+  static const _tokens = TrainerAuthTokens(access: 'a', refresh: 'r');
+
+  @override
+  Future<TrainerAuthTokens> login({
+    required String email,
+    required String password,
+  }) async => _tokens;
+
+  @override
+  Future<TrainerAuthTokens> register({
+    required String email,
+    required String password,
+    required String name,
+  }) async => _tokens;
+
+  @override
+  Future<TrainerAuthTokens> socialLogin({
+    required String provider,
+    required String token,
+  }) async => _tokens;
+
+  @override
+  Future<TrainerAuthTokens> refresh(String refreshToken) async => _tokens;
+
+  @override
+  Future<TrainerProfile> fetchProfile(String accessToken) async =>
+      seedTrainerProfile;
 }
 
 void main() {
@@ -654,5 +793,161 @@ void main() {
 
       expect(find.text('운동을 하나 이상 추가해 주세요'), findsOneWidget);
     });
+  });
+
+  group('AiRoutinePage — real API mode (subin21cc review)', () {
+    // Matches a seeded drift client by NAME so aiRoutineProvider's
+    // clientName fallback still resolves local AI suggestions for a
+    // client id the real API (not drift) issued.
+    const realClient = TrainerClient(
+      id: 'real-client-1',
+      name: '김민수',
+      avatar: '김',
+      goal: '혈압 관리',
+      lastMessage: '-',
+      lastTime: '-',
+      active: true,
+      calories: 0,
+      sodiumMg: 2100,
+      sugarG: 0,
+      lastRoutine: '-',
+      weekCompletion: <int>[0, 0, 0, 0, 0, 0, 0],
+      sodiumWeek: <int>[],
+    );
+
+    const realConfig = AppConfig(
+      environment: Environment.dev,
+      apiBaseUrl: 'http://localhost/v1',
+      useMockApi: false,
+    );
+
+    Future<_SpyTrainerRoutineRepository> openRealApiTab(
+      WidgetTester tester, {
+      bool chatFails = false,
+      Object? assignError,
+    }) async {
+      final routineRepo = _SpyTrainerRoutineRepository(
+        throwOnAssign: assignError,
+      );
+      await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        extraOverrides: <Override>[
+          appConfigProvider.overrideWithValue(realConfig),
+          clientRepositoryProvider.overrideWithValue(
+            _FixedClientRepository(<TrainerClient>[realClient]),
+          ),
+          trainerAuthRepositoryProvider.overrideWithValue(
+            const _FakeTrainerAuthRepository(),
+          ),
+          trainerRoutineRepositoryProvider.overrideWithValue(routineRepo),
+          chatRepositoryProvider.overrideWithValue(
+            _FakeRealChatRepository(failSend: chatFails),
+          ),
+        ],
+      );
+      await tester.tap(find.text('AI루틴'));
+      await settle(tester);
+      return routineRepo;
+    }
+
+    Future<void> tapSend(WidgetTester tester) async {
+      await tester.scrollUntilVisible(
+        find.textContaining('님에게 전송'),
+        150,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.ensureVisible(find.textContaining('님에게 전송'));
+      await tester.pump();
+      await tester.tap(find.textContaining('님에게 전송'));
+      await settle(tester);
+    }
+
+    testWidgets(
+      'assign succeeds even when the chat note fails: still shows the '
+      'send confirmation (assigning IS the delivery; the note is cosmetic)',
+      (tester) async {
+        final routineRepo = await openRealApiTab(tester, chatFails: true);
+
+        await tapSend(tester);
+
+        expect(find.text('✓ 김민수님에게 전송 완료!'), findsOneWidget);
+        expect(routineRepo.lastAssigned, isNotNull);
+      },
+    );
+
+    testWidgets(
+      'a network/timeout assign failure shows the ambiguous verify-first '
+      "message, not '다시 시도' (assign is not idempotent — retrying on an "
+      'ambiguous failure risks a duplicate routine)',
+      (tester) async {
+        await openRealApiTab(tester, assignError: const NetworkError());
+
+        await tapSend(tester);
+
+        expect(
+          find.text('응답을 받지 못했어요. 고객의 받은 루틴을 확인한 뒤 필요한 경우에만 다시 보내주세요'),
+          findsOneWidget,
+        );
+        expect(find.text('전송에 실패했어요. 다시 시도해 주세요'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'a non-network assign failure shows the generic retry message '
+      '(a clear failure, safe to retry)',
+      (tester) async {
+        await openRealApiTab(tester, assignError: const ServerError());
+
+        await tapSend(tester);
+
+        expect(find.text('전송에 실패했어요. 다시 시도해 주세요'), findsOneWidget);
+        expect(
+          find.text('응답을 받지 못했어요. 고객의 받은 루틴을 확인한 뒤 필요한 경우에만 다시 보내주세요'),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets(
+      'an all-custom send (every AI suggestion removed) assigns type/source '
+      "from the custom exercises, not '근력'/'ai' by default",
+      (tester) async {
+        final routineRepo = await openRealApiTab(tester);
+
+        // Remove all 3 seeded AI suggestions for 김민수.
+        for (var i = 0; i < 3; i++) {
+          await tester.tap(find.byIcon(Icons.close).first);
+          await tester.pump();
+        }
+
+        await tester.scrollUntilVisible(
+          find.text('＋ 운동 직접 추가'),
+          150,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.ensureVisible(find.text('＋ 운동 직접 추가'));
+        await tester.pump();
+        await tester.tap(find.text('＋ 운동 직접 추가'));
+        await tester.pump();
+
+        await tester.enterText(find.byType(TextField), '스트레칭 A');
+        // Default type chip is 근력 — switch to 스트레칭 so the assigned
+        // type is provably derived from the custom exercise, not a
+        // coincidental default.
+        await tester.tap(find.text('스트레칭'));
+        await tester.pump();
+        await tester.ensureVisible(find.text('추가하기'));
+        await tester.pump();
+        await tester.tap(find.text('추가하기'));
+        await tester.pump();
+
+        await tapSend(tester);
+
+        expect(find.text('✓ 김민수님에게 전송 완료!'), findsOneWidget);
+        expect(routineRepo.lastAssigned?.type, '스트레칭');
+        expect(routineRepo.lastAssigned?.source, 'trainer');
+      },
+    );
   });
 }

--- a/frontend/flutter_trainer/test/features/ai_routine/ai_routine_page_test.dart
+++ b/frontend/flutter_trainer/test/features/ai_routine/ai_routine_page_test.dart
@@ -13,7 +13,7 @@ import 'package:oncare_trainer/shared/services/chat_repository.dart';
 import '../../helpers/pump_app.dart';
 
 /// A chat repository whose sends always fail.
-class _FailingChatRepository extends ChatRepository {
+class _FailingChatRepository extends DriftChatRepository {
   const _FailingChatRepository(super.db);
 
   @override
@@ -25,7 +25,7 @@ class _FailingChatRepository extends ChatRepository {
 
 /// A chat repository whose sends resolve slowly, so a client switch can
 /// land while a send is still in flight (review PR 239).
-class _SlowChatRepository extends ChatRepository {
+class _SlowChatRepository extends DriftChatRepository {
   const _SlowChatRepository(super.db);
 
   @override

--- a/frontend/flutter_trainer/test/features/ai_routine/ai_routine_page_test.dart
+++ b/frontend/flutter_trainer/test/features/ai_routine/ai_routine_page_test.dart
@@ -84,6 +84,20 @@ void main() {
     });
 
     test(
+      'resolves live backend ids through the matching client name',
+      () async {
+        final repo = AiRoutineRepository(db);
+
+        final minsu = await repo
+            .watchRoutine('user-demo', clientName: '김민수')
+            .first;
+
+        expect(minsu.length, 3);
+        expect(minsu.first.name, '저강도 유산소 (걷기)');
+      },
+    );
+
+    test(
       'registerToTodaySchedule attaches to an existing 예정 session',
       () async {
         final repo = AiRoutineRepository(db);

--- a/frontend/flutter_trainer/test/features/ai_routine/dio_trainer_routine_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/ai_routine/dio_trainer_routine_repository_test.dart
@@ -9,19 +9,19 @@ import 'package:oncare_trainer/features/ai_routine/domain/entities/assigned_rout
 class _MockDio extends Mock implements Dio {}
 
 Response<T> _ok<T>(T body, String path) => Response<T>(
-      requestOptions: RequestOptions(path: path),
-      statusCode: 201,
-      data: body,
-    );
+  requestOptions: RequestOptions(path: path),
+  statusCode: 201,
+  data: body,
+);
 
 DioException _httpError(int status, String path) => DioException(
-      requestOptions: RequestOptions(path: path),
-      type: DioExceptionType.badResponse,
-      response: Response<Object?>(
-        requestOptions: RequestOptions(path: path),
-        statusCode: status,
-      ),
-    );
+  requestOptions: RequestOptions(path: path),
+  type: DioExceptionType.badResponse,
+  response: Response<Object?>(
+    requestOptions: RequestOptions(path: path),
+    statusCode: status,
+  ),
+);
 
 void main() {
   late _MockDio dio;
@@ -32,30 +32,34 @@ void main() {
     repo = DioTrainerRoutineRepository(dio);
   });
 
-  test('assignRoutine POSTs the normalised RoutineAssignRequest body', () async {
-    when(() => dio.post<Map<String, Object?>>(
+  test(
+    'assignRoutine POSTs the normalised RoutineAssignRequest body',
+    () async {
+      when(
+        () => dio.post<Map<String, Object?>>(
           '/trainer/clients/m1/routines',
           data: any(named: 'data'),
-        )).thenAnswer(
-      (_) async => _ok<Map<String, Object?>>(
-        <String, Object?>{'id': 'r1'},
-        '/trainer/clients/m1/routines',
-      ),
-    );
+        ),
+      ).thenAnswer(
+        (_) async => _ok<Map<String, Object?>>(<String, Object?>{
+          'id': 'r1',
+        }, '/trainer/clients/m1/routines'),
+      );
 
-    await repo.assignRoutine(
-      'm1',
-      const AssignedRoutine(
-        id: '',
-        name: 'AI 맞춤 루틴',
-        minutes: 999, // clamped to 600
-        type: 'weird', // -> 근력
-        reason: '걷기, 스쿼트',
-        source: 'ai',
-      ),
-    );
+      await repo.assignRoutine(
+        'm1',
+        const AssignedRoutine(
+          id: '',
+          name: 'AI 맞춤 루틴',
+          minutes: 999, // clamped to 600
+          type: 'weird', // -> 근력
+          reason: '걷기, 스쿼트',
+          source: 'ai',
+        ),
+      );
 
-    verify(() => dio.post<Map<String, Object?>>(
+      verify(
+        () => dio.post<Map<String, Object?>>(
           '/trainer/clients/m1/routines',
           data: <String, Object?>{
             'name': 'AI 맞춤 루틴',
@@ -64,14 +68,18 @@ void main() {
             'reason': '걷기, 스쿼트',
             'source': 'ai',
           },
-        )).called(1);
-  });
+        ),
+      ).called(1);
+    },
+  );
 
   test('assignRoutine surfaces a failure as AppError', () async {
-    when(() => dio.post<Map<String, Object?>>(
-          '/trainer/clients/m1/routines',
-          data: any(named: 'data'),
-        )).thenThrow(_httpError(500, '/trainer/clients/m1/routines'));
+    when(
+      () => dio.post<Map<String, Object?>>(
+        '/trainer/clients/m1/routines',
+        data: any(named: 'data'),
+      ),
+    ).thenThrow(_httpError(500, '/trainer/clients/m1/routines'));
 
     await expectLater(
       repo.assignRoutine(
@@ -90,12 +98,21 @@ void main() {
   });
 
   test('watchAssignedRoutines parses the list', () async {
-    when(() => dio.get<List<dynamic>>('/trainer/clients/m1/routines')).thenAnswer(
+    when(
+      () => dio.get<List<dynamic>>('/trainer/clients/m1/routines'),
+    ).thenAnswer(
       (_) async => Response<List<dynamic>>(
         requestOptions: RequestOptions(path: '/trainer/clients/m1/routines'),
         statusCode: 200,
         data: <dynamic>[
-          <String, Object?>{'id': 'r1', 'name': '저강도 유산소', 'minutes': 30, 'type': '유산소', 'reason': '혈압', 'source': 'ai'},
+          <String, Object?>{
+            'id': 'r1',
+            'name': '저강도 유산소',
+            'minutes': 30,
+            'type': '유산소',
+            'reason': '혈압',
+            'source': 'ai',
+          },
         ],
       ),
     );
@@ -106,12 +123,77 @@ void main() {
   });
 
   test('watchAssignedRoutines surfaces a 404 as NotFoundError', () async {
-    when(() => dio.get<List<dynamic>>('/trainer/clients/x/routines'))
-        .thenThrow(_httpError(404, '/trainer/clients/x/routines'));
+    when(
+      () => dio.get<List<dynamic>>('/trainer/clients/x/routines'),
+    ).thenThrow(_httpError(404, '/trainer/clients/x/routines'));
 
     await expectLater(
       repo.watchAssignedRoutines('x'),
       emitsError(isA<NotFoundError>()),
+    );
+  });
+
+  test('encodes an opaque member id in routine paths', () async {
+    const encoded = 'member%2Fwith%3Freserved';
+    when(
+      () => dio.post<Map<String, Object?>>(
+        '/trainer/clients/$encoded/routines',
+        data: any(named: 'data'),
+      ),
+    ).thenAnswer(
+      (_) async => _ok<Map<String, Object?>>(
+        const <String, Object?>{},
+        '/trainer/clients/$encoded/routines',
+      ),
+    );
+    when(
+      () => dio.get<List<dynamic>>('/trainer/clients/$encoded/routines'),
+    ).thenAnswer(
+      (_) async => Response<List<dynamic>>(
+        requestOptions: RequestOptions(
+          path: '/trainer/clients/$encoded/routines',
+        ),
+        statusCode: 200,
+        data: const <dynamic>[],
+      ),
+    );
+    const routine = AssignedRoutine(
+      id: '',
+      name: 'x',
+      minutes: 10,
+      type: '근력',
+      reason: '',
+      source: 'ai',
+    );
+
+    await repo.assignRoutine('member/with?reserved', routine);
+    await repo.watchAssignedRoutines('member/with?reserved').first;
+
+    verify(
+      () => dio.post<Map<String, Object?>>(
+        '/trainer/clients/$encoded/routines',
+        data: any(named: 'data'),
+      ),
+    ).called(1);
+    verify(
+      () => dio.get<List<dynamic>>('/trainer/clients/$encoded/routines'),
+    ).called(1);
+  });
+
+  test('malformed routine entries fail instead of being dropped', () {
+    when(
+      () => dio.get<List<dynamic>>('/trainer/clients/m1/routines'),
+    ).thenAnswer(
+      (_) async => Response<List<dynamic>>(
+        requestOptions: RequestOptions(path: '/trainer/clients/m1/routines'),
+        statusCode: 200,
+        data: <dynamic>['not-an-object'],
+      ),
+    );
+
+    expect(
+      repo.watchAssignedRoutines('m1'),
+      emitsError(isA<FormatException>()),
     );
   });
 }

--- a/frontend/flutter_trainer/test/features/ai_routine/dio_trainer_routine_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/ai_routine/dio_trainer_routine_repository_test.dart
@@ -1,0 +1,117 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/features/ai_routine/data/repositories/dio_trainer_routine_repository.dart';
+import 'package:oncare_trainer/features/ai_routine/domain/entities/assigned_routine.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+Response<T> _ok<T>(T body, String path) => Response<T>(
+      requestOptions: RequestOptions(path: path),
+      statusCode: 201,
+      data: body,
+    );
+
+DioException _httpError(int status, String path) => DioException(
+      requestOptions: RequestOptions(path: path),
+      type: DioExceptionType.badResponse,
+      response: Response<Object?>(
+        requestOptions: RequestOptions(path: path),
+        statusCode: status,
+      ),
+    );
+
+void main() {
+  late _MockDio dio;
+  late DioTrainerRoutineRepository repo;
+
+  setUp(() {
+    dio = _MockDio();
+    repo = DioTrainerRoutineRepository(dio);
+  });
+
+  test('assignRoutine POSTs the normalised RoutineAssignRequest body', () async {
+    when(() => dio.post<Map<String, Object?>>(
+          '/trainer/clients/m1/routines',
+          data: any(named: 'data'),
+        )).thenAnswer(
+      (_) async => _ok<Map<String, Object?>>(
+        <String, Object?>{'id': 'r1'},
+        '/trainer/clients/m1/routines',
+      ),
+    );
+
+    await repo.assignRoutine(
+      'm1',
+      const AssignedRoutine(
+        id: '',
+        name: 'AI 맞춤 루틴',
+        minutes: 999, // clamped to 600
+        type: 'weird', // -> 근력
+        reason: '걷기, 스쿼트',
+        source: 'ai',
+      ),
+    );
+
+    verify(() => dio.post<Map<String, Object?>>(
+          '/trainer/clients/m1/routines',
+          data: <String, Object?>{
+            'name': 'AI 맞춤 루틴',
+            'minutes': 600,
+            'type': '근력',
+            'reason': '걷기, 스쿼트',
+            'source': 'ai',
+          },
+        )).called(1);
+  });
+
+  test('assignRoutine surfaces a failure as AppError', () async {
+    when(() => dio.post<Map<String, Object?>>(
+          '/trainer/clients/m1/routines',
+          data: any(named: 'data'),
+        )).thenThrow(_httpError(500, '/trainer/clients/m1/routines'));
+
+    await expectLater(
+      repo.assignRoutine(
+        'm1',
+        const AssignedRoutine(
+          id: '',
+          name: 'x',
+          minutes: 30,
+          type: '근력',
+          reason: '',
+          source: 'ai',
+        ),
+      ),
+      throwsA(isA<AppError>()),
+    );
+  });
+
+  test('watchAssignedRoutines parses the list', () async {
+    when(() => dio.get<List<dynamic>>('/trainer/clients/m1/routines')).thenAnswer(
+      (_) async => Response<List<dynamic>>(
+        requestOptions: RequestOptions(path: '/trainer/clients/m1/routines'),
+        statusCode: 200,
+        data: <dynamic>[
+          <String, Object?>{'id': 'r1', 'name': '저강도 유산소', 'minutes': 30, 'type': '유산소', 'reason': '혈압', 'source': 'ai'},
+        ],
+      ),
+    );
+
+    final routines = await repo.watchAssignedRoutines('m1').first;
+    expect(routines.single.name, '저강도 유산소');
+    expect(routines.single.type, '유산소');
+  });
+
+  test('watchAssignedRoutines surfaces a 404 as NotFoundError', () async {
+    when(() => dio.get<List<dynamic>>('/trainer/clients/x/routines'))
+        .thenThrow(_httpError(404, '/trainer/clients/x/routines'));
+
+    await expectLater(
+      repo.watchAssignedRoutines('x'),
+      emitsError(isA<NotFoundError>()),
+    );
+  });
+}

--- a/frontend/flutter_trainer/test/features/ai_routine/routine_dtos_test.dart
+++ b/frontend/flutter_trainer/test/features/ai_routine/routine_dtos_test.dart
@@ -63,4 +63,44 @@ void main() {
       expect(assignRoutineToJson(_routine(source: 'anything'))['source'], 'ai');
     });
   });
+
+  group('summaryTypeAndSource', () {
+    test(
+      'an all-custom routine (every AI suggestion removed) is type + '
+      "source from the custom exercises, not '근력'/'ai' by default "
+      '(review: this used to silently drop custom types, defaulting to '
+      "근력/ai even when every exercise was a trainer-added 스트레칭)",
+      () {
+        final result = summaryTypeAndSource(
+          aiItemTypes: const <String>[], // every AI suggestion was removed
+          customItemTypes: const <String>['스트레칭', '스트레칭', '스트레칭'],
+        );
+        expect(result.type, '스트레칭');
+        expect(result.source, 'trainer');
+      },
+    );
+
+    test('mixed AI + custom: source is ai when any AI item remains', () {
+      final result = summaryTypeAndSource(
+        aiItemTypes: const <String>['유산소'],
+        customItemTypes: const <String>['스트레칭', '스트레칭'],
+      );
+      // 2 스트레칭 outvotes 1 유산소, but an AI item is still present.
+      expect(result.type, '스트레칭');
+      expect(result.source, 'ai');
+    });
+
+    test(
+      'defaults type to 근력 when there are no exercises at all (source '
+      'still trainer — no AI item is present to attribute it to)',
+      () {
+        final result = summaryTypeAndSource(
+          aiItemTypes: const <String>[],
+          customItemTypes: const <String>[],
+        );
+        expect(result.type, '근력');
+        expect(result.source, 'trainer');
+      },
+    );
+  });
 }

--- a/frontend/flutter_trainer/test/features/ai_routine/routine_dtos_test.dart
+++ b/frontend/flutter_trainer/test/features/ai_routine/routine_dtos_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/features/ai_routine/data/dtos/routine_dtos.dart';
+import 'package:oncare_trainer/features/ai_routine/domain/entities/assigned_routine.dart';
+
+AssignedRoutine _routine({
+  String name = 'AI 맞춤 루틴',
+  int minutes = 30,
+  String type = '유산소',
+  String reason = '걷기',
+  String source = 'ai',
+}) => AssignedRoutine(
+      id: '',
+      name: name,
+      minutes: minutes,
+      type: type,
+      reason: reason,
+      source: source,
+    );
+
+void main() {
+  group('assignedRoutineFromJson', () {
+    test('maps RoutineOut into AssignedRoutine', () {
+      final r = assignedRoutineFromJson(<String, Object?>{
+        'id': 'r1',
+        'name': '저강도 유산소',
+        'minutes': 30,
+        'type': '유산소',
+        'reason': '혈압 안정',
+        'source': 'ai',
+      });
+      expect(r.id, 'r1');
+      expect(r.minutes, 30);
+      expect(r.type, '유산소');
+      expect(r.source, 'ai');
+    });
+
+    test('tolerates double minutes (web JSON)', () {
+      final r = assignedRoutineFromJson(<String, Object?>{'minutes': 45.0});
+      expect(r.minutes, 45);
+    });
+  });
+
+  group('assignRoutineToJson (normalises for the backend validators)', () {
+    test('clamps minutes to 0..600', () {
+      expect(assignRoutineToJson(_routine(minutes: 999))['minutes'], 600);
+      expect(assignRoutineToJson(_routine(minutes: -5))['minutes'], 0);
+    });
+
+    test('falls back to 근력 for an invalid type', () {
+      expect(assignRoutineToJson(_routine(type: 'weird'))['type'], '근력');
+      expect(assignRoutineToJson(_routine(type: '스트레칭'))['type'], '스트레칭');
+    });
+
+    test('defaults a blank name and truncates a long reason', () {
+      expect(assignRoutineToJson(_routine(name: '   '))['name'], 'AI 맞춤 루틴');
+      final longReason = 'x' * 250;
+      expect((assignRoutineToJson(_routine(reason: longReason))['reason']! as String).length, 200);
+    });
+
+    test('normalises source (trainer preserved, else ai)', () {
+      expect(assignRoutineToJson(_routine(source: 'trainer'))['source'], 'trainer');
+      expect(assignRoutineToJson(_routine(source: 'anything'))['source'], 'ai');
+    });
+  });
+}

--- a/frontend/flutter_trainer/test/features/ai_routine/trainer_routine_repository_provider_test.dart
+++ b/frontend/flutter_trainer/test/features/ai_routine/trainer_routine_repository_provider_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/features/ai_routine/data/repositories/dio_trainer_routine_repository.dart';
+import 'package:oncare_trainer/features/ai_routine/data/repositories/trainer_routine_repository.dart';
+
+ProviderContainer _containerFor({required bool useMockApi}) {
+  final container = ProviderContainer(
+    overrides: <Override>[
+      appConfigProvider.overrideWithValue(
+        AppConfig(
+          environment: Environment.dev,
+          apiBaseUrl: 'http://localhost/v1',
+          useMockApi: useMockApi,
+        ),
+      ),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  test('resolves the mock routine repository when USE_MOCK_API=true', () {
+    expect(
+      _containerFor(useMockApi: true).read(trainerRoutineRepositoryProvider),
+      isA<MockTrainerRoutineRepository>(),
+    );
+  });
+
+  test('resolves the Dio routine repository when USE_MOCK_API=false', () {
+    expect(
+      _containerFor(useMockApi: false).read(trainerRoutineRepositoryProvider),
+      isA<DioTrainerRoutineRepository>(),
+    );
+  });
+}

--- a/frontend/flutter_trainer/test/features/clients/chat_dtos_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/chat_dtos_test.dart
@@ -20,7 +20,7 @@ void main() {
       expect(m.createdAt, DateTime.parse('2026-07-30T18:10:00'));
     });
 
-    test('maps any non-trainer sender to client', () {
+    test('maps the client sender', () {
       final m = chatMessageFromJson(<String, Object?>{
         'id': 'c2',
         'sender': 'client',
@@ -32,15 +32,26 @@ void main() {
       expect(m.fromTrainer, isFalse);
     });
 
-    test('falls back to epoch on a malformed created_at', () {
-      final m = chatMessageFromJson(<String, Object?>{
+    test('rejects malformed sender and created_at values', () {
+      Map<String, Object?> message({
+        Object? sender = 'client',
+        Object? createdAt = '2026-07-30T18:12:00',
+      }) => <String, Object?>{
         'id': 'c3',
-        'sender': 'client',
+        'sender': sender,
         'body': 'x',
         'time_label': '',
-        'created_at': 'not-a-date',
-      });
-      expect(m.createdAt, DateTime.fromMillisecondsSinceEpoch(0));
+        'created_at': createdAt,
+      };
+
+      expect(
+        () => chatMessageFromJson(message(sender: 'me')),
+        throwsFormatException,
+      );
+      expect(
+        () => chatMessageFromJson(message(createdAt: 'not-a-date')),
+        throwsFormatException,
+      );
     });
   });
 }

--- a/frontend/flutter_trainer/test/features/clients/chat_dtos_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/chat_dtos_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/features/clients/data/dtos/chat_dtos.dart';
+import 'package:oncare_trainer/shared/models/client_chat_message.dart';
+
+void main() {
+  group('chatMessageFromJson', () {
+    test('maps a trainer message', () {
+      final m = chatMessageFromJson(<String, Object?>{
+        'id': 'c1',
+        'sender': 'trainer',
+        'body': '오늘 컨디션 어때요?',
+        'time_label': '18:10',
+        'created_at': '2026-07-30T18:10:00',
+      });
+      expect(m.id, 'c1');
+      expect(m.sender, ChatSender.trainer);
+      expect(m.fromTrainer, isTrue);
+      expect(m.timeLabel, '18:10');
+      expect(m.createdAt, DateTime.parse('2026-07-30T18:10:00'));
+    });
+
+    test('maps any non-trainer sender to client', () {
+      final m = chatMessageFromJson(<String, Object?>{
+        'id': 'c2',
+        'sender': 'client',
+        'body': '좋아요!',
+        'time_label': '18:12',
+        'created_at': '2026-07-30T18:12:00',
+      });
+      expect(m.sender, ChatSender.client);
+      expect(m.fromTrainer, isFalse);
+    });
+
+    test('falls back to epoch on a malformed created_at', () {
+      final m = chatMessageFromJson(<String, Object?>{
+        'id': 'c3',
+        'sender': 'client',
+        'body': 'x',
+        'time_label': '',
+        'created_at': 'not-a-date',
+      });
+      expect(m.createdAt, DateTime.fromMillisecondsSinceEpoch(0));
+    });
+  });
+}

--- a/frontend/flutter_trainer/test/features/clients/chat_repository_provider_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/chat_repository_provider_test.dart
@@ -5,7 +5,31 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:oncare_trainer/core/config/app_config.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/features/clients/data/repositories/dio_chat_repository.dart';
+import 'package:oncare_trainer/shared/models/client_chat_message.dart';
 import 'package:oncare_trainer/shared/services/chat_repository.dart';
+
+class _CountingChatRepository implements ChatRepository {
+  int threadReads = 0;
+
+  @override
+  Stream<List<ClientChatMessage>> watchThread(String clientId) {
+    threadReads++;
+    return Stream<List<ClientChatMessage>>.value(const <ClientChatMessage>[]);
+  }
+
+  @override
+  Future<void> markThreadRead(String clientId) async {}
+
+  @override
+  Future<void> sendTrainerMessage({
+    required String clientId,
+    required String text,
+  }) async {}
+
+  @override
+  Stream<Map<String, int>> watchUnreadCounts() =>
+      Stream<Map<String, int>>.value(const <String, int>{});
+}
 
 ProviderContainer _containerFor({required bool useMockApi}) {
   final db = AppDatabase.forTesting(NativeDatabase.memory());
@@ -40,4 +64,34 @@ void main() {
       isA<DioChatRepository>(),
     );
   });
+
+  test(
+    'thread provider refetches after the view is left and re-entered',
+    () async {
+      final repo = _CountingChatRepository();
+      final container = ProviderContainer(
+        overrides: <Override>[chatRepositoryProvider.overrideWithValue(repo)],
+      );
+      addTearDown(container.dispose);
+
+      var subscription = container.listen(
+        chatThreadProvider('m1'),
+        (_, _) {},
+        fireImmediately: true,
+      );
+      await container.read(chatThreadProvider('m1').future);
+      subscription.close();
+      await container.pump();
+
+      subscription = container.listen(
+        chatThreadProvider('m1'),
+        (_, _) {},
+        fireImmediately: true,
+      );
+      await container.read(chatThreadProvider('m1').future);
+      subscription.close();
+
+      expect(repo.threadReads, 2);
+    },
+  );
 }

--- a/frontend/flutter_trainer/test/features/clients/chat_repository_provider_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/chat_repository_provider_test.dart
@@ -1,0 +1,43 @@
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/core/storage/app_database.dart';
+import 'package:oncare_trainer/features/clients/data/repositories/dio_chat_repository.dart';
+import 'package:oncare_trainer/shared/services/chat_repository.dart';
+
+ProviderContainer _containerFor({required bool useMockApi}) {
+  final db = AppDatabase.forTesting(NativeDatabase.memory());
+  addTearDown(db.close);
+  final container = ProviderContainer(
+    overrides: <Override>[
+      appConfigProvider.overrideWithValue(
+        AppConfig(
+          environment: Environment.dev,
+          apiBaseUrl: 'http://localhost/v1',
+          useMockApi: useMockApi,
+        ),
+      ),
+      appDatabaseProvider.overrideWithValue(db),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  test('resolves the drift chat repository when USE_MOCK_API=true', () {
+    expect(
+      _containerFor(useMockApi: true).read(chatRepositoryProvider),
+      isA<DriftChatRepository>(),
+    );
+  });
+
+  test('resolves the Dio chat repository when USE_MOCK_API=false', () {
+    expect(
+      _containerFor(useMockApi: false).read(chatRepositoryProvider),
+      isA<DioChatRepository>(),
+    );
+  });
+}

--- a/frontend/flutter_trainer/test/features/clients/chat_view_real_api_scroll_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/chat_view_real_api_scroll_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/features/clients/presentation/widgets/chat_view.dart';
+import 'package:oncare_trainer/shared/models/client_chat_message.dart';
+import 'package:oncare_trainer/shared/services/chat_repository.dart';
+
+/// A [ChatRepository] standing in for the real API: `watchThread` returns
+/// a longer thread on its SECOND call (simulating the backend now
+/// including the just-sent message once `chatThreadProvider` is
+/// invalidated and refetches) — used to prove the view scrolls to the
+/// *refetched* thread, not the stale one it had at send-time (review).
+class _RealApiFakeChatRepository implements ChatRepository {
+  int watchThreadCalls = 0;
+
+  static List<ClientChatMessage> _seed(int count) => <ClientChatMessage>[
+    for (var i = 0; i < count; i++)
+      ClientChatMessage(
+        id: 'seed-$i',
+        sender: i.isEven ? ChatSender.client : ChatSender.trainer,
+        body: '메시지 $i',
+        timeLabel: '10:0$i',
+        createdAt: DateTime(2026, 1, 1, 10, i),
+      ),
+  ];
+
+  @override
+  Stream<List<ClientChatMessage>> watchThread(String clientId) {
+    watchThreadCalls++;
+    // First call (initial load): 20 seed messages, enough to overflow the
+    // test viewport. Every call after the send (i.e. the post-invalidate
+    // refetch) appends the message the trainer just sent.
+    final base = _seed(20);
+    if (watchThreadCalls == 1) return Stream.value(base);
+    return Stream.value(<ClientChatMessage>[
+      ...base,
+      ClientChatMessage(
+        id: 'sent-1',
+        sender: ChatSender.trainer,
+        body: '방금 보낸 메시지',
+        timeLabel: '10:20',
+        createdAt: DateTime(2026, 1, 1, 10, 20),
+      ),
+    ]);
+  }
+
+  @override
+  Future<void> sendTrainerMessage({
+    required String clientId,
+    required String text,
+  }) async {}
+
+  @override
+  Stream<Map<String, int>> watchUnreadCounts() => Stream.value(const <String, int>{});
+
+  @override
+  Future<void> markThreadRead(String clientId) async {}
+}
+
+void main() {
+  testWidgets(
+    'real-API send: the view scrolls to the refetched (longer) thread, '
+    'not the stale pre-send one (review: invalidate() only starts an '
+    'async refetch — scrolling immediately would use the old extent)',
+    (tester) async {
+      final fake = _RealApiFakeChatRepository();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: <Override>[
+            appConfigProvider.overrideWithValue(
+              const AppConfig(
+                environment: Environment.dev,
+                apiBaseUrl: 'http://localhost/v1',
+                useMockApi: false,
+              ),
+            ),
+            chatRepositoryProvider.overrideWithValue(fake),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(
+              body: ChatView(
+                clientId: 'm1',
+                clientAvatar: '김',
+                clientName: '김민수',
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '방금 보낸 메시지');
+      await tester.tap(find.byIcon(Icons.send));
+      // Let the send future, the provider invalidation, the refetch, and
+      // the resulting scroll animation all settle.
+      await tester.pumpAndSettle();
+
+      // The refetched (21-message) thread rendered — not just the 20-message
+      // pre-send thread — proving the invalidate -> refetch pipeline landed.
+      expect(find.text('방금 보낸 메시지'), findsOneWidget);
+
+      // And the view is scrolled to (within a hair of) the bottom of THAT
+      // longer list, not to the shorter pre-send extent.
+      final controller = tester
+          .widget<ListView>(find.byType(ListView))
+          .controller!;
+      expect(controller.hasClients, isTrue);
+      expect(
+        controller.position.pixels,
+        closeTo(controller.position.maxScrollExtent, 1.0),
+      );
+    },
+  );
+}

--- a/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
@@ -12,7 +12,7 @@ import 'package:oncare_trainer/shared/models/client_chat_message.dart';
 import '../../helpers/pump_app.dart';
 
 /// Delays every insert so tests can act while a send is in flight.
-class _SlowChatRepository extends ChatRepository {
+class _SlowChatRepository extends DriftChatRepository {
   const _SlowChatRepository(super.db);
 
   @override
@@ -28,7 +28,7 @@ class _SlowChatRepository extends ChatRepository {
 /// Blocks on a caller-controlled future so the test can decide exactly
 /// when (and whether) the send fails — used to fail AFTER the widget is
 /// disposed, deterministically exercising the catch path.
-class _ControllableChatRepository extends ChatRepository {
+class _ControllableChatRepository extends DriftChatRepository {
   const _ControllableChatRepository(super.db, this.gate);
 
   final Future<void> gate;
@@ -41,7 +41,7 @@ class _ControllableChatRepository extends ChatRepository {
 }
 
 void main() {
-  group('ChatRepository', () {
+  group('DriftChatRepository', () {
     late AppDatabase db;
 
     setUp(() async {
@@ -53,7 +53,7 @@ void main() {
     test(
       'watchThread returns a client thread in chronological order',
       () async {
-        final thread = await ChatRepository(
+        final thread = await DriftChatRepository(
           db,
         ).watchThread('seed-client-1').first;
         expect(thread, isNotEmpty);
@@ -73,7 +73,7 @@ void main() {
     test(
       'sendTrainerMessage appends a trainer message that sorts last',
       () async {
-        final repo = ChatRepository(db);
+        final repo = DriftChatRepository(db);
         await repo.sendTrainerMessage(
           clientId: 'seed-client-1',
           text: '  안녕하세요  ',
@@ -88,7 +88,7 @@ void main() {
     );
 
     test('sendTrainerMessage refreshes the client list preview', () async {
-      final repo = ChatRepository(db);
+      final repo = DriftChatRepository(db);
       await repo.sendTrainerMessage(clientId: 'seed-client-2', text: '내일 봬요!');
       final row = await (db.select(
         db.trainerClients,
@@ -100,7 +100,7 @@ void main() {
     test(
       'watchUnreadCounts counts client messages until marked read',
       () async {
-        final repo = ChatRepository(db);
+        final repo = DriftChatRepository(db);
 
         // Seeded client replies: 김민수 2 · 이지수 1 · 박성호 1.
         var counts = await repo.watchUnreadCounts().first;
@@ -138,7 +138,7 @@ void main() {
     );
 
     test('markThreadRead is idempotent and skips redundant writes', () async {
-      final repo = ChatRepository(db);
+      final repo = DriftChatRepository(db);
 
       Future<String?> marker() => db.readValue('chat_read_seed-client-1');
 
@@ -185,7 +185,7 @@ void main() {
     test(
       'a same-second reply after markThreadRead still counts as unread',
       () async {
-        final repo = ChatRepository(db);
+        final repo = DriftChatRepository(db);
         // A fresh client with no seeded messages, so the count is only
         // what this test inserts.
         const cid = 'rowid-test-client';
@@ -229,13 +229,13 @@ void main() {
     test(
       'markThreadRead on a thread with no client message writes nothing',
       () async {
-        await ChatRepository(db).markThreadRead('no-such-client');
+        await DriftChatRepository(db).markThreadRead('no-such-client');
         expect(await db.readValue('chat_read_no-such-client'), isNull);
       },
     );
 
     test('sendTrainerMessage ignores empty/whitespace input', () async {
-      final repo = ChatRepository(db);
+      final repo = DriftChatRepository(db);
       final before = (await repo.watchThread('seed-client-1').first).length;
       await repo.sendTrainerMessage(clientId: 'seed-client-1', text: '   ');
       final after = (await repo.watchThread('seed-client-1').first).length;

--- a/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
@@ -4,8 +4,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:oncare_trainer/core/config/app_config.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/storage/seed_data.dart';
+import 'package:oncare_trainer/features/clients/presentation/widgets/chat_view.dart';
 import 'package:oncare_trainer/shared/services/chat_repository.dart';
 import 'package:oncare_trainer/shared/models/client_chat_message.dart';
 
@@ -38,6 +40,33 @@ class _ControllableChatRepository extends DriftChatRepository {
     required String clientId,
     required String text,
   }) => gate;
+}
+
+class _StaticLiveChatRepository implements ChatRepository {
+  @override
+  Stream<List<ClientChatMessage>> watchThread(String clientId) =>
+      Stream<List<ClientChatMessage>>.value(<ClientChatMessage>[
+        ClientChatMessage(
+          id: 'live-1',
+          sender: ChatSender.client,
+          body: '실제 회원 답장',
+          timeLabel: '09:00',
+          createdAt: DateTime.utc(2026, 7, 31, 9),
+        ),
+      ]);
+
+  @override
+  Future<void> markThreadRead(String clientId) async {}
+
+  @override
+  Future<void> sendTrainerMessage({
+    required String clientId,
+    required String text,
+  }) async {}
+
+  @override
+  Stream<Map<String, int>> watchUnreadCounts() =>
+      Stream<Map<String, int>>.value(const <String, int>{});
 }
 
 void main() {
@@ -244,6 +273,42 @@ void main() {
   });
 
   group('ClientDetailPage chat', () {
+    testWidgets('real chat omits demo-only analysis and sent banners', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: <Override>[
+            appConfigProvider.overrideWithValue(
+              const AppConfig(
+                environment: Environment.dev,
+                apiBaseUrl: 'http://localhost/v1',
+                useMockApi: false,
+              ),
+            ),
+            chatRepositoryProvider.overrideWithValue(
+              _StaticLiveChatRepository(),
+            ),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(
+              body: ChatView(
+                clientId: 'user-demo',
+                clientAvatar: '김',
+                clientName: '김민수',
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('실제 회원 답장'), findsOneWidget);
+      expect(find.textContaining('AI가 김민수님의 식단'), findsNothing);
+      expect(find.textContaining('AI 분석 기반 루틴'), findsNothing);
+    });
+
     Future<void> openDetail(WidgetTester tester) async {
       await pumpTrainerApp(tester, token: 'demo-trainer-token');
       await tester.tap(find.text('김민수'));

--- a/frontend/flutter_trainer/test/features/clients/dio_chat_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/dio_chat_repository_test.dart
@@ -9,19 +9,19 @@ import 'package:oncare_trainer/shared/models/client_chat_message.dart';
 class _MockDio extends Mock implements Dio {}
 
 Response<T> _ok<T>(T body, String path) => Response<T>(
-      requestOptions: RequestOptions(path: path),
-      statusCode: 200,
-      data: body,
-    );
+  requestOptions: RequestOptions(path: path),
+  statusCode: 200,
+  data: body,
+);
 
 DioException _httpError(int status, String path) => DioException(
-      requestOptions: RequestOptions(path: path),
-      type: DioExceptionType.badResponse,
-      response: Response<Object?>(
-        requestOptions: RequestOptions(path: path),
-        statusCode: status,
-      ),
-    );
+  requestOptions: RequestOptions(path: path),
+  type: DioExceptionType.badResponse,
+  response: Response<Object?>(
+    requestOptions: RequestOptions(path: path),
+    statusCode: status,
+  ),
+);
 
 void main() {
   late _MockDio dio;
@@ -34,13 +34,22 @@ void main() {
 
   test('watchThread parses the message list (oldest→newest)', () async {
     when(() => dio.get<List<dynamic>>('/trainer/clients/m1/chat')).thenAnswer(
-      (_) async => _ok<List<dynamic>>(
-        <dynamic>[
-          <String, Object?>{'id': 'a', 'sender': 'client', 'body': '안녕', 'time_label': '9:00', 'created_at': '2026-07-30T09:00:00'},
-          <String, Object?>{'id': 'b', 'sender': 'trainer', 'body': '네', 'time_label': '9:01', 'created_at': '2026-07-30T09:01:00'},
-        ],
-        '/trainer/clients/m1/chat',
-      ),
+      (_) async => _ok<List<dynamic>>(<dynamic>[
+        <String, Object?>{
+          'id': 'a',
+          'sender': 'client',
+          'body': '안녕',
+          'time_label': '9:00',
+          'created_at': '2026-07-30T09:00:00',
+        },
+        <String, Object?>{
+          'id': 'b',
+          'sender': 'trainer',
+          'body': '네',
+          'time_label': '9:01',
+          'created_at': '2026-07-30T09:01:00',
+        },
+      ], '/trainer/clients/m1/chat'),
     );
 
     final thread = await repo.watchThread('m1').first;
@@ -49,34 +58,41 @@ void main() {
   });
 
   test('sendTrainerMessage POSTs the trimmed text', () async {
-    when(() => dio.post<Map<String, Object?>>(
-          '/trainer/clients/m1/chat',
-          data: any(named: 'data'),
-        )).thenAnswer(
-      (_) async => _ok<Map<String, Object?>>(
-        <String, Object?>{'id': 'x'},
+    when(
+      () => dio.post<Map<String, Object?>>(
         '/trainer/clients/m1/chat',
+        data: any(named: 'data'),
       ),
+    ).thenAnswer(
+      (_) async => _ok<Map<String, Object?>>(<String, Object?>{
+        'id': 'x',
+      }, '/trainer/clients/m1/chat'),
     );
 
     await repo.sendTrainerMessage(clientId: 'm1', text: '  안녕하세요  ');
 
-    verify(() => dio.post<Map<String, Object?>>(
-          '/trainer/clients/m1/chat',
-          data: <String, Object?>{'text': '안녕하세요'},
-        )).called(1);
+    verify(
+      () => dio.post<Map<String, Object?>>(
+        '/trainer/clients/m1/chat',
+        data: <String, Object?>{'text': '안녕하세요'},
+      ),
+    ).called(1);
   });
 
   test('sendTrainerMessage skips the network call for blank text', () async {
     await repo.sendTrainerMessage(clientId: 'm1', text: '   ');
-    verifyNever(() => dio.post<Map<String, Object?>>(any(), data: any(named: 'data')));
+    verifyNever(
+      () => dio.post<Map<String, Object?>>(any(), data: any(named: 'data')),
+    );
   });
 
   test('sendTrainerMessage surfaces a failure as AppError', () async {
-    when(() => dio.post<Map<String, Object?>>(
-          '/trainer/clients/m1/chat',
-          data: any(named: 'data'),
-        )).thenThrow(_httpError(500, '/trainer/clients/m1/chat'));
+    when(
+      () => dio.post<Map<String, Object?>>(
+        '/trainer/clients/m1/chat',
+        data: any(named: 'data'),
+      ),
+    ).thenThrow(_httpError(500, '/trainer/clients/m1/chat'));
 
     await expectLater(
       repo.sendTrainerMessage(clientId: 'm1', text: 'hi'),
@@ -85,11 +101,13 @@ void main() {
   });
 
   test('watchUnreadCounts parses the per-client map', () async {
-    when(() => dio.get<Map<String, Object?>>('/trainer/chat/unread')).thenAnswer(
-      (_) async => _ok<Map<String, Object?>>(
-        <String, Object?>{'m1': 2, 'm2': 0},
-        '/trainer/chat/unread',
-      ),
+    when(
+      () => dio.get<Map<String, Object?>>('/trainer/chat/unread'),
+    ).thenAnswer(
+      (_) async => _ok<Map<String, Object?>>(<String, Object?>{
+        'm1': 2,
+        'm2': 0,
+      }, '/trainer/chat/unread'),
     );
 
     final unread = await repo.watchUnreadCounts().first;
@@ -98,27 +116,85 @@ void main() {
   });
 
   test('markThreadRead POSTs to the read endpoint', () async {
-    when(() => dio.post<Map<String, Object?>>(
-          '/trainer/clients/m1/chat/read',
-        )).thenAnswer(
-      (_) async => _ok<Map<String, Object?>>(
-        <String, Object?>{'marked_read': 2},
-        '/trainer/clients/m1/chat/read',
-      ),
+    when(
+      () => dio.post<Map<String, Object?>>('/trainer/clients/m1/chat/read'),
+    ).thenAnswer(
+      (_) async => _ok<Map<String, Object?>>(<String, Object?>{
+        'marked_read': 2,
+      }, '/trainer/clients/m1/chat/read'),
     );
 
     await repo.markThreadRead('m1');
-    verify(() => dio.post<Map<String, Object?>>('/trainer/clients/m1/chat/read'))
-        .called(1);
+    verify(
+      () => dio.post<Map<String, Object?>>('/trainer/clients/m1/chat/read'),
+    ).called(1);
   });
 
   test('watchThread surfaces a 404 (not this trainer\'s client)', () async {
-    when(() => dio.get<List<dynamic>>('/trainer/clients/x/chat'))
-        .thenThrow(_httpError(404, '/trainer/clients/x/chat'));
+    when(
+      () => dio.get<List<dynamic>>('/trainer/clients/x/chat'),
+    ).thenThrow(_httpError(404, '/trainer/clients/x/chat'));
 
-    await expectLater(
-      repo.watchThread('x'),
-      emitsError(isA<NotFoundError>()),
+    await expectLater(repo.watchThread('x'), emitsError(isA<NotFoundError>()));
+  });
+
+  test('encodes an opaque member id in every client-scoped path', () async {
+    const encoded = 'member%2Fwith%3Freserved';
+    when(
+      () => dio.get<List<dynamic>>('/trainer/clients/$encoded/chat'),
+    ).thenAnswer(
+      (_) async => _ok<List<dynamic>>(
+        const <dynamic>[],
+        '/trainer/clients/$encoded/chat',
+      ),
     );
+    when(
+      () => dio.post<Map<String, Object?>>(
+        '/trainer/clients/$encoded/chat',
+        data: any(named: 'data'),
+      ),
+    ).thenAnswer(
+      (_) async => _ok<Map<String, Object?>>(
+        const <String, Object?>{},
+        '/trainer/clients/$encoded/chat',
+      ),
+    );
+    when(
+      () =>
+          dio.post<Map<String, Object?>>('/trainer/clients/$encoded/chat/read'),
+    ).thenAnswer(
+      (_) async => _ok<Map<String, Object?>>(
+        const <String, Object?>{},
+        '/trainer/clients/$encoded/chat/read',
+      ),
+    );
+
+    await repo.watchThread('member/with?reserved').first;
+    await repo.sendTrainerMessage(clientId: 'member/with?reserved', text: 'hi');
+    await repo.markThreadRead('member/with?reserved');
+
+    verify(
+      () => dio.get<List<dynamic>>('/trainer/clients/$encoded/chat'),
+    ).called(1);
+    verify(
+      () => dio.post<Map<String, Object?>>(
+        '/trainer/clients/$encoded/chat',
+        data: <String, Object?>{'text': 'hi'},
+      ),
+    ).called(1);
+    verify(
+      () =>
+          dio.post<Map<String, Object?>>('/trainer/clients/$encoded/chat/read'),
+    ).called(1);
+  });
+
+  test('malformed thread entries fail instead of being dropped', () {
+    when(() => dio.get<List<dynamic>>('/trainer/clients/m1/chat')).thenAnswer(
+      (_) async => _ok<List<dynamic>>(<dynamic>[
+        'not-an-object',
+      ], '/trainer/clients/m1/chat'),
+    );
+
+    expect(repo.watchThread('m1'), emitsError(isA<FormatException>()));
   });
 }

--- a/frontend/flutter_trainer/test/features/clients/dio_chat_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/dio_chat_repository_test.dart
@@ -1,0 +1,124 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/features/clients/data/repositories/dio_chat_repository.dart';
+import 'package:oncare_trainer/shared/models/client_chat_message.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+Response<T> _ok<T>(T body, String path) => Response<T>(
+      requestOptions: RequestOptions(path: path),
+      statusCode: 200,
+      data: body,
+    );
+
+DioException _httpError(int status, String path) => DioException(
+      requestOptions: RequestOptions(path: path),
+      type: DioExceptionType.badResponse,
+      response: Response<Object?>(
+        requestOptions: RequestOptions(path: path),
+        statusCode: status,
+      ),
+    );
+
+void main() {
+  late _MockDio dio;
+  late DioChatRepository repo;
+
+  setUp(() {
+    dio = _MockDio();
+    repo = DioChatRepository(dio);
+  });
+
+  test('watchThread parses the message list (oldest→newest)', () async {
+    when(() => dio.get<List<dynamic>>('/trainer/clients/m1/chat')).thenAnswer(
+      (_) async => _ok<List<dynamic>>(
+        <dynamic>[
+          <String, Object?>{'id': 'a', 'sender': 'client', 'body': '안녕', 'time_label': '9:00', 'created_at': '2026-07-30T09:00:00'},
+          <String, Object?>{'id': 'b', 'sender': 'trainer', 'body': '네', 'time_label': '9:01', 'created_at': '2026-07-30T09:01:00'},
+        ],
+        '/trainer/clients/m1/chat',
+      ),
+    );
+
+    final thread = await repo.watchThread('m1').first;
+    expect(thread.map((m) => m.id).toList(), <String>['a', 'b']);
+    expect(thread.last.sender, ChatSender.trainer);
+  });
+
+  test('sendTrainerMessage POSTs the trimmed text', () async {
+    when(() => dio.post<Map<String, Object?>>(
+          '/trainer/clients/m1/chat',
+          data: any(named: 'data'),
+        )).thenAnswer(
+      (_) async => _ok<Map<String, Object?>>(
+        <String, Object?>{'id': 'x'},
+        '/trainer/clients/m1/chat',
+      ),
+    );
+
+    await repo.sendTrainerMessage(clientId: 'm1', text: '  안녕하세요  ');
+
+    verify(() => dio.post<Map<String, Object?>>(
+          '/trainer/clients/m1/chat',
+          data: <String, Object?>{'text': '안녕하세요'},
+        )).called(1);
+  });
+
+  test('sendTrainerMessage skips the network call for blank text', () async {
+    await repo.sendTrainerMessage(clientId: 'm1', text: '   ');
+    verifyNever(() => dio.post<Map<String, Object?>>(any(), data: any(named: 'data')));
+  });
+
+  test('sendTrainerMessage surfaces a failure as AppError', () async {
+    when(() => dio.post<Map<String, Object?>>(
+          '/trainer/clients/m1/chat',
+          data: any(named: 'data'),
+        )).thenThrow(_httpError(500, '/trainer/clients/m1/chat'));
+
+    await expectLater(
+      repo.sendTrainerMessage(clientId: 'm1', text: 'hi'),
+      throwsA(isA<AppError>()),
+    );
+  });
+
+  test('watchUnreadCounts parses the per-client map', () async {
+    when(() => dio.get<Map<String, Object?>>('/trainer/chat/unread')).thenAnswer(
+      (_) async => _ok<Map<String, Object?>>(
+        <String, Object?>{'m1': 2, 'm2': 0},
+        '/trainer/chat/unread',
+      ),
+    );
+
+    final unread = await repo.watchUnreadCounts().first;
+    expect(unread['m1'], 2);
+    expect(unread['m2'], 0);
+  });
+
+  test('markThreadRead POSTs to the read endpoint', () async {
+    when(() => dio.post<Map<String, Object?>>(
+          '/trainer/clients/m1/chat/read',
+        )).thenAnswer(
+      (_) async => _ok<Map<String, Object?>>(
+        <String, Object?>{'marked_read': 2},
+        '/trainer/clients/m1/chat/read',
+      ),
+    );
+
+    await repo.markThreadRead('m1');
+    verify(() => dio.post<Map<String, Object?>>('/trainer/clients/m1/chat/read'))
+        .called(1);
+  });
+
+  test('watchThread surfaces a 404 (not this trainer\'s client)', () async {
+    when(() => dio.get<List<dynamic>>('/trainer/clients/x/chat'))
+        .thenThrow(_httpError(404, '/trainer/clients/x/chat'));
+
+    await expectLater(
+      repo.watchThread('x'),
+      emitsError(isA<NotFoundError>()),
+    );
+  });
+}

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -13,7 +13,7 @@ import 'package:oncare_trainer/shared/services/chat_repository.dart';
 import '../../helpers/pump_app.dart';
 
 /// A chat repository whose sends always fail.
-class _FailingChatRepository extends ChatRepository {
+class _FailingChatRepository extends DriftChatRepository {
   const _FailingChatRepository(super.db);
 
   @override


### PR DESCRIPTION
## Summary

* 트레이너↔회원 채팅을 실 백엔드에 연결해 회원 앱과 같은 채팅 스레드를 조회하고 실제 메시지를 주고받도록 변경했습니다.
* AI 루틴의 “회원에게 전송” 동작을 실 루틴 배정 API에 연결해 회원 앱의 `/me/coach/routines`에서 동일한 배정 레코드를 확인할 수 있습니다.
* `USE_MOCK_API` 설정에 따라 채팅과 루틴 저장소를 Drift/Mock 또는 Dio 구현으로 전환합니다.
* 실 채팅 재진입 시 서버 데이터를 다시 조회하고, 읽음 처리·미확인 메시지 수·전송 실패 상태를 처리합니다.

---

## Changes

### ✨ Features

* `ChatRepository` 인터페이스와 다음 구현을 추가했습니다.
  * `DriftChatRepository`: 데모 및 Mock 모드
  * `DioChatRepository`: 실 백엔드 채팅
* 다음 트레이너 채팅 API를 연결했습니다.
  * `GET /trainer/clients/{memberId}/chat`
  * `POST /trainer/clients/{memberId}/chat`
  * `POST /trainer/clients/{memberId}/chat/read`
  * `GET /trainer/chat/unread`
* 회원이 보낸 메시지의 미확인 개수를 고객별로 표시하고, 스레드 진입 시 읽음 처리합니다.
* `TrainerRoutineRepository` 인터페이스와 Mock/Dio 구현을 추가했습니다.
* 다음 루틴 API를 연결했습니다.
  * `GET /trainer/clients/{memberId}/routines`
  * `POST /trainer/clients/{memberId}/routines`
* AI 루틴 전송 시 편집된 운동 목록을 하나의 요약 루틴으로 변환해 회원에게 배정합니다.
* 루틴 배정 후 채팅 스레드에 전송 요약 메시지를 남깁니다.

### 🔧 Improvements

* 실 채팅 provider를 `autoDispose`로 구성해 스레드 재진입 시 최신 회원 답장을 다시 조회합니다.
* 메시지 전송 후 채팅 스레드와 미확인 메시지 수를 갱신합니다.
* 루틴 배정 성공 후 채팅 요약 메시지만 실패한 경우, 이미 배정된 루틴을 재전송해 중복 생성하지 않도록 처리했습니다.
* 실 고객 ID와 로컬 AI 추천 ID가 다른 경우 고객 이름으로 추천 데이터를 연결합니다.
* 커스텀 운동까지 포함해 배정 루틴의 대표 운동 타입을 계산합니다.
* 회원 ID를 단일 URL path segment로 인코딩합니다.
* 채팅 sender·생성 시간과 API 목록 항목의 형식을 검증해 잘못된 응답이 조용히 누락되거나 잘못 표시되지 않도록 했습니다.
* 읽음 처리 실패는 채팅 조회 성공과 분리해 비동기 미처리 예외로 전파되지 않도록 했습니다.

### 🎨 UI/UX

* 채팅 전송 중 중복 입력을 차단하고, 실패하면 작성 중인 메시지를 유지한 채 재시도 안내를 표시합니다.
* 실 API 채팅에서는 실제 데이터와 무관한 데모 전용 AI 분석·루틴 전송 배너를 숨깁니다.
* 채팅 화면을 다시 열면 회원이 새로 보낸 메시지가 반영됩니다.
* 루틴 배정 성공과 실패 상태를 구분해 잘못된 전송 완료 표시를 방지합니다.

### 🐛 Fixes

* 실 API 고객 ID로 AI 추천을 조회하면 목록이 비어 루틴을 전송할 수 없던 문제를 수정했습니다.
* 채팅 provider 캐시 때문에 화면 재진입 후에도 회원의 최신 답장이 표시되지 않던 문제를 수정했습니다.
* 모든 실 채팅에 “AI 분석 기반 루틴이 전송됐다”는 데모 문구가 표시되던 문제를 수정했습니다.
* 읽음 처리 API 실패가 처리되지 않은 비동기 예외로 남던 문제를 수정했습니다.
* AI 운동을 모두 제거하고 커스텀 운동만 추가한 경우 대표 타입이 항상 `근력`으로 저장되던 문제를 수정했습니다.

---

## Commits

1. `e4ff7fb` feat(trainer-chat): connect trainer↔member chat to the real API
2. `80f8274` feat(trainer-routine): assign routines to members via the real API
3. `05bdde0` fix(trainer-chat): refresh live threads and routine delivery

---

## Notes

* Base branch는 `feature/316-trainer-clients-live-data`인 stacked PR입니다.
* #316이 먼저 병합되면 base를 `main`으로 변경합니다.
* 실시간 수신을 위한 WebSocket 또는 polling은 이번 범위에 포함하지 않습니다.
* 회원이 보낸 새 메시지는 채팅 스레드 재진입 시 다시 조회합니다.
* AI 추천 생성 데이터 자체는 기존 로컬 Drift 데이터를 사용하며, 이번 PR은 편집된 추천 루틴의 실제 회원 배정을 연결합니다.
* 회원 앱의 채팅·루틴 수신 UI는 별도 `member-coach` PR 범위입니다.
* 백엔드 루틴 계약이 운동별 프로그램이 아닌 단일 `RoutineOut`이므로, 편집한 운동 목록은 운동 수·총 시간·대표 타입·운동명 요약으로 배정합니다.

---

## Screenshots (Optional)

* 기존 UI 구조는 유지하며 데이터 연결과 데모/실 모드의 노출 조건만 변경했습니다.

---

## Test Plan

* [x] `flutter analyze --no-pub` 통과
* [x] 트레이너 전체 테스트 194개 통과
* [x] 채팅 DTO 및 sender·생성 시간 검증
* [x] 채팅 조회·발신·읽음 처리·미확인 메시지 API 검증
* [x] 채팅 재진입 시 서버 재조회 검증
* [x] 실 채팅의 데모 배너 비노출 검증
* [x] 루틴 DTO 정규화 및 API 배정·조회 검증
* [x] 실 고객 ID와 로컬 AI 추천 연결 검증
* [x] 회원 ID URL 인코딩 검증
* [x] 잘못된 API 목록 응답 처리 검증
* [x] 기존 Drift 데모 채팅·AI 루틴·스케줄 회귀 테스트 통과

### Manual Test Steps

1. `USE_MOCK_API=false`로 트레이너 앱과 회원 앱에 각각 로그인합니다.
2. 트레이너 앱에서 고객 채팅을 열고 메시지를 전송합니다.
3. 회원 앱에서 같은 스레드에 메시지가 표시되는지 확인합니다.
4. 회원 앱에서 답장한 뒤 트레이너 채팅을 다시 열어 답장이 표시되는지 확인합니다.
5. 채팅 진입 후 해당 고객의 미확인 메시지 배지가 해제되는지 확인합니다.
6. 트레이너 앱의 AI 루틴에서 운동을 편집하고 “회원에게 전송”을 실행합니다.
7. 회원 앱에서 배정된 요약 루틴이 표시되는지 확인합니다.
8. Mock 모드에서 기존 Drift 채팅과 AI 루틴 데모 흐름이 유지되는지 확인합니다.

---

## Related Issues

Closes #341

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 회원별 AI 루틴을 실제 API로 할당하고 조회할 수 있습니다.
  * 트레이너와 회원 간 실시간 채팅, 읽지 않은 메시지 확인 및 읽음 처리를 지원합니다.
  * 개발 환경에서는 모의 API, 운영 환경에서는 실제 API를 선택해 사용할 수 있습니다.

* **개선 사항**
  * 루틴과 채팅 데이터의 형식 및 입력값을 검증하고 안전한 기본값을 적용합니다.
  * 메시지 전송 후 대화 목록과 알림 배지가 자동으로 갱신됩니다.
  * 루틴과 채팅 관련 오류 처리가 강화되었습니다.

* **테스트**
  * 루틴 할당, 채팅, 오류 처리 및 화면 갱신 동작에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->