### PR TITLE
refactor(trainer): 스케줄이 고객을 이름 대신 member_id 로 참조

### DIFF
--- a/frontend/flutter_trainer/lib/core/storage/app_database.dart
+++ b/frontend/flutter_trainer/lib/core/storage/app_database.dart
@@ -112,6 +112,14 @@ class TrainerScheduleEntries extends Table {
   TextColumn get id => text()();
   TextColumn get date => text()(); // YYYY-MM-DD (slides to today)
   TextColumn get time => text()(); // "10:00"
+  /// 예약된 고객의 id. 이름은 식별자가 아니다 — 고객 이름을 바꾸면 과거
+  /// 세션이 통째로 끊기고, 조용히 "세션 0건" 리포트가 되어 그대로 회원에게
+  /// 전송될 수 있었다(#386).
+  ///
+  /// nullable 인 이유: 상담 등 미등록 고객 슬롯과 공백 슬롯에는 붙일 id 가
+  /// 없고, v3 이전에 저장된 기존 행도 값이 없다. 조회는 id 를 우선하고
+  /// 없을 때만 이름으로 폴백한다.
+  TextColumn get clientId => text().nullable()();
   TextColumn get clientName => text().withDefault(const Constant(''))();
   TextColumn get type => text().withDefault(const Constant(''))();
   IntColumn get durationMinutes => integer().withDefault(const Constant(0))();
@@ -160,7 +168,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 2;
+  int get schemaVersion => 3;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -172,6 +180,14 @@ class AppDatabase extends _$AppDatabase {
       // valid; the next re-seed backfills real values).
       if (from < 2) {
         await m.addColumn(trainerClients, trainerClients.sodiumWeekJson);
+      }
+      // v3: 스케줄이 고객을 이름 대신 id 로 참조한다(#386). 기존 행은 null 로
+      // 남고 조회가 이름으로 폴백하므로, 다음 재시딩 전까지도 끊기지 않는다.
+      if (from < 3) {
+        await m.addColumn(
+          trainerScheduleEntries,
+          trainerScheduleEntries.clientId,
+        );
       }
     },
   );

--- a/frontend/flutter_trainer/lib/core/storage/app_database.g.dart
+++ b/frontend/flutter_trainer/lib/core/storage/app_database.g.dart
@@ -2949,6 +2949,17 @@ class $TrainerScheduleEntriesTable extends TrainerScheduleEntries
     type: DriftSqlType.string,
     requiredDuringInsert: true,
   );
+  static const VerificationMeta _clientIdMeta = const VerificationMeta(
+    'clientId',
+  );
+  @override
+  late final GeneratedColumn<String> clientId = GeneratedColumn<String>(
+    'client_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _clientNameMeta = const VerificationMeta(
     'clientName',
   );
@@ -3031,6 +3042,7 @@ class $TrainerScheduleEntriesTable extends TrainerScheduleEntries
     id,
     date,
     time,
+    clientId,
     clientName,
     type,
     durationMinutes,
@@ -3071,6 +3083,12 @@ class $TrainerScheduleEntriesTable extends TrainerScheduleEntries
       );
     } else if (isInserting) {
       context.missing(_timeMeta);
+    }
+    if (data.containsKey('client_id')) {
+      context.handle(
+        _clientIdMeta,
+        clientId.isAcceptableOrUnknown(data['client_id']!, _clientIdMeta),
+      );
     }
     if (data.containsKey('client_name')) {
       context.handle(
@@ -3143,6 +3161,10 @@ class $TrainerScheduleEntriesTable extends TrainerScheduleEntries
         DriftSqlType.string,
         data['${effectivePrefix}time'],
       )!,
+      clientId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}client_id'],
+      ),
       clientName: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}client_name'],
@@ -3185,6 +3207,15 @@ class TrainerScheduleRow extends DataClass
   final String id;
   final String date;
   final String time;
