### PR TITLE
fix(diet): 당류(sugar_g) 계약을 소수로 통일

### DIFF
--- a/backend/API_CONTRACT.md
+++ b/backend/API_CONTRACT.md
@@ -18,6 +18,7 @@
 ## 프론트에 실제 구현된 엔드포인트 (이번에 완성할 대상)
 
 ### 시스템
+
 | Method | Path | 응답 |
 |---|---|---|
 | GET | `/ping` | `{ message }` |
@@ -25,6 +26,7 @@
 | GET | `/version` | `{ api_version, app_version }` |
 
 ### 사용자
+
 | Method | Path | 응답 핵심 필드 |
 |---|---|---|
 | GET | `/users/me` | `{ id(str), name, email }` |
@@ -36,6 +38,7 @@
 `risk`: `{ title, body, level(low|medium|high) }`
 
 ### 대시보드
+
 | Method | Path | 응답 핵심 필드 |
 |---|---|---|
 | GET | `/dashboard/summary` | `{ indicators[], diet_entries(int), exercise_minutes, today_schedule[], week_score, week_score_delta, sodium_warning(nullable), exercise_feedback }` |
@@ -44,6 +47,7 @@
 `current` 는 당류가 소수(17.8g)라 float. 칼로리·나트륨은 정수 값이 그대로 실린다. 목표치(`max`)는 셋 다 정수.
 
 ### 식단 (핵심: 나트륨·당류·고혈압 관점)
+
 | Method | Path | 응답 핵심 필드 |
 |---|---|---|
 | GET | `/diet/days/today` | `{ entries[], total_calories, total_sodium_mg, total_sugar_g, macros, ai_coach_message }` |
@@ -56,6 +60,7 @@
 `idempotency_key`(선택): 재시도 중복 저장 방지. 클라 요청당 1회 생성해 재시도 시 재사용하면, 서버는 (user_id, key) 유니크 제약으로 같은 키의 재요청에 대해 **인식·저장을 건너뛰고 기존 entry 를 반환**한다(중복 기록·RAG 재적재 없음).
 
 ### 운동
+
 | Method | Path | 응답 핵심 필드 |
 |---|---|---|
 | GET | `/exercise/weeks/current` | `{ sessions[], daily_minutes[7], daily_calories[7], cardio_minutes[7], strength_minutes[7], stretching_minutes[7], day_labels[7], total_minutes, total_calories, streak_days, ai_coach_message }` |
@@ -68,6 +73,7 @@
 `daily_calories`: 요일별 소모 칼로리(합 = `total_calories`). 홈 '주간 추이' 차트가 이 시리즈를 읽으며, 비어 있으면 클라이언트가 데모 상수로 폴백한다.
 
 ### 일정 (캘린더 상세 CRUD)
+
 | Method | Path | 응답 |
 |---|---|---|
 | GET | `/schedule/events?date=YYYY-MM-DD` | `[{ id, date, time, title, category, emoji, color_hex }]` (배열) |
@@ -82,6 +88,7 @@ category: hospital|exercise|meal|medication|other
   형식 위반 시 **422**. 특히 `month`는 미검증 시 `month=%` 같은 값이 LIKE 와일드카드로 새므로 필수.
 
 ### 알림 (액션)
+
 | Method | Path | 응답 |
 |---|---|---|
 | GET | `/notifications` | `[{ id, title, body, category, read(bool), created_at(ISO), time_ago }]` (배열, 최신순) |
@@ -93,6 +100,7 @@ category: hospital|exercise|meal|medication|other
 category: reminder|health_check|achievement|system
 
 ### AI 코치
+
 | Method | Path | 응답 |
 |---|---|---|
 | GET | `/ai-coach/feedback` | `{ greeting, suggestions[{ tag, title, body }] }` |
@@ -100,6 +108,7 @@ category: reminder|health_check|achievement|system
 tag: diet|exercise|hydration|...
 
 ### 바이탈 (체중/혈압/혈당)
+
 | Method | Path | 본문/응답 |
 |---|---|---|
 | POST | `/vitals/weight` | body: `{ ...value, recorded_at? }` → `{ id, kind, value, recorded_at }` |
@@ -110,6 +119,7 @@ tag: diet|exercise|hydration|...
 value 예시(drift 주석): weight `{kg}`, blood-pressure `{systolic, diastolic}`, blood-sugar `{mg_per_dl}`
 
 ### 장소 (온오프라인 연결, O2O)
