### PR TITLE
feat(member-coach): add coach chat and received routines to exercise tab

### DIFF
--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -8,6 +8,7 @@ import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/features/exercise/presentation/widgets/exercise_flows.dart';
 import 'package:oncare/features/exercise/presentation/widgets/gym_tab.dart';
+import 'package:oncare/features/member_coach/presentation/widgets/coach_card.dart';
 import 'package:oncare/features/notification/presentation/widgets/notification_panel.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/widgets/modals/right_slide_panel.dart';
@@ -63,9 +64,10 @@ class _ExercisePageState extends State<ExercisePage> {
                   onChanged: (int i) => setState(() => _subTab = i),
                 ),
                 const SizedBox(height: 16),
-                if (_subTab == 0)
-                  const _RecordTab()
-                else
+                if (_subTab == 0) ...<Widget>[
+                  const CoachCard(),
+                  const _RecordTab(),
+                ] else
                   GymTab(
                     selectedSlot: _slot,
                     onSlot: (String s) =>

--- a/frontend/flutter/lib/features/member_coach/data/dtos/member_coach_dtos.dart
+++ b/frontend/flutter/lib/features/member_coach/data/dtos/member_coach_dtos.dart
@@ -1,0 +1,41 @@
+import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
+
+/// `/me/coach` (MemberCoachOut) → [MemberCoach].
+MemberCoach memberCoachFromJson(Map<String, Object?> json) {
+  final gym = json['gym'];
+  return MemberCoach(
+    trainerId: _str(json['trainer_id']),
+    name: _str(json['name']),
+    specialty: _str(json['specialty']),
+    career: _str(json['career']),
+    intro: _str(json['intro']),
+    gymName: gym is Map<String, Object?> ? _str(gym['name']) : '',
+    goal: _str(json['goal']),
+  );
+}
+
+/// `/me/coach/routines` element (RoutineOut) → [CoachRoutine].
+CoachRoutine coachRoutineFromJson(Map<String, Object?> json) {
+  return CoachRoutine(
+    id: _str(json['id']),
+    name: _str(json['name']),
+    minutes: json['minutes'] is num ? (json['minutes']! as num).toInt() : 0,
+    type: _str(json['type']),
+    reason: _str(json['reason']),
+    source: _str(json['source']),
+  );
+}
+
+/// `/me/coach/chat` element (ChatMessageOut) → [CoachMessage]. From the
+/// member's viewpoint `sender` is `me` | `trainer`; anything that isn't
+/// `trainer` maps to [CoachSender.me].
+CoachMessage coachMessageFromJson(Map<String, Object?> json) {
+  return CoachMessage(
+    id: _str(json['id']),
+    sender: json['sender'] == 'trainer' ? CoachSender.trainer : CoachSender.me,
+    body: _str(json['body']),
+    timeLabel: _str(json['time_label']),
+  );
+}
+
+String _str(Object? v) => v is String ? v : '';

--- a/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
@@ -1,0 +1,88 @@
+import 'package:dio/dio.dart';
+
+import 'package:oncare/core/errors/app_error.dart';
+import 'package:oncare/features/member_coach/data/dtos/member_coach_dtos.dart';
+import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
+import 'package:oncare/features/member_coach/domain/repositories/member_coach_repository.dart';
+
+/// Reads the member's coach + received routines + chat from the FastAPI
+/// backend. The chat thread is the same one the trainer app writes to, so
+/// messages and routines flow both ways.
+class DioMemberCoachRepository implements MemberCoachRepository {
+  DioMemberCoachRepository(this._dio);
+
+  final Dio _dio;
+
+  @override
+  Future<MemberCoach?> fetchCoach() async {
+    try {
+      final res = await _dio.get<Map<String, Object?>>('/me/coach');
+      final data = res.data;
+      return data == null ? null : memberCoachFromJson(data);
+    } on DioException catch (e) {
+      // No assigned coach yet → 404 is an expected empty state, not an error.
+      if (e.response?.statusCode == 404) return null;
+      throw AppError.fromDio(e);
+    }
+  }
+
+  @override
+  Future<List<CoachRoutine>> fetchRoutines() =>
+      _getList('/me/coach/routines', coachRoutineFromJson);
+
+  @override
+  Future<List<CoachMessage>> fetchChat() =>
+      _getList('/me/coach/chat', coachMessageFromJson);
+
+  @override
+  Future<void> sendMessage(String text) async {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) return;
+    try {
+      await _dio.post<Map<String, Object?>>(
+        '/me/coach/chat',
+        data: <String, Object?>{'text': trimmed},
+      );
+    } on DioException catch (e) {
+      throw AppError.fromDio(e);
+    }
+  }
+
+  @override
+  Future<void> markRead() async {
+    try {
+      await _dio.post<Map<String, Object?>>('/me/coach/chat/read');
+    } on DioException catch (e) {
+      throw AppError.fromDio(e);
+    }
+  }
+
+  @override
+  Future<int> unreadCount() async {
+    try {
+      final res = await _dio.get<Map<String, Object?>>('/me/coach/chat/unread');
+      final v = res.data?['unread'];
+      return v is num ? v.toInt() : 0;
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) return 0;
+      throw AppError.fromDio(e);
+    }
+  }
+
+  Future<List<T>> _getList<T>(
+    String path,
+    T Function(Map<String, Object?>) fromJson,
+  ) async {
+    try {
+      final res = await _dio.get<List<dynamic>>(path);
+      final data = res.data ?? const <dynamic>[];
+      return data
+          .whereType<Map<String, Object?>>()
+          .map(fromJson)
+          .toList(growable: false);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) return <T>[];
+      throw AppError.fromDio(e);
+    }
+  }
+}