+
+  /// 예약된 고객의 id. 이름은 식별자가 아니다 — 고객 이름을 바꾸면 과거
+  /// 세션이 통째로 끊기고, 조용히 "세션 0건" 리포트가 되어 그대로 회원에게
+  /// 전송될 수 있었다(#386).
+  ///
+  /// nullable 인 이유: 상담 등 미등록 고객 슬롯과 공백 슬롯에는 붙일 id 가
+  /// 없고, v3 이전에 저장된 기존 행도 값이 없다. 조회는 id 를 우선하고
+  /// 없을 때만 이름으로 폴백한다.
+  final String? clientId;
   final String clientName;
   final String type;
   final int durationMinutes;
@@ -3196,6 +3227,7 @@ class TrainerScheduleRow extends DataClass
     required this.id,
     required this.date,
     required this.time,
+    this.clientId,
     required this.clientName,
     required this.type,
     required this.durationMinutes,
@@ -3210,6 +3242,9 @@ class TrainerScheduleRow extends DataClass
     map['id'] = Variable<String>(id);
     map['date'] = Variable<String>(date);
     map['time'] = Variable<String>(time);
+    if (!nullToAbsent || clientId != null) {
+      map['client_id'] = Variable<String>(clientId);
+    }
     map['client_name'] = Variable<String>(clientName);
     map['type'] = Variable<String>(type);
     map['duration_minutes'] = Variable<int>(durationMinutes);
@@ -3225,6 +3260,9 @@ class TrainerScheduleRow extends DataClass
       id: Value(id),
       date: Value(date),
       time: Value(time),
+      clientId: clientId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(clientId),
       clientName: Value(clientName),
       type: Value(type),
       durationMinutes: Value(durationMinutes),
@@ -3244,6 +3282,7 @@ class TrainerScheduleRow extends DataClass
       id: serializer.fromJson<String>(json['id']),
       date: serializer.fromJson<String>(json['date']),
       time: serializer.fromJson<String>(json['time']),
+      clientId: serializer.fromJson<String?>(json['clientId']),
       clientName: serializer.fromJson<String>(json['clientName']),
       type: serializer.fromJson<String>(json['type']),
       durationMinutes: serializer.fromJson<int>(json['durationMinutes']),
@@ -3260,6 +3299,7 @@ class TrainerScheduleRow extends DataClass
       'id': serializer.toJson<String>(id),
       'date': serializer.toJson<String>(date),
       'time': serializer.toJson<String>(time),
+      'clientId': serializer.toJson<String?>(clientId),
       'clientName': serializer.toJson<String>(clientName),
       'type': serializer.toJson<String>(type),
       'durationMinutes': serializer.toJson<int>(durationMinutes),
@@ -3274,6 +3314,7 @@ class TrainerScheduleRow extends DataClass
     String? id,
     String? date,
     String? time,
+    Value<String?> clientId = const Value.absent(),
     String? clientName,
     String? type,
     int? durationMinutes,
@@ -3285,6 +3326,7 @@ class TrainerScheduleRow extends DataClass
     id: id ?? this.id,
     date: date ?? this.date,
     time: time ?? this.time,
+    clientId: clientId.present ? clientId.value : this.clientId,
     clientName: clientName ?? this.clientName,
     type: type ?? this.type,
     durationMinutes: durationMinutes ?? this.durationMinutes,
@@ -3298,6 +3340,7 @@ class TrainerScheduleRow extends DataClass
       id: data.id.present ? data.id.value : this.id,
       date: data.date.present ? data.date.value : this.date,
       time: data.time.present ? data.time.value : this.time,
+      clientId: data.clientId.present ? data.clientId.value : this.clientId,
       clientName: data.clientName.present
           ? data.clientName.value
           : this.clientName,
@@ -3320,6 +3363,7 @@ class TrainerScheduleRow extends DataClass
           ..write('id: $id, ')
           ..write('date: $date, ')
           ..write('time: $time, ')
+          ..write('clientId: $clientId, ')
           ..write('clientName: $clientName, ')
           ..write('type: $type, ')
           ..write('durationMinutes: $durationMinutes, ')
@@ -3336,6 +3380,7 @@ class TrainerScheduleRow extends DataClass
     id,
     date,
     time,
+    clientId,
     clientName,
     type,
     durationMinutes,
@@ -3351,6 +3396,7 @@ class TrainerScheduleRow extends DataClass
           other.id == this.id &&
           other.date == this.date &&
           other.time == this.time &&
