### PR TITLE
fix(exercise): 상담 요청 날짜 선택 버튼 배경색 수정

### DIFF
--- a/frontend/flutter/lib/features/exercise/presentation/pages/consultation_request_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/consultation_request_page.dart
@@ -506,7 +506,7 @@ class _DateField extends StatelessWidget {
         ? l.exSelectDate
         : MaterialLocalizations.of(context).formatMediumDate(date!);
     return Material(
-      color: FigmaColors.softBlue,
+      color: Colors.white,
       borderRadius: BorderRadius.circular(14),
       child: InkWell(
         onTap: onTap,

--- a/frontend/flutter/test/features/exercise/consultation_request_flow_test.dart
+++ b/frontend/flutter/test/features/exercise/consultation_request_flow_test.dart
@@ -181,10 +181,24 @@ void main() {
     await _scrollTo(tester, find.text(l.exPurposeNone), 180);
     await tester.tap(find.text(l.exPurposeNone));
     await _scrollTo(tester, find.text(l.exSelectDate), 180);
+    Finder dateMaterial = find
+        .ancestor(
+          of: find.byIcon(Icons.calendar_today_outlined),
+          matching: find.byType(Material),
+        )
+        .first;
+    expect(tester.widget<Material>(dateMaterial).color, Colors.white);
     await tester.tap(find.text(l.exSelectDate));
     await tester.pumpAndSettle();
     await tester.tap(find.text('확인'));
     await tester.pumpAndSettle();
+    dateMaterial = find
+        .ancestor(
+          of: find.byIcon(Icons.calendar_today_outlined),
+          matching: find.byType(Material),
+        )
+        .first;
+    expect(tester.widget<Material>(dateMaterial).color, Colors.white);
     await _scrollTo(tester, find.text(l.exTimeAfternoon), 180);
     await tester.tap(find.text(l.exTimeAfternoon));
     await _scrollTo(tester, find.text(l.exSendConsultRequest), 220);


### PR DESCRIPTION
## Summary

* 헬스장 상담 요청 화면의 날짜 선택 버튼 배경색을 흰색으로 변경했습니다.
* 날짜 선택 전과 선택 후에 동일한 흰색 배경이 유지되도록 했습니다.
* 기존 상담 요청 플로우 테스트에 선택 전·후 배경색 검증을 추가했습니다.

---

## Changes

### 🔧 Improvements

* 날짜 선택 상태와 관계없이 일관된 버튼 배경색을 사용합니다.

### 🎨 UI/UX

* `_DateField`의 `Material.color`를 `FigmaColors.softBlue`에서 `Colors.white`로 변경했습니다.

### 🐛 Fixes

* 상담 요청 화면의 날짜 선택 버튼이 의도와 다른 연한 파란색으로 표시되던 문제를 수정했습니다.

---

## Commits

1. `988d76b` fix(exercise): use white consultation date background

---

## Notes

* API 및 데이터 모델 변경은 없습니다.
* 기존 상담 요청 플로우 테스트에서 날짜 선택 전·후 배경색을 검증합니다.
* `flutter analyze --no-pub lib/features/exercise/presentation/pages/consultation_request_page.dart`를 통과했습니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] UI 확인
* [ ] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 헬스장 상담 요청 화면에 진입해 날짜 선택 버튼이 흰색 배경으로 표시되는지 확인합니다.
2. 날짜를 선택한 뒤에도 버튼 배경이 흰색으로 유지되는지 확인합니다.
3. 상담 요청을 정상 제출할 수 있는지 확인합니다.

---

## Related Issues

Closes #370

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 날짜 선택 영역의 배경색이 더 자연스럽게 표시되도록 조정했습니다.
  * 날짜 선택 전후 캘린더 화면의 흰색 배경 표시를 검증하도록 테스트를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->