### PR TITLE
refactor(exercise): 운동 목표 조회를 shared 공용 계층으로 분리

### DIFF
--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -6,14 +6,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart' show NumberFormat;
 
 import 'package:oncare/design_system/figma/figma_kit.dart';
-import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
-import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
 import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/features/exercise/presentation/widgets/exercise_flows.dart';
 import 'package:oncare/features/exercise/presentation/widgets/gym_tab.dart';
 import 'package:oncare/features/notification/presentation/widgets/notification_panel.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/services/exercise_burn_goal_provider.dart';
 import 'package:oncare/shared/widgets/modals/right_slide_panel.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
 
@@ -189,10 +188,9 @@ class _RecordTabState extends ConsumerState<_RecordTab> {
     );
     final List<bool> routineDone = ref.watch(exerciseRoutineDoneProvider);
     // 주간 소모 목표는 서버(exercise_burn_goal)에서 온다. 홈 운동 카드도 같은
-    // 값을 읽어 두 화면의 목표치가 어긋나지 않는다. 로딩 전에는 엔티티 기본값.
-    final int burnGoal =
-        ref.watch(dashboardSummaryProvider).valueOrNull?.exerciseBurnGoal ??
-        DashboardSummary.defaultExerciseBurnGoal;
+    // 값을 읽어 두 화면의 목표치가 어긋나지 않는다. 출처(대시보드 요약)와
+    // 로딩 전 기본값 처리는 공용 provider 안에 있다.
+    final int burnGoal = ref.watch(exerciseBurnGoalProvider);
     final DateTime today = _today;
     final DateTime center = today.add(Duration(days: _weekShift * 7));
     final bool atToday = _weekShift == 0 && _selected == today;

--- a/frontend/flutter/lib/shared/services/exercise_burn_goal_provider.dart
+++ b/frontend/flutter/lib/shared/services/exercise_burn_goal_provider.dart
@@ -12,7 +12,13 @@ import 'package:oncare/features/dashboard/presentation/controllers/dashboard_con
 ///
 /// 요약이 로딩 중이거나 실패하면 엔티티 기본값을 돌려준다 — 목표치 하나 때문에
 /// 운동 화면 전체가 로딩·에러 상태로 빠지지 않게 한다.