+          other.clientId == this.clientId &&
           other.clientName == this.clientName &&
           other.type == this.type &&
           other.durationMinutes == this.durationMinutes &&
@@ -3365,6 +3411,7 @@ class TrainerScheduleEntriesCompanion
   final Value<String> id;
   final Value<String> date;
   final Value<String> time;
+  final Value<String?> clientId;
   final Value<String> clientName;
   final Value<String> type;
   final Value<int> durationMinutes;
@@ -3377,6 +3424,7 @@ class TrainerScheduleEntriesCompanion
     this.id = const Value.absent(),
     this.date = const Value.absent(),
     this.time = const Value.absent(),
+    this.clientId = const Value.absent(),
     this.clientName = const Value.absent(),
     this.type = const Value.absent(),
     this.durationMinutes = const Value.absent(),
@@ -3390,6 +3438,7 @@ class TrainerScheduleEntriesCompanion
     required String id,
     required String date,
     required String time,
+    this.clientId = const Value.absent(),
     this.clientName = const Value.absent(),
     this.type = const Value.absent(),
     this.durationMinutes = const Value.absent(),
@@ -3406,6 +3455,7 @@ class TrainerScheduleEntriesCompanion
     Expression<String>? id,
     Expression<String>? date,
     Expression<String>? time,
+    Expression<String>? clientId,
     Expression<String>? clientName,
     Expression<String>? type,
     Expression<int>? durationMinutes,
@@ -3419,6 +3469,7 @@ class TrainerScheduleEntriesCompanion
       if (id != null) 'id': id,
       if (date != null) 'date': date,
       if (time != null) 'time': time,
+      if (clientId != null) 'client_id': clientId,
       if (clientName != null) 'client_name': clientName,
       if (type != null) 'type': type,
       if (durationMinutes != null) 'duration_minutes': durationMinutes,
@@ -3434,6 +3485,7 @@ class TrainerScheduleEntriesCompanion
     Value<String>? id,
     Value<String>? date,
     Value<String>? time,
+    Value<String?>? clientId,
     Value<String>? clientName,
     Value<String>? type,
     Value<int>? durationMinutes,
@@ -3447,6 +3499,7 @@ class TrainerScheduleEntriesCompanion
       id: id ?? this.id,
       date: date ?? this.date,
       time: time ?? this.time,
+      clientId: clientId ?? this.clientId,
       clientName: clientName ?? this.clientName,
       type: type ?? this.type,
       durationMinutes: durationMinutes ?? this.durationMinutes,