+
 | Method | Path | 응답 |
 |---|---|---|
 | GET | `/places/nearby?lat=&lng=&category=&radius_m=` | `[{ id, name, category, address, distance_meters, lat, lng }]` (거리순 배열) |

--- a/backend/API_CONTRACT.md
+++ b/backend/API_CONTRACT.md
@@ -48,7 +48,8 @@
 | GET | `/diet/days/today` | `{ entries[], total_calories, total_sodium_mg, total_sugar_g, macros, ai_coach_message }` |
 | POST | `/diet/analyze` | multipart `{ image, meal_type, idempotency_key? }` → `{ entry_id, analysis }` (분석과 동시에 diet_entries 저장) |
 
-`entries[]`: `{ id(str), meal_type(breakfast|lunch|dinner|snack), time_label, foods[], total_calories, sodium_mg, sugar_g }`
+`entries[]`: `{ id(str), meal_type(breakfast|lunch|dinner|snack), time_label, foods[], total_calories(int), sodium_mg(int), sugar_g(float) }`
+당류만 소수다 — 항목 단위 당류가 6.3g·8.5g 처럼 소수로 들어오고 합계도 절삭 없이 유지된다(`total_sugar_g` 도 float).
 `foods[]`: `[{ name, calories }]` (drift 주석 기준)
 `macros`: `{ carbs_pct, protein_pct, fat_pct }`
 `idempotency_key`(선택): 재시도 중복 저장 방지. 클라 요청당 1회 생성해 재시도 시 재사용하면, 서버는 (user_id, key) 유니크 제약으로 같은 키의 재요청에 대해 **인식·저장을 건너뛰고 기존 entry 를 반환**한다(중복 기록·RAG 재적재 없음).

--- a/backend/API_CONTRACT.md
+++ b/backend/API_CONTRACT.md
@@ -40,7 +40,8 @@
 |---|---|---|
 | GET | `/dashboard/summary` | `{ indicators[], diet_entries(int), exercise_minutes, today_schedule[], week_score, week_score_delta, sodium_warning(nullable), exercise_feedback }` |
 
-`indicators[]`: `{ label, current(int), max(int), unit, over_budget?(bool) }` — 칼로리/나트륨/당류 3종.
+`indicators[]`: `{ label, current(float), max(int), unit, over_budget?(bool) }` — 칼로리/나트륨/당류 3종.
+`current` 는 당류가 소수(17.8g)라 float. 칼로리·나트륨은 정수 값이 그대로 실린다. 목표치(`max`)는 셋 다 정수.
 
 ### 식단 (핵심: 나트륨·당류·고혈압 관점)
 | Method | Path | 응답 핵심 필드 |