--- a/frontend/flutter/lib/features/member_coach/data/repositories/mock_member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/data/repositories/mock_member_coach_repository.dart
@@ -1,0 +1,84 @@
+import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
+import 'package:oncare/features/member_coach/domain/repositories/member_coach_repository.dart';
+
+/// In-memory demo coach for `USE_MOCK_API=true`. Mirrors the trainer app's
+/// seed identity (김트레이너) so the two demo apps tell one story. Chat is
+/// stateful for the session so a sent message appears in the thread.
+class MockMemberCoachRepository implements MemberCoachRepository {
+  MockMemberCoachRepository();
+
+  static const _coach = MemberCoach(
+    trainerId: 'seed-trainer',
+    name: '김트레이너',
+    specialty: '퍼스널 트레이너',
+    career: '7년',
+    intro: '혈압 관리와 체중 감량 전문 트레이너입니다.',
+    gymName: '온케어짐 신촌점',
+    goal: '혈압 관리 · 체중 감량',
+  );
+
+  final List<CoachRoutine> _routines = <CoachRoutine>[
+    const CoachRoutine(
+      id: 'seed-r1',
+      name: '저강도 유산소 (걷기)',
+      minutes: 20,
+      type: '유산소',
+      reason: '혈압 안정에 효과적',
+      source: 'ai',
+    ),
+    const CoachRoutine(
+      id: 'seed-r2',
+      name: '코어 스트레칭',
+      minutes: 10,
+      type: '스트레칭',
+      reason: '허리 부담 완화',
+      source: 'trainer',
+    ),
+  ];
+
+  final List<CoachMessage> _chat = <CoachMessage>[
+    const CoachMessage(
+      id: 'seed-m1',
+      sender: CoachSender.trainer,
+      body: '오늘 점심 등록 잘 확인했어요. 나트륨만 조금 신경 써 주세요!',
+      timeLabel: '13:20',
+    ),
+  ];
+
+  bool _read = false;
+
+  @override
+  Future<MemberCoach?> fetchCoach() async => _coach;
+
+  @override
+  Future<List<CoachRoutine>> fetchRoutines() async =>
+      List<CoachRoutine>.unmodifiable(_routines);
+
+  @override
+  Future<List<CoachMessage>> fetchChat() async =>
+      List<CoachMessage>.unmodifiable(_chat);
+
+  @override
+  Future<void> sendMessage(String text) async {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) return;
+    final now = DateTime.now();
+    _chat.add(
+      CoachMessage(
+        id: 'me-${now.microsecondsSinceEpoch}',
+        sender: CoachSender.me,
+        body: trimmed,
+        timeLabel:
+            '${now.hour.toString().padLeft(2, '0')}:'
+            '${now.minute.toString().padLeft(2, '0')}',
+      ),
+    );
+  }
+
+  @override
+  Future<void> markRead() async => _read = true;
+
+  @override
+  Future<int> unreadCount() async =>
+      _read ? 0 : _chat.where((m) => m.sender == CoachSender.trainer).length;
+}