@@ -3469,6 +3522,9 @@ class TrainerScheduleEntriesCompanion
     }
     if (time.present) {
       map['time'] = Variable<String>(time.value);
+    }
+    if (clientId.present) {
+      map['client_id'] = Variable<String>(clientId.value);
     }
     if (clientName.present) {
       map['client_name'] = Variable<String>(clientName.value);
@@ -3503,6 +3559,7 @@ class TrainerScheduleEntriesCompanion
           ..write('id: $id, ')
           ..write('date: $date, ')
           ..write('time: $time, ')
+          ..write('clientId: $clientId, ')
           ..write('clientName: $clientName, ')
           ..write('type: $type, ')
           ..write('durationMinutes: $durationMinutes, ')
@@ -5109,6 +5166,7 @@ typedef $$TrainerScheduleEntriesTableCreateCompanionBuilder =
       required String id,
       required String date,
       required String time,
+      Value<String?> clientId,
       Value<String> clientName,
       Value<String> type,
       Value<int> durationMinutes,
@@ -5123,6 +5181,7 @@ typedef $$TrainerScheduleEntriesTableUpdateCompanionBuilder =
       Value<String> id,
       Value<String> date,
       Value<String> time,
+      Value<String?> clientId,
       Value<String> clientName,
       Value<String> type,
       Value<int> durationMinutes,
@@ -5154,6 +5213,11 @@ class $$TrainerScheduleEntriesTableFilterComposer
 
   ColumnFilters<String> get time => $composableBuilder(
     column: $table.time,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get clientId => $composableBuilder(
+    column: $table.clientId,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -5217,6 +5281,11 @@ class $$TrainerScheduleEntriesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get clientId => $composableBuilder(
+    column: $table.clientId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get clientName => $composableBuilder(
     column: $table.clientName,
     builder: (column) => ColumnOrderings(column),
@@ -5270,6 +5339,9 @@ class $$TrainerScheduleEntriesTableAnnotationComposer
 
   GeneratedColumn<String> get time =>
       $composableBuilder(column: $table.time, builder: (column) => column);
+
+  GeneratedColumn<String> get clientId =>
+      $composableBuilder(column: $table.clientId, builder: (column) => column);
 
   GeneratedColumn<String> get clientName => $composableBuilder(
     column: $table.clientName,
@@ -5348,6 +5420,7 @@ class $$TrainerScheduleEntriesTableTableManager
                 Value<String> id = const Value.absent(),
                 Value<String> date = const Value.absent(),
                 Value<String> time = const Value.absent(),
+                Value<String?> clientId = const Value.absent(),
                 Value<String> clientName = const Value.absent(),
                 Value<String> type = const Value.absent(),
                 Value<int> durationMinutes = const Value.absent(),
@@ -5360,6 +5433,7 @@ class $$TrainerScheduleEntriesTableTableManager
                 id: id,
                 date: date,
                 time: time,
+                clientId: clientId,
                 clientName: clientName,
                 type: type,
                 durationMinutes: durationMinutes,
@@ -5374,6 +5448,7 @@ class $$TrainerScheduleEntriesTableTableManager
                 required String id,
                 required String date,
                 required String time,
+                Value<String?> clientId = const Value.absent(),
                 Value<String> clientName = const Value.absent(),
                 Value<String> type = const Value.absent(),
                 Value<int> durationMinutes = const Value.absent(),
@@ -5386,6 +5461,7 @@ class $$TrainerScheduleEntriesTableTableManager
                 id: id,
                 date: date,
                 time: time,
+                clientId: clientId,
                 clientName: clientName,
                 type: type,
                 durationMinutes: durationMinutes,

--- a/frontend/flutter_trainer/lib/core/storage/seed_data.dart
+++ b/frontend/flutter_trainer/lib/core/storage/seed_data.dart
@@ -172,6 +172,12 @@ Future<void> seedIfEmpty(AppDatabase db) async {
     }
 
     // ---- Trainer's schedule for today ----
+    // 스케줄은 고객을 id 로 참조한다(#386). 슬롯 데이터는 이름만 들고 있으므로
+    // 시드 고객 목록에서 id 를 유도한다 — 매핑을 따로 손으로 관리하면 이름을
+    // 고칠 때 또 어긋난다. 미등록(상담)·공백 슬롯은 이름이 없어 null 로 남는다.
+    final seedClientIdByName = <String, String>{
+      for (final _Client c in _clients) c.name: 'seed-client-${c.id}',
+    };
     await db.batch((Batch b) {
       b.insertAll(db.trainerScheduleEntries, <TrainerScheduleEntriesCompanion>[
         for (var i = 0; i < _schedule.length; i++)
@@ -179,6 +185,7 @@ Future<void> seedIfEmpty(AppDatabase db) async {
             id: 'seed-schedule-$i',
             date: today,
             time: _schedule[i].time,
+            clientId: Value(seedClientIdByName[_schedule[i].clientName]),
             clientName: Value(_schedule[i].clientName),
             type: Value(_schedule[i].type),
             durationMinutes: Value(_schedule[i].durationMinutes),

--- a/frontend/flutter_trainer/lib/features/schedule/data/dtos/schedule_dtos.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/data/dtos/schedule_dtos.dart
@@ -9,6 +9,11 @@ ScheduleSession scheduleSessionFromJson(Map<String, dynamic> json) {
     id: _str(json['id']),
     date: _str(json['date']),
     time: _str(json['time']),
+    // 서버는 고객을 member_id 로 참조한다. 빈 문자열은 미등록(상담) 슬롯이라
+    // null 로 눕혀 이름 폴백 경로와 같은 의미가 되게 한다(#386).
+    clientId: _str(json['member_id']).isEmpty
+        ? null
+        : _str(json['member_id']),
     clientName: _str(json['client_name']),
     type: _str(json['type']),
     durationMinutes: _int(json['duration_minutes']),

--- a/frontend/flutter_trainer/lib/features/schedule/data/repositories/dio_schedule_repository.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/data/repositories/dio_schedule_repository.dart
@@ -114,6 +114,7 @@ class DioScheduleRepository implements ScheduleRepository {
   Future<void> addSession({
     required String date,
     required String clientName,
+    String? clientId,
     required String time,
     required String type,
     required int durationMinutes,
@@ -126,6 +127,7 @@ class DioScheduleRepository implements ScheduleRepository {
           'date': date,
           'time': time,
           'client_name': clientName,
+          'member_id': ?clientId,
           'type': type,
           'duration_minutes': durationMinutes,
           'note': note,
@@ -138,6 +140,7 @@ class DioScheduleRepository implements ScheduleRepository {
   Future<void> updateSession(
     String id, {
     required String clientName,
+    String? clientId,
     required String time,
     required String type,
     required int durationMinutes,
@@ -148,6 +151,7 @@ class DioScheduleRepository implements ScheduleRepository {
         '/trainer/schedule/${Uri.encodeComponent(id)}',
         data: <String, Object?>{
           'client_name': clientName,
+          'member_id': ?clientId,
           'time': time,
           'type': type,
           'duration_minutes': durationMinutes,

--- a/frontend/flutter_trainer/lib/features/schedule/data/repositories/schedule_repository.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/data/repositories/schedule_repository.dart
@@ -46,6 +46,7 @@ abstract interface class ScheduleRepository {
   Future<void> addSession({
     required String date,
     required String clientName,
+    String? clientId,
     required String time,
     required String type,
     required int durationMinutes,
@@ -56,6 +57,7 @@ abstract interface class ScheduleRepository {
   Future<void> updateSession(
     String id, {
     required String clientName,
+    String? clientId,
     required String time,
     required String type,
     required int durationMinutes,
@@ -145,20 +147,25 @@ class DriftScheduleRepository implements ScheduleRepository {
   /// A client's booked sessions, newest first. Drives the 고객 상세 루틴
   /// tab (what programs this person has been given).
   ///
-  /// Schedules reference a client by NAME — see `addClient`'s uniqueness
-  /// guard, which exists precisely so this lookup can't collide. Matched
-  /// on `lower(trim(name))`, the SAME normalisation that guard uses: an
-  /// exact compare would silently return nothing for a name stored with
-  /// stray whitespace or different case, and the weekly report would
-  /// then show 0 sessions for a client who clearly has some.
+  /// Sessions belonging to [client] — matched by **id**, not name (#386).
+  ///
+  /// 이름 매칭은 조용히 실패했다. 고객 이름을 바꾸거나 공백·대소문자가 어긋나면
+  /// 크래시도 오류 표시도 없이 주간 리포트가 "세션 0건" 이 되고, 트레이너가
+  /// 그걸 그대로 회원에게 전송할 수 있었다.
+  ///
+  /// v3 이전에 저장된 행은 `client_id` 가 null 이라 예전처럼 정규화된 이름으로
+  /// 폴백한다. 폴백은 `lower(trim(name))` — `addClient` 의 유일성 가드와 같은
+  /// 정규화라, 저장/조회 기준이 어긋나지 않는다.
   @override
   Stream<List<ScheduleSession>> watchClientSessions(ScheduleClientKey client) {
     final query = _db.select(_db.trainerScheduleEntries)
       ..where(
         (t) =>
-            t.clientName.lower().trim().equals(
-              client.name.trim().toLowerCase(),
-            ) &
+            (t.clientId.equals(client.id) |
+                (t.clientId.isNull() &
+                    t.clientName.lower().trim().equals(
+                      client.name.trim().toLowerCase(),
+                    ))) &
             t.status.equals('공백').not(),
       )
       ..orderBy(<OrderingTerm Function($TrainerScheduleEntriesTable)>[
@@ -174,6 +181,7 @@ class DriftScheduleRepository implements ScheduleRepository {
   Future<void> addSession({
     required String date,
     required String clientName,
+    String? clientId,
     required String time,
     required String type,
     required int durationMinutes,
@@ -186,6 +194,7 @@ class DriftScheduleRepository implements ScheduleRepository {
             id: 'sched-${DateTime.now().microsecondsSinceEpoch}',
             date: date,
             time: time,
+            clientId: Value(clientId),
             clientName: Value(clientName),
             type: Value(type),
             durationMinutes: Value(durationMinutes),
@@ -201,6 +210,7 @@ class DriftScheduleRepository implements ScheduleRepository {
   Future<void> updateSession(
     String id, {
     required String clientName,
+    String? clientId,
     required String time,
     required String type,
     required int durationMinutes,
@@ -210,6 +220,7 @@ class DriftScheduleRepository implements ScheduleRepository {
       _db.trainerScheduleEntries,
     )..where((t) => t.id.equals(id))).write(
       TrainerScheduleEntriesCompanion(
+        clientId: Value(clientId),
         clientName: Value(clientName),
         time: Value(time),
         type: Value(type),
@@ -295,9 +306,17 @@ class DriftScheduleRepository implements ScheduleRepository {
           );
       if (changed != 1) return;
 
+      // 기록을 남길 고객도 id 로 찾는다. v3 이전 행만 이름으로 폴백한다.
+      final clientId = session.clientId;
       final client =
           await (_db.select(_db.trainerClients)
-                ..where((t) => t.name.equals(session.clientName))
+                ..where(
+                  (t) => clientId != null
+                      ? t.id.equals(clientId)
+                      : t.name.lower().trim().equals(
+                          session.clientName.trim().toLowerCase(),
+                        ),
+                )
                 ..limit(1))
               .getSingleOrNull();
 
@@ -354,6 +373,7 @@ class DriftScheduleRepository implements ScheduleRepository {
       id: row.id,
       date: row.date,
       time: row.time,
+      clientId: row.clientId,
       clientName: row.clientName,
       type: row.type,
       durationMinutes: row.durationMinutes,

--- a/frontend/flutter_trainer/lib/features/schedule/domain/entities/schedule_session.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/domain/entities/schedule_session.dart
@@ -29,6 +29,7 @@ class ScheduleSession {
     required this.id,
     required this.date,
     required this.time,
+    this.clientId,
     required this.clientName,
     required this.type,
     required this.durationMinutes,
@@ -48,7 +49,12 @@ class ScheduleSession {
   /// Slot time (e.g. "10:00").
   final String time;
 
-  /// Booked client's name — empty for a gap slot.
+  /// Booked client's id. Null for gap slots, 미등록(상담) 고객, and rows
+  /// stored before v3 — see the drift column comment (#386).
+  final String? clientId;
+
+  /// Booked client's display name — empty for a gap slot. 표시 전용이다.
+  /// 조회는 [clientId] 로 한다.
   final String clientName;
 
   /// Session kind (e.g. "1:1 PT", "상담") — empty for a gap.

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -33,6 +33,7 @@ class _ThrowingScheduleRepository extends DriftScheduleRepository {
   Future<void> addSession({
     required String date,
     required String clientName,
+    String? clientId,
     required String time,
     required String type,
     required int durationMinutes,
@@ -69,6 +70,54 @@ void main() {
         '19:00',
       ]);
       expect(slots.where((s) => s.isGap).length, 2);
+    });
+
+    // #386 회귀: 스케줄이 고객을 이름으로 참조하던 시절에는 고객 이름을
+    // 바꾸면 과거 세션이 통째로 끊겼다. 크래시도 오류 표시도 없이 주간
+    // 리포트가 "세션 0건" 이 되고, 그대로 회원에게 전송될 수 있었다.
+    test('고객 이름을 바꿔도 과거 세션이 끊기지 않는다', () async {
+      final repo = DriftScheduleRepository(db);
+      const key = (id: 'seed-client-1', name: '김민수');
+      final before = await repo.watchClientSessions(key).first;
+      expect(before, isNotEmpty, reason: '시드에 김민수 세션이 있어야 한다');
+
+      await (db.update(db.trainerClients)
+            ..where((t) => t.id.equals('seed-client-1')))
+          .write(const TrainerClientsCompanion(name: Value('김민수2')));
+
+      final after = await repo
+          .watchClientSessions((id: 'seed-client-1', name: '김민수2'))
+          .first;
+      expect(after.length, before.length);
+    });
+
+    test('이름이 같아도 다른 고객의 세션은 섞이지 않는다', () async {
+      final repo = DriftScheduleRepository(db);
+      // 이름만 같고 id 가 다른 고객은 남의 세션을 가져오면 안 된다.
+      final sessions = await repo
+          .watchClientSessions((id: 'other-client', name: '김민수'))
+          .first;
+      expect(sessions, isEmpty);
+    });
+
+    test('v3 이전 행(client_id 없음)은 이름으로 폴백한다', () async {
+      // 마이그레이션만 거친 기존 설치를 흉내 낸다 — client_id 가 null 이다.
+      await db
+          .into(db.trainerScheduleEntries)
+          .insert(
+            TrainerScheduleEntriesCompanion.insert(
+              id: 'legacy-row',
+              date: ymd(DateTime.now()),
+              time: '21:00',
+              status: '예정',
+              clientName: const Value('  김민수  '), // 공백까지 섞인 기존 데이터
+            ),
+          );
+
+      final sessions = await DriftScheduleRepository(
+        db,
+      ).watchClientSessions((id: 'seed-client-1', name: '김민수')).first;
+      expect(sessions.any((s) => s.id == 'legacy-row'), isTrue);
     });
 
     test('decodes the PT program and expandability rules', () async {


### PR DESCRIPTION
Closes #386

## Summary

`trainer_schedule` 이 고객을 **표시 이름**으로 참조했습니다. 이름은 식별자가 아닙니다.

조용히 실패한다는 점이 가장 나쁩니다 — 이름이 어긋나면 크래시도 오류 표시도 없이 주간 리포트가 **"세션 0건"** 이 되고, 트레이너가 그대로 회원에게 전송할 수 있었습니다. 고객 이름을 바꾸면 과거 세션이 통째로 끊겼습니다.

## Changes

**스키마**
- drift `trainer_schedule_entries.client_id` 추가 (nullable), `schemaVersion` 2 → 3 + `addColumn` 마이그레이션

**조회**
- `watchClientSessions` 를 **id 매칭**으로 전환
- `completeSession` 의 고객 조회도 id 우선

두 곳 모두 **v3 이전 행은 `client_id` 가 null 이라 기존처럼 `lower(trim(name))` 로 폴백**합니다. 마이그레이션만 거친 설치도 재시딩 전까지 끊기지 않습니다.

**쓰기**
- `addSession`/`updateSession` 이 `clientId` 를 받아 저장
- Dio 구현은 백엔드 계약대로 `member_id` 로 보내고, 응답 DTO 도 `member_id` 를 엔티티에 싣습니다(빈 문자열은 미등록 슬롯이라 null 로 눕힘)

**시드**
- 매핑을 손으로 들지 않고 **시드 고객 목록에서 id 를 유도**합니다. 매핑을 따로 관리하면 이름을 고칠 때 또 어긋납니다

`client_name` 은 표시용으로 남깁니다 — 상담 등 미등록 고객 슬롯에는 붙일 id 가 없습니다(이슈의 명시 요구).

## Verification

회귀 테스트 3건을 추가했고, **앞의 둘은 이름 기반 코드에서 실제로 실패하는 것을 확인**했습니다.

| 테스트 | 이름 기반 코드에서 |
|---|---|
| 이름을 바꿔도 세션이 유지되는지 | **실패** — `Expected: <1>  Actual: <0>` (이슈가 말한 조용한 "0건") |
| 이름만 같고 id 가 다른 고객의 세션이 섞이지 않는지 | **실패** — 남의 세션이 새어 들어옴 |
| v3 이전 행(client_id null, 이름에 공백 섞임)이 폴백으로 잡히는지 | 폴백 경로 확인 |

`flutter analyze` 이슈 없음, 트레이너 앱 **320 passed**.

## Notes

`DioScheduleRepository` 는 이미 `member_id` 로 필터하고 있어 실 API 조회 경로는 원래 안전했습니다. 이 PR 은 drift(데모) 경로의 정합성과, 쓰기 경로에서 id 를 함께 보내는 부분을 맞춥니다.