--- a/backend/app/api/v1/dashboard.py
+++ b/backend/app/api/v1/dashboard.py
@@ -76,7 +76,7 @@ def _nutrition_week(
     rows = db.scalars(
         select(DietEntry).where(DietEntry.user_id == uid).where(DietEntry.date.in_(dates))
     ).all()
-    acc: dict[str, list[int]] = {d: [0, 0, 0] for d in dates}  # [cal, na, sugar]
+    acc: dict[str, list[float]] = {d: [0, 0, 0] for d in dates}  # [cal, na, sugar]
     for r in rows:
         a = acc.get(r.date)
         if a is not None:

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -108,7 +108,9 @@ class DietEntry(Base):
     protein_g: Mapped[float] = mapped_column(Float, default=0.0)
     fat_g: Mapped[float] = mapped_column(Float, default=0.0)
     sodium_mg: Mapped[int] = mapped_column(Integer, default=0)
-    sugar_g: Mapped[int] = mapped_column(Integer, default=0)
+    # 당류는 소수. 음식 단위(FoodNutrient.sugar_g)가 이미 Float 이라 항목 단위만
+    # Integer 로 남아 있으면 6.3+8.5 같은 합이 절삭된다(프론트도 double 로 다룸).
+    sugar_g: Mapped[float] = mapped_column(Float, default=0.0)
     engine: Mapped[str] = mapped_column(String(20), default="")  # 인식 엔진(gemini|yolo)
     # 재시도 중복 저장 방지용 멱등키(클라 요청당 1회 생성). NULL 허용 → 기존/무키 요청은 제약 밖.
     idempotency_key: Mapped[str | None] = mapped_column(String(64), nullable=True)

--- a/backend/app/schemas/dashboard_api.py
+++ b/backend/app/schemas/dashboard_api.py
@@ -9,7 +9,9 @@ from app.schemas.diet_api import Macros
 
 class DashboardIndicator(BaseModel):
     label: str            # 칼로리 | 나트륨 | 당류
-    current: int
+    # 당류가 소수(17.8g)라 current 는 float. 칼로리·나트륨은 정수 값이 그대로
+    # 실려 나가고, 목표치(max)는 세 지표 모두 정수라 int 를 유지한다.
+    current: float
     max: int
     unit: str
     over_budget: bool = False
@@ -29,7 +31,7 @@ class DashboardNutritionDay(BaseModel):
     label: str       # 요일 라벨(월/화/…) — 프론트 x축용
     calories: int
     sodium_mg: int
-    sugar_g: int
+    sugar_g: float
 
 
 class DashboardSummary(BaseModel):

--- a/backend/app/schemas/diet.py
+++ b/backend/app/schemas/diet.py
@@ -23,7 +23,7 @@ class RecognizedFood(BaseModel):
     fat_g: Optional[float] = Field(None, ge=0, allow_inf_nan=False, description="지방 g")
     sodium_mg: Optional[int] = Field(None, description="나트륨 mg")
     sugar_g: Optional[float] = Field(
-        None, allow_inf_nan=False, description="당류 g"
+        None, ge=0, allow_inf_nan=False, description="당류 g"
     )
     confidence: Optional[float] = Field(None, ge=0.0, le=1.0)
     # 영양 수치 출처: 공공 DB | 인식기 추정 | 두 값의 혼합

--- a/backend/app/schemas/diet.py
+++ b/backend/app/schemas/diet.py
@@ -22,7 +22,9 @@ class RecognizedFood(BaseModel):
     )
     fat_g: Optional[float] = Field(None, ge=0, allow_inf_nan=False, description="지방 g")
     sodium_mg: Optional[int] = Field(None, description="나트륨 mg")
-    sugar_g: Optional[int] = Field(None, description="당류 g")
+    sugar_g: Optional[float] = Field(
+        None, allow_inf_nan=False, description="당류 g"
+    )
     confidence: Optional[float] = Field(None, ge=0.0, le=1.0)
     # 영양 수치 출처: 공공 DB | 인식기 추정 | 두 값의 혼합
     source: str = Field("estimate", description="db|estimate|mixed")
@@ -37,7 +39,7 @@ class DietAnalysis(BaseModel):
     total_protein_g: float = 0.0
     total_fat_g: float = 0.0
     total_sodium_mg: int = 0
-    total_sugar_g: int = 0
+    total_sugar_g: float = 0.0
     # 고혈압·DASH 관점 식단평 (기존 PoC 의 핵심 가치)
     coach_comment: str = ""
     latency_ms: Optional[int] = None
@@ -49,5 +51,5 @@ class DietAnalysis(BaseModel):
         self.total_protein_g = sum(f.protein_g or 0.0 for f in self.foods)
         self.total_fat_g = sum(f.fat_g or 0.0 for f in self.foods)
         self.total_sodium_mg = sum(f.sodium_mg or 0 for f in self.foods)
-        self.total_sugar_g = sum(f.sugar_g or 0 for f in self.foods)
+        self.total_sugar_g = sum(f.sugar_g or 0.0 for f in self.foods)
         return self

--- a/backend/app/schemas/diet_api.py
+++ b/backend/app/schemas/diet_api.py
@@ -60,7 +60,7 @@ class DietEntryOut(BaseModel):
     protein_g: float
     fat_g: float
     sodium_mg: int
-    sugar_g: int
+    sugar_g: float
 
 
 class DietEntryUpdate(BaseModel):
@@ -72,14 +72,14 @@ class DietEntryUpdate(BaseModel):
     protein_g: float | None = Field(None, ge=0, allow_inf_nan=False)
     fat_g: float | None = Field(None, ge=0, allow_inf_nan=False)
     sodium_mg: int | None = Field(None, ge=0)
-    sugar_g: int | None = Field(None, ge=0)
+    sugar_g: float | None = Field(None, ge=0, allow_inf_nan=False)
 
 
 class DietTodayResponse(BaseModel):
     entries: list[DietEntryOut]
     total_calories: int
     total_sodium_mg: int
-    total_sugar_g: int
+    total_sugar_g: float
     macros: Macros
     ai_coach_message: str
 

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -62,7 +62,7 @@ class TrainerClientOut(BaseModel):
     active: bool
     calories: int                # 오늘 총 칼로리(회원 실데이터)
     sodium_mg: int               # 오늘 총 나트륨
