### PR TITLE
feat(trainer): 실 API 모드 오늘 예약 수 배지 연결

### DIFF
--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_client_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_client_repository.dart
@@ -34,13 +34,6 @@ class DioClientRepository implements ClientRepository {
   Stream<Map<String, DateTime>> watchLastChatAt() =>
       Stream<Map<String, DateTime>>.value(const <String, DateTime>{});
 
-  /// Today's booked-session count is schedule-derived (a later issue wires
-  /// `/trainer/schedule`). Emitting nothing keeps the header badge hidden
-  /// (its provider stays loading → `valueOrNull` is null) rather than
-  /// showing a stale/zero count over real clients.
-  @override
-  Stream<int> watchTodayReservationCount() => const Stream<int>.empty();
-
   @override
   Stream<List<ClientDietEntry>> watchDiet(String clientId) =>
       Stream<List<ClientDietEntry>>.fromFuture(_fetchDiet(clientId));

--- a/frontend/flutter_trainer/lib/shared/services/client_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/client_repository.dart
@@ -6,12 +6,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:oncare_trainer/core/config/app_config.dart';
 import 'package:oncare_trainer/core/network/dio_client.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
-import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/features/clients/data/dtos/client_dtos.dart'
     show prioritizeClients;
 import 'package:oncare_trainer/features/clients/data/repositories/dio_client_repository.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/client_diet_entry.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/routine_history_entry.dart';
+import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
 
 /// Reads a trainer's clients + their diet/history for the 고객 관리 tab.
@@ -37,14 +37,6 @@ abstract interface class ClientRepository {
   /// [prioritizeClients]. Sources without a chat signal emit `{}`.
   Stream<Map<String, DateTime>> watchLastChatAt();
 
-  /// Today's booked-session count for the header badge.
-  ///
-  /// Contract: an implementation with no reservation data source (the real
-  /// API doesn't wire `/trainer/schedule` yet) should emit nothing rather
-  /// than `0` — the consuming `StreamProvider` then stays in its initial
-  /// loading state, whose `valueOrNull` is `null`, and the UI hides the
-  /// badge instead of showing a misleading "0명 예약".
-  Stream<int> watchTodayReservationCount();
   Stream<List<ClientDietEntry>> watchDiet(String clientId);
   Stream<List<RoutineHistoryEntry>> watchHistory(String clientId);
 
@@ -185,19 +177,6 @@ class DriftClientRepository implements ClientRepository {
     );
   }
 
-  /// Count of today's booked sessions — every schedule slot dated today
-  /// that isn't a gap (`공백`). Drives the "오늘 N명 예약" header badge.
-  /// Uses a SQL `COUNT(*)` aggregate rather than loading every row.
-  @override
-  Stream<int> watchTodayReservationCount() {
-    final today = ymd(DateTime.now());
-    final table = _db.trainerScheduleEntries;
-    final count = countAll();
-    final query = _db.selectOnly(table)
-      ..addColumns(<Expression<Object>>[count])
-      ..where(table.date.equals(today) & table.status.equals('공백').not());
-    return query.map((row) => row.read(count) ?? 0).watchSingle();
-  }
 
   /// A client's meals for the 식단 sub-tab, in seeded order (아침 → 저녁).
   @override
@@ -321,9 +300,20 @@ final lastChatAtProvider = StreamProvider<Map<String, DateTime>>((ref) {
   return ref.watch(clientRepositoryProvider).watchLastChatAt();
 });
 
-/// Streams today's booked-session count for the sidebar badge.
-final todayReservationCountProvider = StreamProvider<int>((ref) {
-  return ref.watch(clientRepositoryProvider).watchTodayReservationCount();
+/// Today's booked-session count for the sidebar badge and dashboard KPI.
+///
+/// Derived from [todayScheduleProvider] rather than the roster: the count is
+/// a property of the schedule, and the dashboard already subscribes to that
+/// stream, so composing here avoids a second request for the same data.
+/// 공백 slots are placeholders, not bookings, so they don't count.
+///
+/// Stays an [AsyncValue] on purpose. When the schedule is loading or failed
+/// there is no honest number to show, and `valueOrNull` is null — the UI
+/// hides the badge instead of claiming "0명 예약", which would be wrong.
+final todayReservationCountProvider = Provider<AsyncValue<int>>((ref) {
+  return ref
+      .watch(todayScheduleProvider)
+      .whenData((sessions) => sessions.where((s) => !s.isGap).length);
 });
 
 /// Streams a client's meals for the 식단 sub-tab.

--- a/frontend/flutter_trainer/test/features/clients/client_repository_provider_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_repository_provider_test.dart
@@ -50,8 +50,6 @@ class _StreamingClientRepository implements ClientRepository {
   Stream<Map<String, DateTime>> watchLastChatAt() =>
       Stream<Map<String, DateTime>>.value(const <String, DateTime>{});
   @override
-  Stream<int> watchTodayReservationCount() => const Stream<int>.empty();
-  @override
   Stream<List<ClientDietEntry>> watchDiet(String clientId) =>
       const Stream<List<ClientDietEntry>>.empty();
   @override

--- a/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
@@ -1,11 +1,13 @@
-import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/storage/seed_data.dart';
+import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
+import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 
 import '../../helpers/pump_app.dart';
@@ -122,31 +124,41 @@ void main() {
       expect(clients.firstWhere((c) => c.name == '김민수').active, isTrue);
     });
 
-    test('reservation count excludes 공백 slots', () async {
-      final count = await DriftClientRepository(
-        db,
-      ).watchTodayReservationCount().first;
-      expect(count, 4); // 6 slots − 2 공백
+    // 예약 수는 이제 로스터가 아니라 오늘 스케줄에서 파생된다(#387).
+    // 배지 계산은 todayReservationCountProvider 테스트가 덮고, 날짜 필터링은
+    // ScheduleRepository.watchToday 테스트(schedule_page_test)가 덮는다.
+    test('오늘 스케줄에서 공백을 뺀 수가 예약 수가 된다', () async {
+      final container = ProviderContainer(
+        overrides: <Override>[
+          scheduleRepositoryProvider.overrideWithValue(
+            DriftScheduleRepository(db),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(todayScheduleProvider.future);
+      expect(container.read(todayReservationCountProvider).value, 4);
     });
 
-    test('reservation count excludes non-today schedule rows', () async {
-      // A booked session on a different date must NOT inflate today's badge.
-      await db
-          .into(db.trainerScheduleEntries)
-          .insert(
-            TrainerScheduleEntriesCompanion.insert(
-              id: 'schedule-other-day',
-              date: '2020-01-01',
-              time: '10:00',
-              status: '예정',
-              clientName: const Value('과거 고객'),
+    test('스케줄을 못 읽으면 0 이 아니라 값 없음으로 남는다', () async {
+      // 0 을 내보내면 "오늘 예약 0건" 이라는 틀린 사실이 된다 — 배지를 숨겨야 한다.
+      final container = ProviderContainer(
+        overrides: <Override>[
+          todayScheduleProvider.overrideWith(
+            (ref) => Stream<List<ScheduleSession>>.error(
+              StateError('schedule unavailable'),
             ),
-          );
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
 
-      final count = await DriftClientRepository(
-        db,
-      ).watchTodayReservationCount().first;
-      expect(count, 4); // still 4 — the 2020 row is excluded
+      await expectLater(
+        container.read(todayScheduleProvider.future),
+        throwsStateError,
+      );
+      expect(container.read(todayReservationCountProvider).valueOrNull, isNull);
     });
   });
 

--- a/frontend/flutter_trainer/test/features/clients/dio_client_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/dio_client_repository_test.dart
@@ -123,13 +123,6 @@ void main() {
     },
   );
 
-  test(
-    'watchTodayReservationCount emits nothing (schedule wired later)',
-    () async {
-      expect(await repo.watchTodayReservationCount().isEmpty, isTrue);
-    },
-  );
-
   group('roster mutations are demo-only against the real API', () {
     test('advertises the roster as read-only', () {
       expect(repo.supportsRosterMutations, isFalse);

--- a/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
@@ -96,9 +96,6 @@ class _FixedClientRepository implements ClientRepository {
       Stream<Map<String, DateTime>>.value(const <String, DateTime>{});
 
   @override
-  Stream<int> watchTodayReservationCount() => const Stream<int>.empty();
-
-  @override
   Stream<List<ClientDietEntry>> watchDiet(String clientId) =>
       Stream.value(const <ClientDietEntry>[]);
 


### PR DESCRIPTION
Closes #387

## Summary

`DioClientRepository.watchTodayReservationCount()` 가 빈 스트림을 emit 해 **실 API 모드에서 사이드바 `스케줄` 배지와 대시보드 `오늘 예약` KPI 가 비어** 있었습니다. 예약 수 출처가 없어 배지를 숨기려던 의도였는데(0 을 emit 하면 "오늘 예약 0건" 이라는 **틀린 사실**), #380 에서 `DioScheduleRepository` 가 들어오면서 전제가 바뀌었습니다.

## Changes

예약 수는 로스터가 아니라 **스케줄의 성질**이므로 provider 를 조합합니다.

```dart
final todayReservationCountProvider = Provider<AsyncValue<int>>((ref) {
  return ref
      .watch(todayScheduleProvider)
      .whenData((sessions) => sessions.where((s) => !s.isGap).length);
});
```

- 대시보드가 **이미 오늘 타임라인을 구독**하므로 같은 데이터에 요청이 두 번 나가지 않습니다(이슈의 "provider 조합으로 정리")
- 데모(drift)·실 API 양쪽이 같은 경로를 타면서 모드별 분기가 사라졌습니다
- 공백(`공백`) 슬롯은 예약이 아니므로 제외합니다

**`AsyncValue<int>` 를 그대로 노출합니다.** 스케줄이 로딩 중이거나 실패하면 정직하게 내놓을 숫자가 없고, `valueOrNull` 이 null 이라 UI 가 배지를 숨깁니다 — 이슈에 적힌 "파생 불가 시 0 이 아니라 계속 숨긴다" 를 유지합니다.

**정리**: 쓰이지 않게 된 `ClientRepository.watchTodayReservationCount()` 를 인터페이스와 drift·dio 구현에서 걷어냈습니다(테스트 가짜 구현 2곳 포함).

## Verification

- 기존 drift 카운트 테스트 2건을 **provider 단위로 이전** — 공백 제외 카운트, 그리고 스케줄 실패 시 0 이 아니라 값 없음으로 남는지
- 날짜 필터링(다른 날 예약이 오늘 배지를 부풀리지 않음)은 `ScheduleRepository.watchToday` 테스트가 이미 덮고 있어 중복 제거했습니다
- `flutter analyze` 이슈 없음, 트레이너 앱 **316 passed**