--- a/frontend/flutter/lib/features/member_coach/domain/entities/member_coach.dart
+++ b/frontend/flutter/lib/features/member_coach/domain/entities/member_coach.dart
@@ -1,0 +1,63 @@
+/// The member's assigned trainer (coach) summary — `/me/coach`.
+class MemberCoach {
+  const MemberCoach({
+    required this.trainerId,
+    required this.name,
+    required this.specialty,
+    required this.career,
+    required this.intro,
+    required this.gymName,
+    required this.goal,
+  });
+
+  final String trainerId;
+  final String name;
+  final String specialty;
+  final String career;
+  final String intro;
+  final String gymName;
+
+  /// The coaching goal the trainer set for this member.
+  final String goal;
+}
+
+/// A routine the member received from their coach — `/me/coach/routines`.
+class CoachRoutine {
+  const CoachRoutine({
+    required this.id,
+    required this.name,
+    required this.minutes,
+    required this.type,
+    required this.reason,
+    required this.source,
+  });
+
+  final String id;
+  final String name;
+  final int minutes;
+  final String type;
+  final String reason;
+
+  /// `ai` (AI-suggested) or `trainer` (hand-assigned).
+  final String source;
+}
+
+/// Chat message viewpoint for the member: their own message vs the coach's.
+enum CoachSender { me, trainer }
+
+/// A message in the member↔coach thread — `/me/coach/chat`.
+class CoachMessage {
+  const CoachMessage({
+    required this.id,
+    required this.sender,
+    required this.body,
+    required this.timeLabel,
+  });
+
+  final String id;
+  final CoachSender sender;
+  final String body;
+  final String timeLabel;
+
+  bool get fromMe => sender == CoachSender.me;
+}

--- a/frontend/flutter/lib/features/member_coach/domain/repositories/member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/domain/repositories/member_coach_repository.dart
@@ -1,0 +1,28 @@
+import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
+
+/// The member's view of their assigned coach: profile, received routines,
+/// and the shared chat thread (the same thread the trainer app writes to).
+///
+/// Two implementations sit behind this contract (selected by
+/// [memberCoachRepositoryProvider] via `AppConfig.useMockApi`):
+///  * `MockMemberCoachRepository` — demo / `USE_MOCK_API=true`;
+///  * `DioMemberCoachRepository` — the real FastAPI backend.
+abstract interface class MemberCoachRepository {
+  /// The assigned coach, or `null` when the member has none yet (404).
+  Future<MemberCoach?> fetchCoach();
+
+  /// Routines the coach has assigned (newest first).
+  Future<List<CoachRoutine>> fetchRoutines();
+
+  /// The chat thread (oldest → newest).
+  Future<List<CoachMessage>> fetchChat();
+
+  /// Sends a message to the coach. No-ops on blank text.
+  Future<void> sendMessage(String text);
+
+  /// Marks the thread read up to the newest coach message.
+  Future<void> markRead();
+
+  /// Unread coach-sent message count for the entry badge.
+  Future<int> unreadCount();
+}