-    sugar_g: int                 # 오늘 총 당류
+    sugar_g: float               # 오늘 총 당류(소수)
     last_routine: str            # 마지막 루틴 전송 라벨(오늘/어제/N일 전)
     week_completion: list[int]   # 이번 주 일별 완료율 7개(월→일)
     sodium_week: list[int]       # 최근 7일 일별 나트륨(오래된→오늘)

--- a/backend/app/services/coach/personal_ingest.py
+++ b/backend/app/services/coach/personal_ingest.py
@@ -30,7 +30,7 @@ def _safe(db: Session, user_id: str, text: str, *, domain: str, source: str) -> 
 
 def record_diet(
     db: Session, user_id: str, *, date: str, foods: list[dict],
-    total_calories: int, sodium_mg: int, sugar_g: int,
+    total_calories: int, sodium_mg: int, sugar_g: float,
 ) -> None:
     names = ", ".join(f.get("name", "") for f in foods if f.get("name")) or "식단"
     text = (

--- a/backend/migrations/versions/0018_diet_entry_sugar_g_float.py
+++ b/backend/migrations/versions/0018_diet_entry_sugar_g_float.py
@@ -4,8 +4,10 @@
 실서버 경로에서 `sugar_g=8.5` 가 절삭되거나 요청이 거부됐다. 음식 단위
 (`food_nutrients.sugar_g`)는 이미 Float 이라 항목 단위만 어긋나 있었다.
 
-정수 → 실수 확대라 기존 값은 그대로 보존된다(8 → 8.0). 되돌릴 때는 소수부가
-버려지므로(8.5 → 8) downgrade 는 손실이 있다 — 주석으로 명시한다.
+정수 → 실수 확대라 기존 값은 그대로 보존된다(8 → 8.0). 되돌릴 때는
+`round(sugar_g)::integer` 로 변환하므로 소수 정밀도가 손실된다 — 절삭이 아니라
+반올림이라 8.6 은 9 가 되고, 중간값은 은행가 반올림이라 8.5·7.5 모두 8 이 된다
+(PostgreSQL 의 double precision round 는 C 라이브러리 rint 에 위임된다).
 
 Revision ID: 0018_diet_entry_sugar_g_float
 Revises: 0017_add_diet_exercise_goals
@@ -37,7 +39,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # 주의: 소수부가 버려진다(8.5 → 8). 되돌릴 일이 생기면 데이터 손실을 감수한 것.
+    # 주의: 반올림이라 소수 정밀도가 사라진다(8.6 → 9, 8.5 → 8). 되돌릴 일이
+    # 생기면 데이터 손실을 감수한 것.
     op.alter_column(
         "diet_entries",
         "sugar_g",

--- a/backend/migrations/versions/0018_diet_entry_sugar_g_float.py
+++ b/backend/migrations/versions/0018_diet_entry_sugar_g_float.py
@@ -1,0 +1,49 @@
+"""당류 계약 정합: diet_entries.sugar_g 를 Integer → Double precision 으로
+
+프론트는 항목 당류를 소수(double)로 다루는데 항목 단위 컬럼만 Integer 라,
+실서버 경로에서 `sugar_g=8.5` 가 절삭되거나 요청이 거부됐다. 음식 단위
+(`food_nutrients.sugar_g`)는 이미 Float 이라 항목 단위만 어긋나 있었다.
+
+정수 → 실수 확대라 기존 값은 그대로 보존된다(8 → 8.0). 되돌릴 때는 소수부가
+버려지므로(8.5 → 8) downgrade 는 손실이 있다 — 주석으로 명시한다.
+
+Revision ID: 0018_diet_entry_sugar_g_float
+Revises: 0017_add_diet_exercise_goals
+Create Date: 2026-08-05
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0018_diet_entry_sugar_g_float"
+down_revision: str | Sequence[str] | None = "0017_add_diet_exercise_goals"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "diet_entries",
+        "sugar_g",
+        existing_type=sa.Integer(),
+        type_=sa.Float(),
+        existing_nullable=False,
+        existing_server_default=None,
+        postgresql_using="sugar_g::double precision",
+    )
+
+
+def downgrade() -> None:
+    # 주의: 소수부가 버려진다(8.5 → 8). 되돌릴 일이 생기면 데이터 손실을 감수한 것.
+    op.alter_column(
+        "diet_entries",
+        "sugar_g",
+        existing_type=sa.Float(),
+        type_=sa.Integer(),
+        existing_nullable=False,
+        existing_server_default=None,
+        postgresql_using="round(sugar_g)::integer",
+    )

--- a/backend/tests/test_diet.py
+++ b/backend/tests/test_diet.py
@@ -556,3 +556,78 @@ def test_update_entry_hides_other_users_record(client, db_session):
 def test_update_entry_404_when_missing(client):
     r = client.put("/v1/diet/entries/diet-nope", json={"meal_type": "dinner"})
     assert r.status_code == 404
+
+
+def test_update_entry_keeps_fractional_sugar(client, db_session):
+    """#296 회귀: 항목 당류가 Integer 라 소수가 절삭·거부되던 문제.
+
+    프론트는 항목 당류를 double 로 다루고 음식 단위(food_nutrients.sugar_g)도
+    이미 Float 이었는데, 항목 단위만 Integer 로 남아 `sugar_g=8.5` 가 실서버
+    경로에서 깨졌다.
+    """
+    from app.services.diet_service import today_str as _today_str
+    from app.db.init_db import DEMO_USER_ID
+    from app.models.models import DietEntry
+
+    db_session.execute(
+        delete(DietEntry).where(
+            DietEntry.user_id == DEMO_USER_ID,
+            DietEntry.date == _today_str(),
+        )
+    )
+    db_session.commit()
+    entry_id = client.post(
+        "/v1/diet/analyze",
+        files={"image": ("food.jpg", _JPEG, "image/jpeg")},
+        data={"meal_type": "lunch"},
+    ).json()["entry_id"]
+
+    r = client.put(f"/v1/diet/entries/{entry_id}", json={"sugar_g": 8.5})
+    assert r.status_code == 200, r.text
+    # 예전엔 Pydantic int 검증에서 422 로 거부되거나 8 로 절삭됐다.
+    assert r.json()["sugar_g"] == 8.5
+
+    # DB 컬럼도 소수를 보존해야 한다(왕복 후 재조회).
+    db_session.expire_all()
+    assert db_session.get(DietEntry, entry_id).sugar_g == 8.5
+    assert client.get("/v1/diet/days/today").json()["total_sugar_g"] == 8.5
+
+
+def test_fractional_sugar_sums_without_truncation(client, db_session):
+    """#296 회귀: 6.3 + 8.5 가 14 나 15 가 아니라 14.8 이어야 한다."""
+    from app.services.diet_service import today_str as _today_str
+    from app.db.init_db import DEMO_USER_ID
+    from app.models.models import DietEntry
+
+    db_session.execute(
+        delete(DietEntry).where(
+            DietEntry.user_id == DEMO_USER_ID,
+            DietEntry.date == _today_str(),
+        )
+    )
+    db_session.commit()
+    for meal, sugar in (("lunch", 6.3), ("dinner", 8.5)):
+        entry_id = client.post(
+            "/v1/diet/analyze",
+            files={"image": ("food.jpg", _JPEG, "image/jpeg")},
+            data={"meal_type": meal},
+        ).json()["entry_id"]
+        assert client.put(
+            f"/v1/diet/entries/{entry_id}", json={"sugar_g": sugar}
+        ).status_code == 200
+
+    assert client.get("/v1/diet/days/today").json()["total_sugar_g"] == pytest.approx(14.8)
+
+    # 홈 지표 카드도 같은 소수를 봐야 한다(반올림 18 로 굳으면 회귀).
+    summary = client.get("/v1/dashboard/summary").json()
+    sugar = next(i for i in summary["indicators"] if i["label"] == "당류")
+    assert sugar["current"] == pytest.approx(14.8)
+
+
+def test_entry_update_rejects_non_finite_sugar():
+    """float 로 넓힌 뒤 NaN/inf 가 새어 들어오지 않는지."""
+    from app.schemas.diet_api import DietEntryUpdate
+
+    for value in (math.nan, math.inf, -math.inf):
+        with pytest.raises(ValidationError):
+            DietEntryUpdate(sugar_g=value)


### PR DESCRIPTION
Closes #296

## Summary

PR #293 CodeRabbit 리뷰(Major) 후속입니다. 프론트는 항목 당류를 `double` 로 다루고 음식 단위(`food_nutrients.sugar_g`)도 이미 `Float` 인데 항목 단위만 `Integer` 로 남아, 실서버 경로에서 소수 당류가 거부됐습니다.

변경 전 코드에서 재현한 실제 응답:

```
PUT /v1/diet/entries/{id}  {"sugar_g": 8.5}
→ 422 {"type":"int_from_float","msg":"Input should be a valid integer, got a number with a fractional part","input":8.5}
```

## Changes

**컬럼 + 마이그레이션**
- `diet_entries.sugar_g` `Integer` → `Float` (`0018_diet_entry_sugar_g_float`, single head)

**이슈에 적힌 스키마 정합**
- `diet.py` 의 `sugar_g`(`RecognizedFood`), `total_sugar_g`(`DietAnalysis`) → `float`
- `diet_api.py` 의 `sugar_g`(`DietEntryOut`·`DietEntryUpdate`), `total_sugar_g`(`DietTodayResponse`) → `float`
- `trainer_api.py:65` 회원 총 당류 → `float` (이슈의 "필요 시 검토" 항목)

**함께 고쳐야 했던 곳**
컬럼이 소수가 되면 당류가 흘러드는 응답 스키마도 같이 넓혀야 합니다. 안 그러면 Pydantic v2 가 `17.8` 을 `int` 로 받지 못해 `/dashboard/summary` 가 500 납니다.

- `DashboardIndicator.current` → `float` — 당류 지표가 소수를 싣습니다. 목표치(`max`)는 세 지표 모두 정수라 `int` 유지
- `DashboardNutritionDay.sugar_g` → `float`, 주간 집계 누산기 타입도 `float`
- `personal_ingest` 의 `sugar_g` 인자 타입

**부수**
- `float` 로 넓히면서 NaN/inf 가 새지 않도록 `allow_inf_nan=False` 추가 (형제 float 필드들과 동일)
- `API_CONTRACT.md` 에 당류만 소수라는 점 명시

## Verification

로컬 Postgres 에 임시 DB(`oncare_296_verify`)를 만들어 검증하고 끝나고 삭제했습니다. 기존 로컬 `oncare` DB 는 건드리지 않았습니다.

- `0017` → `0018` 적용: 컬럼 `integer` → `double precision`, **기존 정수 값 보존**(8 → 8.0)
- 소수 저장(8.5) 및 **합계 무절삭**: 6.3 + 8.5 = 14.8
- `downgrade` → `upgrade` 재적용 정상. downgrade 는 소수부가 버려지므로(8.5 → 8) 마이그레이션 주석에 손실을 명시했습니다
- 백엔드 테스트 **265 passed**
- 신규 회귀 테스트 3건이 **변경 전 코드에서는 실패**하는 것까지 확인했습니다 (위 422 가 그 결과)

## Notes — drift(mock DB) 라운드트립 확인 결과

이슈 체크리스트의 "drift(mock DB) 스키마·인터셉터 라운드트립 확인" 을 수행한 결과, **클라이언트 쪽에도 절삭 지점이 남아 있습니다.** 이슈가 이 작업을 "별도 백엔드 PR" 로 못박고 있고 drift 스키마 변경은 로컬 DB 마이그레이션 + 코드 생성이 필요해, 이 PR 에는 넣지 않았습니다.

- `lib/core/storage/app_database.dart:27` — `IntColumn get sugarG => integer()` (로컬 drift 컬럼이 정수)
- `lib/core/network/interceptors/local_api_interceptor.dart:214` — `Value(sugarGValue.toInt())`
- `lib/features/diet/domain/entities/diet_analysis.dart:24,57` — `.toInt()`
- `lib/features/dashboard/domain/entities/dashboard_summary.dart:72` — `NutritionDay.sugarG` 가 `.toInt()`

실모드 주 경로(`DietDay`·`FoodItem`·`DietEntry`, `lib/features/diet/domain/entities/diet_day.dart`)와 홈 지표 카드(`current` 를 `num` 으로 파싱)는 이미 소수를 보존하므로 이 PR 만으로 이슈의 증상은 해소됩니다. 남은 4곳은 후속으로 다루면 됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 식단의 당류를 소수점 단위로 입력하고 저장할 수 있습니다.
  - 식단 요약, 일일 합계, 주간 대시보드에서 당류 합계가 반올림이나 절삭 없이 표시됩니다.
  - 식품 분석 및 트레이너 화면에서도 소수점 당류 정보를 지원합니다.

- **버그 수정**
  - 당류 입력 시 NaN 및 무한대 값이 허용되지 않도록 검증을 강화했습니다.

- **문서**
  - 식단 및 영양 지표의 당류 데이터 형식을 소수형으로 명확히 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->