-final exerciseBurnGoalProvider = Provider<int>(
+///
+/// autoDispose 인 이유: [dashboardSummaryProvider] 가 `FutureProvider.autoDispose`
+/// 다. 항상 살아있는 Provider 로 두면 그 구독이 끊기지 않아 요약이 영구히
+/// 캐시되고, 화면을 다시 열어도 갱신되지 않는다(운동 화면이 직접 구독하던
+/// 시절에는 화면이 사라지면 함께 해제됐다). autoDispose 를 전파해 그 수명을
+/// 그대로 유지한다.
+final exerciseBurnGoalProvider = Provider.autoDispose<int>(
   (ref) =>
       ref.watch(dashboardSummaryProvider).valueOrNull?.exerciseBurnGoal ??
       DashboardSummary.defaultExerciseBurnGoal,

--- a/frontend/flutter/lib/shared/services/exercise_burn_goal_provider.dart
+++ b/frontend/flutter/lib/shared/services/exercise_burn_goal_provider.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
+import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
+
+/// 주간 소모 칼로리 목표(kcal). 홈 운동 카드와 운동 탭이 같은 목표치를 보여야
+/// 하는데 값의 출처가 대시보드 요약이라, 운동 화면이 `features/dashboard` 의
+/// provider 를 직접 구독하며 대시보드의 상태 수명·API 에 결합돼 있었다.
+///
+/// 그 의존을 이 한 곳으로 모아, 목표치를 쓰는 feature 는 "int 하나" 라는 계약만
+/// 본다. 값의 출처가 바뀌어도(개인화 API 신설 등) 고칠 곳은 여기뿐이다.
+///
+/// 요약이 로딩 중이거나 실패하면 엔티티 기본값을 돌려준다 — 목표치 하나 때문에
+/// 운동 화면 전체가 로딩·에러 상태로 빠지지 않게 한다.
+final exerciseBurnGoalProvider = Provider<int>(
+  (ref) =>
+      ref.watch(dashboardSummaryProvider).valueOrNull?.exerciseBurnGoal ??
+      DashboardSummary.defaultExerciseBurnGoal,
+  name: 'exerciseBurnGoal',
+);

--- a/frontend/flutter/test/shared/exercise_burn_goal_provider_test.dart
+++ b/frontend/flutter/test/shared/exercise_burn_goal_provider_test.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
+import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+import 'package:oncare/shared/services/exercise_burn_goal_provider.dart';
+
+void main() {
+  DashboardSummary summaryWithGoal(int goal) => DashboardSummary(
+    indicators: const <HealthIndicator>[],
+    macros: const DietMacros.zero(),
+    dietEntries: 0,
+    exerciseMinutes: 0,
+    exerciseBurnGoal: goal,
+    todaySchedule: const <ScheduleItem>[],
+    weekScore: 0,
+    weekScoreDelta: 0,
+    sodiumWarning: null,
+  );
+
+  ProviderContainer containerWith(
+    Future<DashboardSummary> Function() load,
+  ) {
+    final container = ProviderContainer(
+      overrides: <Override>[
+        dashboardSummaryProvider.overrideWith((ref) => load()),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test('요약이 내려준 목표치를 그대로 노출한다', () async {
+    final container = containerWith(() async => summaryWithGoal(800));
+    await container.read(dashboardSummaryProvider.future);
+
+    expect(container.read(exerciseBurnGoalProvider), 800);
+  });
+
+  test('로딩 중에는 엔티티 기본값으로 버틴다', () {
+    // 목표치 하나 때문에 운동 화면이 로딩 상태로 빠지면 안 된다.
+    final container = containerWith(() => Completer<DashboardSummary>().future);
+
+    expect(
+      container.read(exerciseBurnGoalProvider),
+      DashboardSummary.defaultExerciseBurnGoal,
+    );
+  });
+
+  test('요약 조회가 실패해도 엔티티 기본값으로 버틴다', () async {
+    final container = containerWith(
+      () => Future<DashboardSummary>.error(StateError('boom')),
+    );
+    await expectLater(
+      container.read(dashboardSummaryProvider.future),
+      throwsStateError,
+    );
+
+    expect(
+      container.read(exerciseBurnGoalProvider),
+      DashboardSummary.defaultExerciseBurnGoal,
+    );
+  });
+
+  test('요약이 갱신되면 목표치도 따라 바뀐다', () async {
+    // 한 번 읽고 마는 스냅샷이 아니라 요약을 계속 구독하는지 확인한다.
+    int goal = 800;
+    final container = containerWith(() async => summaryWithGoal(goal));
+    await container.read(dashboardSummaryProvider.future);
+    expect(container.read(exerciseBurnGoalProvider), 800);
+
+    goal = 650;
+    await container.refresh(dashboardSummaryProvider.future);
+
+    expect(container.read(exerciseBurnGoalProvider), 650);
+  });
+}

--- a/frontend/flutter/test/shared/exercise_burn_goal_provider_test.dart
+++ b/frontend/flutter/test/shared/exercise_burn_goal_provider_test.dart
@@ -77,4 +77,31 @@ void main() {
 
     expect(container.read(exerciseBurnGoalProvider), 650);
   });
+
+  test('구독이 끊기면 대시보드 요약도 함께 해제된다 (autoDispose 전파)', () async {
+    // dashboardSummaryProvider 는 FutureProvider.autoDispose 다. 항상 살아있는
+    // Provider 가 이것을 watch 하면 영구히 붙잡아 요약이 갱신되지 않는다.
+    int loads = 0;
+    final container = ProviderContainer(
+      overrides: <Override>[
+        dashboardSummaryProvider.overrideWith((ref) async {
+          loads++;
+          return summaryWithGoal(800);
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final sub = container.listen(exerciseBurnGoalProvider, (_, _) {});
+    await container.read(dashboardSummaryProvider.future);
+    expect(loads, 1);
+
+    sub.close();
+    await Future<void>.delayed(Duration.zero);
+
+    // 해제됐다면 다시 읽을 때 로더가 한 번 더 돈다.
+    container.listen(exerciseBurnGoalProvider, (_, _) {});
+    await container.read(dashboardSummaryProvider.future);
+    expect(loads, 2, reason: '요약이 해제되지 않고 계속 캐시돼 있다');
+  });
 }


### PR DESCRIPTION
Closes #359

## Summary

PR #358 CodeRabbit 리뷰의 Nitpick 후속입니다. `exercise_page.dart` 가 `features/dashboard` 의 `dashboardSummaryProvider` 를 직접 구독해 운동 화면이 대시보드의 상태 수명·API 에 결합돼 있던 것을 공용 계층으로 분리했습니다.

동작 변화는 없습니다. 홈 운동 카드와 운동 탭이 같은 목표치를 본다는 성질은 그대로입니다.

## Changes

**신규 `shared/services/exercise_burn_goal_provider.dart`**
- 주간 소모 목표(kcal)만 노출하는 `Provider<int>`
- 대시보드 요약 의존과, 로딩·에러 시 엔티티 기본값(500)으로 버티는 폴백을 이 안으로 모음
- 값의 출처가 바뀌어도(목표 개인화 API 신설 등) 고칠 곳이 여기 한 곳

**`exercise_page.dart`**
- `ref.watch(exerciseBurnGoalProvider)` 한 줄로 축약
- `features/dashboard` import 2개 제거 (`dashboard_summary.dart`, `dashboard_controller.dart`)

**홈 운동 카드는 그대로 둠**
- `features/dashboard` 내부이고 요약 객체를 이미 손에 들고 있어, 같은 값을 provider 로 한 번 더 우회할 이유가 없습니다. 이슈에서 "판단 필요"로 남겨둔 항목에 대한 결론입니다.

## Notes

- `shared/` 가 `features/` 를 참조하는 것은 이 저장소의 기존 패턴입니다 (`shared/widgets/modals/add_event_dialog.dart` 도 `dashboard_controller.dart` 를 import).
- 신규 테스트 `test/shared/exercise_burn_goal_provider_test.dart` 4건으로 provider 계약을 고정했습니다 — 값 노출 / 로딩 중 기본값 / 에러 시 기본값 / 요약 갱신 반영(스냅샷이 아니라 구독인지).
- `flutter analyze` 이슈 없음. 전체 스위트에서 `test/golden/app_button_golden_test.dart` 1건이 실패하지만 **이 변경 이전부터 main 에서 실패하던 기존 건**입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기능 개선**
  * 운동 페이지가 대시보드의 운동 소모 칼로리 목표를 일관되게 표시합니다.
  * 목표 정보를 불러오는 중이거나 조회에 실패한 경우에도 기본 목표값을 표시합니다.
  * 대시보드 요약이 갱신되면 운동 목표도 자동으로 업데이트됩니다.

* **버그 수정**
  * 운동 소모 칼로리 목표가 로딩 상태나 조회 실패로 비어 보일 수 있는 문제를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->