--- a/frontend/flutter/lib/features/member_coach/presentation/controllers/member_coach_providers.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/controllers/member_coach_providers.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/core/network/dio_client.dart';
+import 'package:oncare/features/member_coach/data/repositories/dio_member_coach_repository.dart';
+import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
+import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
+import 'package:oncare/features/member_coach/domain/repositories/member_coach_repository.dart';
+
+/// Selects the real Dio-backed coach repository against the FastAPI backend,
+/// or the in-memory demo for `USE_MOCK_API=true`. One mock instance per
+/// provider lifetime so demo chat sends persist for the session.
+final memberCoachRepositoryProvider = Provider<MemberCoachRepository>((ref) {
+  if (ref.watch(appConfigProvider).useMockApi) {
+    return MockMemberCoachRepository();
+  }
+  return DioMemberCoachRepository(ref.watch(dioProvider));
+}, name: 'memberCoachRepository');
+
+/// The member's assigned coach (null when none).
+final memberCoachProvider = FutureProvider<MemberCoach?>((ref) {
+  return ref.watch(memberCoachRepositoryProvider).fetchCoach();
+});
+
+/// Routines the coach has assigned to the member.
+final coachRoutinesProvider = FutureProvider<List<CoachRoutine>>((ref) {
+  return ref.watch(memberCoachRepositoryProvider).fetchRoutines();
+});
+
+/// The member↔coach chat thread (oldest → newest).
+final coachChatProvider = FutureProvider<List<CoachMessage>>((ref) {
+  return ref.watch(memberCoachRepositoryProvider).fetchChat();
+});
+
+/// Unread coach-sent message count for the entry badge.
+final coachUnreadProvider = FutureProvider<int>((ref) {
+  return ref.watch(memberCoachRepositoryProvider).unreadCount();
+});

