### PR TITLE
chore(ci): 사용자 앱 PR CI 신설 — analyze + test

### DIFF
--- a/.github/workflows/user-app-ci.yml
+++ b/.github/workflows/user-app-ci.yml
@@ -47,5 +47,12 @@ jobs:
       - name: Analyze
         run: flutter analyze
 
+      # `flutter analyze` 는 analysis_options.yaml 의 custom_lint 플러그인을
+      # 실행하지 않는다(분석 서버 경로에서만 동작). riverpod_lint 규칙이
+      # 여기서만 걸리므로 별도 단계로 돌린다 — 이 저장소의 analysis_options
+      # 주석도 `dart run custom_lint` 를 안내한다.
+      - name: Custom lint (riverpod_lint)
+        run: dart run custom_lint
+
       - name: Test
         run: flutter test

--- a/.github/workflows/user-app-ci.yml
+++ b/.github/workflows/user-app-ci.yml
@@ -1,0 +1,51 @@
+name: User App CI
+
+# 사용자 Flutter 앱(frontend/flutter) 전용 PR/main CI.
+# 트레이너 앱은 trainer-ci.yml 이 같은 일을 하는데 사용자 앱에는 대응이 없어,
+# 200건이 넘는 테스트가 로컬에서만 돌고 PR 화면에서는 통과 여부를 볼 수 없었다(#374).
+# 웹 빌드 검증은 deploy.yml 이 main 배포에서 이미 하므로 여기서는 analyze/test 만 한다.
+on:
+  pull_request:
+    paths:
+      - "frontend/flutter/**"
+      - ".github/workflows/user-app-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "frontend/flutter/**"
+      - ".github/workflows/user-app-ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: user-app-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze-and-test:
+    name: Analyze and test (user app)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend/flutter
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Test
+        run: flutter test


### PR DESCRIPTION
Closes #374

## Summary

사용자 앱(`frontend/flutter`)에 PR 단계 CI 가 없어, 200건이 넘는 테스트가 로컬에서만 돌고 리뷰어는 PR 화면에서 통과 여부를 볼 수 없었습니다. 트레이너 앱의 `trainer-ci.yml` 과 같은 구조로 신설합니다.

기존 커버리지:

| 워크플로 | 사용자 앱에 하는 일 |
|---|---|
| `deploy.yml` | `flutter pub get` → `flutter build web` (main 배포) — **컴파일만** |
| `trainer-ci.yml` | `frontend/flutter_trainer/**` 전용 |

## Changes

`.github/workflows/user-app-ci.yml` 신설 — `frontend/flutter/**` 변경 시에만 `flutter analyze` + `flutter test`.

웹 빌드는 `deploy.yml` 과 중복이고 drift WASM 다운로드 비용이 있어 뺐습니다.

## 선행 조건

#372(골든 허용 오차)가 #375 로 머지돼 해제됐습니다. 그 전에 CI 를 붙였다면 골든 테스트가 러너 환경 기준으로 실패해 모든 PR 이 빨갛게 됐을 것입니다.

## 이 PR 자체가 검증입니다

워크플로 파일이 자기 트리거 경로에 포함돼 있어, **이 PR 에서 새 CI 가 실제로 돕니다.** 특히 확인이 필요한 지점은 골든 테스트입니다 — baseline 은 macOS 에서 찍혔는데 러너는 Ubuntu 라 폰트 렌더링 차이가 #375 의 허용 오차(0.5%)를 넘을 수 있습니다.

체크가 초록이면 그대로 머지하면 되고, 골든에서 실패하면 머지 전에 조정하겠습니다(임계값 상향 또는 `--exclude-tags golden`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * Flutter 앱 변경 사항에 대해 자동 정적 분석과 테스트를 수행하도록 CI 검증을 추가했습니다.
  * `main` 브랜치 업데이트 및 관련 변경이 포함된 풀 리퀘스트에서 자동으로 실행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->