### PR TITLE
fix(schedule): 일정 추가 다이얼로그 최대 너비 제한

### DIFF
--- a/frontend/flutter/lib/shared/widgets/modals/add_event_dialog.dart
+++ b/frontend/flutter/lib/shared/widgets/modals/add_event_dialog.dart
@@ -100,75 +100,78 @@ class _AddEventDialogState extends ConsumerState<_AddEventDialog> {
         horizontal: AppSpacing.lg,
         vertical: AppSpacing.xl,
       ),
-      child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.lg),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
-            Row(
-              children: <Widget>[
-                Expanded(
-                  child: Text(
-                    '일정 추가',
-                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                      fontWeight: FontWeight.w700,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 400),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.lg),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              Row(
+                children: <Widget>[
+                  Expanded(
+                    child: Text(
+                      '일정 추가',
+                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
                     ),
                   ),
-                ),
-                Material(
-                  color: AppColors.accent,
-                  shape: const CircleBorder(),
-                  child: InkWell(
-                    customBorder: const CircleBorder(),
-                    onTap: () => Navigator.of(context).pop(),
-                    child: const SizedBox(
-                      width: 32,
-                      height: 32,
-                      child: Icon(Icons.close, size: 18),
+                  Material(
+                    color: AppColors.accent,
+                    shape: const CircleBorder(),
+                    child: InkWell(
+                      customBorder: const CircleBorder(),
+                      onTap: () => Navigator.of(context).pop(),
+                      child: const SizedBox(
+                        width: 32,
+                        height: 32,
+                        child: Icon(Icons.close, size: 18),
+                      ),
                     ),
                   ),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.md),
+              AppInput(controller: _title, label: '일정 제목', hint: '예: 병원 정기검진'),
+              const SizedBox(height: AppSpacing.sm),
+              AppInput(controller: _date, label: '날짜', hint: '2026-05-14'),
+              const SizedBox(height: AppSpacing.sm),
+              AppInput(controller: _time, label: '시간', hint: '10:00'),
+              const SizedBox(height: AppSpacing.sm),
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.md,
+                  vertical: 4,
                 ),
-              ],
-            ),
-            const SizedBox(height: AppSpacing.md),
-            AppInput(controller: _title, label: '일정 제목', hint: '예: 병원 정기검진'),
-            const SizedBox(height: AppSpacing.sm),
-            AppInput(controller: _date, label: '날짜', hint: '2026-05-14'),
-            const SizedBox(height: AppSpacing.sm),
-            AppInput(controller: _time, label: '시간', hint: '10:00'),
-            const SizedBox(height: AppSpacing.sm),
-            Container(
-              padding: const EdgeInsets.symmetric(
-                horizontal: AppSpacing.md,
-                vertical: 4,
-              ),
-              decoration: BoxDecoration(
-                color: AppColors.inputBackground,
-                borderRadius: const BorderRadius.all(AppRadius.md),
-                border: Border.all(color: AppColors.border),
-              ),
-              child: DropdownButtonHideUnderline(
-                child: DropdownButton<String>(
-                  value: _category,
-                  isExpanded: true,
-                  onChanged: (String? value) {
-                    if (value != null) setState(() => _category = value);
-                  },
-                  items: <DropdownMenuItem<String>>[
-                    for (final String c in _categoryMap.keys)
-                      DropdownMenuItem<String>(value: c, child: Text(c)),
-                  ],
+                decoration: BoxDecoration(
+                  color: AppColors.inputBackground,
+                  borderRadius: const BorderRadius.all(AppRadius.md),
+                  border: Border.all(color: AppColors.border),
+                ),
+                child: DropdownButtonHideUnderline(
+                  child: DropdownButton<String>(
+                    value: _category,
+                    isExpanded: true,
+                    onChanged: (String? value) {
+                      if (value != null) setState(() => _category = value);
+                    },
+                    items: <DropdownMenuItem<String>>[
+                      for (final String c in _categoryMap.keys)
+                        DropdownMenuItem<String>(value: c, child: Text(c)),
+                    ],
+                  ),
                 ),
               ),
-            ),
-            const SizedBox(height: AppSpacing.lg),
-            AppButton(
-              label: _saving ? '추가 중...' : '추가하기',
-              fullWidth: true,
-              onPressed: _saving ? null : _submit,
-            ),
-          ],
+              const SizedBox(height: AppSpacing.lg),
+              AppButton(
+                label: _saving ? '추가 중...' : '추가하기',
+                fullWidth: true,
+                onPressed: _saving ? null : _submit,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/frontend/flutter/test/shared/widgets/modals/add_event_dialog_test.dart
+++ b/frontend/flutter/test/shared/widgets/modals/add_event_dialog_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oncare/shared/widgets/modals/add_event_dialog.dart';
+
+void main() {
+  testWidgets('limits the add event dialog width on wide screens', (
+    WidgetTester tester,
+  ) async {
+    tester.view.physicalSize = const Size(1000, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Builder(
+            builder: (BuildContext context) => Scaffold(
+              body: TextButton(
+                onPressed: () => showAddEventDialog(context),
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    final Finder widthConstraint = find.byWidgetPredicate(
+      (Widget widget) =>
+          widget is ConstrainedBox && widget.constraints.maxWidth == 400,
+    );
+
+    expect(widthConstraint, findsOneWidget);
+    expect(tester.getSize(widthConstraint).width, lessThanOrEqualTo(400));
+  });
+}


### PR DESCRIPTION
## Summary

* 넓은 화면에서 일정 추가 다이얼로그가 가로로 과도하게 늘어나는 문제를 수정했습니다.
* 다이얼로그 콘텐츠의 최대 너비를 400px로 제한했습니다.
* 넓은 화면의 최대 너비를 검증하는 위젯 테스트를 추가했습니다.

---

## Changes

### 🔧 Improvements

* 태블릿 및 넓은 화면에서 일정 추가 폼의 가독성을 개선했습니다.
* 모바일에서는 기존 `insetPadding`과 반응형 너비 동작을 유지합니다.

### 🎨 UI/UX

* `_AddEventDialog`의 콘텐츠를 `ConstrainedBox(maxWidth: 400)`로 감쌌습니다.

### 🐛 Fixes

* 넓은 화면에서 일정 추가 다이얼로그가 사용 가능한 가로 영역까지 늘어나던 문제를 수정했습니다.

---

## Commits

1. `e757810` fix(schedule): constrain add event dialog width

---

## Notes

* API 및 데이터 모델 변경은 없습니다.
* 1000px 너비의 테스트 화면에서 다이얼로그 콘텐츠가 400px를 넘지 않는지 검증합니다.
* `flutter analyze --no-pub lib/shared/widgets/modals/add_event_dialog.dart`를 통과했습니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] UI 확인
* [ ] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 태블릿 또는 넓은 화면에서 일정 추가 다이얼로그를 엽니다.
2. 다이얼로그 콘텐츠가 400px 이하 너비로 표시되는지 확인합니다.
3. 모바일 화면에서 입력, 카테고리 선택, 일정 추가 및 닫기 동작이 기존과 동일한지 확인합니다.

---

## Related Issues

Closes #371

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