--- a/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
@@ -1,0 +1,230 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
+import 'package:oncare/features/member_coach/presentation/widgets/coach_chat_sheet.dart';
+
+/// "담당 코치" card for the 운동 기록 sub-tab: the assigned trainer, the
+/// routines they've sent, and an entry point to the chat thread. Renders
+/// nothing when the member has no coach (keeps the tab clean).
+class CoachCard extends ConsumerWidget {
+  const CoachCard({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final coachAsync = ref.watch(memberCoachProvider);
+    final coach = coachAsync.valueOrNull;
+    if (coach == null) return const SizedBox.shrink();
+
+    final routines = ref.watch(coachRoutinesProvider).valueOrNull ??
+        const <CoachRoutine>[];
+    final unread = ref.watch(coachUnreadProvider).valueOrNull ?? 0;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 0, 24, 20),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: FigmaColors.hairline),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Container(
+                  width: 36,
+                  height: 36,
+                  decoration: const BoxDecoration(
+                    color: FigmaColors.iconTint,
+                    shape: BoxShape.circle,
+                  ),
+                  child: const Icon(
+                    Icons.person,
+                    color: FigmaColors.primary,
+                    size: 20,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      const Text(
+                        '담당 코치',
+                        style: TextStyle(
+                          fontSize: 10.5,
+                          fontWeight: FontWeight.w700,
+                          color: FigmaColors.textMuted,
+                        ),
+                      ),
+                      Text(
+                        '${coach.name} · ${coach.specialty}',
+                        style: const TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w800,
+                          color: FigmaColors.ink,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 14),
+            const Text(
+              '받은 루틴',
+              style: TextStyle(
+                fontSize: 11.5,
+                fontWeight: FontWeight.w700,
+                color: FigmaColors.textSub,
+              ),
+            ),
+            const SizedBox(height: 8),
+            if (routines.isEmpty)
+              const Text(
+                '아직 받은 루틴이 없어요',
+                style: TextStyle(fontSize: 12, color: FigmaColors.textMuted),
+              )
+            else
+              for (final r in routines) ...<Widget>[
+                _RoutineRow(routine: r),
+                const SizedBox(height: 8),
+              ],
+            const SizedBox(height: 6),
+            _ChatButton(
+              coachName: coach.name,
+              unread: unread,
+              onTap: () => showCoachChatSheet(context, coachName: coach.name),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RoutineRow extends StatelessWidget {
+  const _RoutineRow({required this.routine});
+
+  final CoachRoutine routine;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: FigmaColors.statBg,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  routine.name,
+                  style: const TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: FigmaColors.ink,
+                  ),
+                ),
+                if (routine.reason.isNotEmpty) ...<Widget>[
+                  const SizedBox(height: 2),
+                  Text(
+                    routine.reason,
+                    style: const TextStyle(
+                      fontSize: 11,
+                      color: FigmaColors.textBody,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            '${routine.type} · ${routine.minutes}분',
+            style: const TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              color: FigmaColors.primary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ChatButton extends StatelessWidget {
+  const _ChatButton({
+    required this.coachName,
+    required this.unread,
+    required this.onTap,
+  });
+
+  final String coachName;
+  final int unread;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: FigmaColors.softBlue,
+      borderRadius: BorderRadius.circular(12),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Container(
+          height: 44,
+          alignment: Alignment.center,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              const Icon(
+                Icons.chat_bubble_outline,
+                size: 16,
+                color: FigmaColors.primary,
+              ),
+              const SizedBox(width: 8),
+              const Text(
+                '코치와 대화하기',
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  color: FigmaColors.primary,
+                ),
+              ),
+              if (unread > 0) ...<Widget>[
+                const SizedBox(width: 8),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                  decoration: const BoxDecoration(
+                    color: FigmaColors.redDot,
+                    borderRadius: BorderRadius.all(Radius.circular(999)),
+                  ),
+                  child: Text(
+                    '$unread',
+                    style: const TextStyle(
+                      fontSize: 10,
+                      fontWeight: FontWeight.w800,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_chat_sheet.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_chat_sheet.dart
@@ -1,0 +1,236 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
+
+/// Opens the member↔coach chat as a bottom sheet from the 운동 tab (the app
+/// keeps its four fixed tabs — this is an entry point, not a new screen).
+Future<void> showCoachChatSheet(BuildContext context, {required String coachName}) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.white,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+    ),
+    builder: (_) => CoachChatSheet(coachName: coachName),
+  );
+}
+
+/// Chat thread + input for the member's conversation with their coach.
+class CoachChatSheet extends ConsumerStatefulWidget {
+  const CoachChatSheet({required this.coachName, super.key});
+
+  final String coachName;
+
+  @override
+  ConsumerState<CoachChatSheet> createState() => _CoachChatSheetState();
+}
+
+class _CoachChatSheetState extends ConsumerState<CoachChatSheet> {
+  final TextEditingController _input = TextEditingController();
+  bool _sending = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // Opening the thread clears the unread badge.
+    Future<void>.microtask(() async {
+      await ref.read(memberCoachRepositoryProvider).markRead();
+      if (mounted) ref.invalidate(coachUnreadProvider);
+    });
+  }
+
+  @override
+  void dispose() {
+    _input.dispose();
+    super.dispose();
+  }
+
+  Future<void> _send() async {
+    if (_sending) return;
+    final text = _input.text.trim();
+    if (text.isEmpty) return;
+    final messenger = ScaffoldMessenger.of(context);
+    setState(() => _sending = true);
+    try {
+      await ref.read(memberCoachRepositoryProvider).sendMessage(text);
+    } catch (_) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        const SnackBar(content: Text('메시지 전송에 실패했어요. 다시 시도해 주세요')),
+      );
+      return;
+    } finally {
+      if (mounted) setState(() => _sending = false);
+    }
+    if (!mounted) return;
+    _input.clear();
+    ref.invalidate(coachChatProvider);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final chat = ref.watch(coachChatProvider);
+    return Padding(
+      padding: EdgeInsets.only(bottom: MediaQuery.viewInsetsOf(context).bottom),
+      child: SizedBox(
+        height: MediaQuery.sizeOf(context).height * 0.7,
+        child: Column(
+          children: <Widget>[
+            const SizedBox(height: 8),
+            Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: FigmaColors.track,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                children: <Widget>[
+                  const Icon(Icons.person, color: FigmaColors.primary, size: 20),
+                  const SizedBox(width: 8),
+                  Text(
+                    '${widget.coachName} 코치',
+                    style: const TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w800,
+                      color: FigmaColors.ink,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const Divider(height: 1, color: FigmaColors.hairline),
+            Expanded(
+              child: chat.when(
+                loading: () =>
+                    const Center(child: CircularProgressIndicator()),
+                error: (_, _) => const Center(
+                  child: Text(
+                    '대화를 불러오지 못했어요',
+                    style: TextStyle(color: FigmaColors.textMuted),
+                  ),
+                ),
+                data: (messages) => ListView.builder(
+                  padding: const EdgeInsets.all(16),
+                  itemCount: messages.length,
+                  itemBuilder: (_, i) => _Bubble(message: messages[i]),
+                ),
+              ),
+            ),
+            _InputBar(controller: _input, sending: _sending, onSend: _send),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Bubble extends StatelessWidget {
+  const _Bubble({required this.message});
+
+  final CoachMessage message;
+
+  @override
+  Widget build(BuildContext context) {
+    final fromMe = message.fromMe;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Column(
+        crossAxisAlignment:
+            fromMe ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+        children: <Widget>[
+          Container(
+            constraints: BoxConstraints(
+              maxWidth: MediaQuery.sizeOf(context).width * 0.72,
+            ),
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            decoration: BoxDecoration(
+              color: fromMe ? FigmaColors.primary : FigmaColors.softBlue,
+              borderRadius: BorderRadius.circular(14),
+            ),
+            child: Text(
+              message.body,
+              style: TextStyle(
+                fontSize: 13,
+                height: 1.4,
+                fontWeight: FontWeight.w500,
+                color: fromMe ? Colors.white : FigmaColors.ink,
+              ),
+            ),
+          ),
+          const SizedBox(height: 3),
+          Text(
+            message.timeLabel,
+            style: const TextStyle(fontSize: 9, color: FigmaColors.textFaint),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InputBar extends StatelessWidget {
+  const _InputBar({
+    required this.controller,
+    required this.sending,
+    required this.onSend,
+  });
+
+  final TextEditingController controller;
+  final bool sending;
+  final Future<void> Function() onSend;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 12),
+      decoration: const BoxDecoration(
+        border: Border(top: BorderSide(color: FigmaColors.hairline)),
+      ),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: TextField(
+              controller: controller,
+              enabled: !sending,
+              textInputAction: TextInputAction.send,
+              onSubmitted: (_) => onSend(),
+              decoration: InputDecoration(
+                hintText: '코치에게 메시지 보내기...',
+                filled: true,
+                fillColor: FigmaColors.statBg,
+                isDense: true,
+                contentPadding:
+                    const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(14),
+                  borderSide: BorderSide.none,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Material(
+            color: sending ? FigmaColors.textFaint : FigmaColors.primary,
+            shape: const CircleBorder(),
+            child: InkWell(
+              customBorder: const CircleBorder(),
+              onTap: sending ? null : onSend,
+              child: const Padding(
+                padding: EdgeInsets.all(10),
+                child: Icon(Icons.send, size: 18, color: Colors.white),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/flutter/test/features/member_coach/dio_member_coach_repository_test.dart
+++ b/frontend/flutter/test/features/member_coach/dio_member_coach_repository_test.dart
@@ -1,0 +1,106 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:oncare/features/member_coach/data/repositories/dio_member_coach_repository.dart';
+import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+Response<T> _ok<T>(T body, String path) => Response<T>(
+      requestOptions: RequestOptions(path: path),
+      statusCode: 200,
+      data: body,
+    );
+
+DioException _httpError(int status, String path) => DioException(
+      requestOptions: RequestOptions(path: path),
+      type: DioExceptionType.badResponse,
+      response: Response<Object?>(
+        requestOptions: RequestOptions(path: path),
+        statusCode: status,
+      ),
+    );
+
+void main() {
+  late _MockDio dio;
+  late DioMemberCoachRepository repo;
+
+  setUp(() {
+    dio = _MockDio();
+    repo = DioMemberCoachRepository(dio);
+  });
+
+  test('fetchCoach returns the coach', () async {
+    when(() => dio.get<Map<String, Object?>>('/me/coach')).thenAnswer(
+      (_) async => _ok<Map<String, Object?>>(
+        <String, Object?>{'trainer_id': 't1', 'name': '김트레이너'},
+        '/me/coach',
+      ),
+    );
+    final coach = await repo.fetchCoach();
+    expect(coach?.name, '김트레이너');
+  });
+
+  test('fetchCoach returns null when the member has no coach (404)', () async {
+    when(() => dio.get<Map<String, Object?>>('/me/coach'))
+        .thenThrow(_httpError(404, '/me/coach'));
+    expect(await repo.fetchCoach(), isNull);
+  });
+
+  test('fetchRoutines parses the received routines', () async {
+    when(() => dio.get<List<dynamic>>('/me/coach/routines')).thenAnswer(
+      (_) async => Response<List<dynamic>>(
+        requestOptions: RequestOptions(path: '/me/coach/routines'),
+        statusCode: 200,
+        data: <dynamic>[
+          <String, Object?>{'id': 'r1', 'name': '저강도 유산소', 'minutes': 20, 'type': '유산소', 'reason': '', 'source': 'ai'},
+        ],
+      ),
+    );
+    final routines = await repo.fetchRoutines();
+    expect(routines.single.name, '저강도 유산소');
+  });
+
+  test('fetchChat parses the thread', () async {
+    when(() => dio.get<List<dynamic>>('/me/coach/chat')).thenAnswer(
+      (_) async => Response<List<dynamic>>(
+        requestOptions: RequestOptions(path: '/me/coach/chat'),
+        statusCode: 200,
+        data: <dynamic>[
+          <String, Object?>{'id': 'm1', 'sender': 'trainer', 'body': '안녕', 'time_label': '13:20'},
+        ],
+      ),
+    );
+    final chat = await repo.fetchChat();
+    expect(chat.single.sender, CoachSender.trainer);
+  });
+
+  test('sendMessage POSTs the trimmed text; skips blank', () async {
+    when(() => dio.post<Map<String, Object?>>(
+          '/me/coach/chat',
+          data: any(named: 'data'),
+        )).thenAnswer(
+      (_) async => _ok<Map<String, Object?>>(<String, Object?>{'id': 'x'}, '/me/coach/chat'),
+    );
+
+    await repo.sendMessage('  좋아요  ');
+    verify(() => dio.post<Map<String, Object?>>(
+          '/me/coach/chat',
+          data: <String, Object?>{'text': '좋아요'},
+        )).called(1);
+
+    await repo.sendMessage('   ');
+    verifyNoMoreInteractions(dio);
+  });
+
+  test('unreadCount reads the unread field', () async {
+    when(() => dio.get<Map<String, Object?>>('/me/coach/chat/unread')).thenAnswer(
+      (_) async => _ok<Map<String, Object?>>(
+        <String, Object?>{'unread': 3},
+        '/me/coach/chat/unread',
+      ),
+    );
+    expect(await repo.unreadCount(), 3);
+  });
+}

--- a/frontend/flutter/test/features/member_coach/member_coach_dtos_test.dart
+++ b/frontend/flutter/test/features/member_coach/member_coach_dtos_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/member_coach/data/dtos/member_coach_dtos.dart';
+import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
+
+void main() {
+  test('memberCoachFromJson maps the coach summary (nested gym)', () {
+    final c = memberCoachFromJson(<String, Object?>{
+      'trainer_id': 't1',
+      'name': '김트레이너',
+      'specialty': '퍼스널 트레이너',
+      'career': '7년',
+      'intro': '안녕하세요',
+      'gym': <String, Object?>{'name': '온케어짐 신촌점'},
+      'goal': '혈압 관리',
+    });
+    expect(c.trainerId, 't1');
+    expect(c.name, '김트레이너');
+    expect(c.gymName, '온케어짐 신촌점');
+    expect(c.goal, '혈압 관리');
+  });
+
+  test('coachRoutineFromJson maps a received routine (double minutes ok)', () {
+    final r = coachRoutineFromJson(<String, Object?>{
+      'id': 'r1',
+      'name': '저강도 유산소',
+      'minutes': 20.0,
+      'type': '유산소',
+      'reason': '혈압 안정',
+      'source': 'ai',
+    });
+    expect(r.minutes, 20);
+    expect(r.source, 'ai');
+  });
+
+  group('coachMessageFromJson (member viewpoint)', () {
+    test('maps a coach (trainer) message', () {
+      final m = coachMessageFromJson(<String, Object?>{
+        'id': 'm1',
+        'sender': 'trainer',
+        'body': '안녕하세요',
+        'time_label': '13:20',
+      });
+      expect(m.sender, CoachSender.trainer);
+      expect(m.fromMe, isFalse);
+    });
+
+    test('maps my own message (me / anything else) to me', () {
+      final m = coachMessageFromJson(<String, Object?>{
+        'id': 'm2',
+        'sender': 'me',
+        'body': '좋아요',
+        'time_label': '13:21',
+      });
+      expect(m.sender, CoachSender.me);
+      expect(m.fromMe, isTrue);
+    });
+  });
+}

--- a/frontend/flutter/test/features/member_coach/member_coach_providers_test.dart
+++ b/frontend/flutter/test/features/member_coach/member_coach_providers_test.dart
@@ -1,0 +1,44 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/core/network/dio_client.dart';
+import 'package:oncare/features/member_coach/data/repositories/dio_member_coach_repository.dart';
+import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
+
+AppConfig _config({required bool useMockApi}) => AppConfig(
+      environment: Environment.dev,
+      apiBaseUrl: 'http://localhost/v1',
+      useMockApi: useMockApi,
+    );
+
+void main() {
+  test('resolves the mock repository when USE_MOCK_API=true', () {
+    final container = ProviderContainer(
+      overrides: <Override>[
+        appConfigProvider.overrideWithValue(_config(useMockApi: true)),
+      ],
+    );
+    addTearDown(container.dispose);
+    expect(
+      container.read(memberCoachRepositoryProvider),
+      isA<MockMemberCoachRepository>(),
+    );
+  });
+
+  test('resolves the Dio repository when USE_MOCK_API=false', () {
+    final container = ProviderContainer(
+      overrides: <Override>[
+        appConfigProvider.overrideWithValue(_config(useMockApi: false)),
+        dioProvider.overrideWithValue(Dio()),
+      ],
+    );
+    addTearDown(container.dispose);
+    expect(
+      container.read(memberCoachRepositoryProvider),
+      isA<DioMemberCoachRepository>(),
+    );
+  });
+}


### PR DESCRIPTION
## Summary
* 회원 앱 운동 기록 탭에 담당 코치 카드, 받은 루틴 목록, 미확인 메시지 배지와 코치 채팅 시트를 추가합니다.
* 트레이너 앱과 동일한 `chat_messages` 및 배정 루틴 데이터를 `/me/coach*` API로 조회해 실제 송수신 결과를 공유합니다.
* `MemberCoachRepository` 인터페이스와 Mock/Dio 구현을 분리하고 `USE_MOCK_API` 설정에 따라 전환합니다.
* 채팅 시트를 다시 열 때 대화를 재조회해 닫혀 있던 동안 받은 메시지를 반영합니다.
* 읽음 처리 요청이 실패해도 채팅 UI가 깨지지 않으며, 배지는 성공한 경우에만 갱신합니다.
* 회원 앱의 기존 4개 하단 탭은 유지하고 운동 기록 화면 내부 카드와 bottom sheet로 제공합니다.

## Notes
* base: `main`
* 상담 요청 채팅(`consultation_requests`)과 분리된, 이미 연결된 트레이너↔회원의 코칭 채팅입니다.
* 웹소켓 실시간 수신은 범위 밖이며 시트 재진입과 메시지 전송 후 재조회합니다.
* 담당 코치가 없는 회원에게는 코치 카드가 표시되지 않습니다.

## Test Plan
* [x] `flutter analyze --no-pub`
* [x] 회원 앱 Flutter 테스트 214개 통과
* [x] Mock/Dio repository 선택 테스트
* [x] DTO 및 API 요청 매핑 테스트
* [x] 채팅 재진입 시 최신 메시지 재조회 테스트
* [x] 읽음 처리 실패 시 UI 유지 테스트

### Manual
1. `USE_MOCK_API=false`로 회원 앱과 트레이너 웹에 로그인합니다.
2. 트레이너가 채팅과 루틴을 전송합니다.
3. 회원 앱 운동 기록 탭에서 받은 루틴과 미확인 배지를 확인합니다.
4. 채팅 시트를 열어 답장한 뒤 트레이너 웹에서 재진입하여 수신을 확인합니다.
5. 채팅 시트를 닫은 동안 트레이너가 보낸 메시지가 재진입 후 표시되는지 확인합니다.

## Related Issues
Closes #346