### PR TITLE
fix(diet): 공공 DB 보정이 당류를 정수로 깎던 문제

### DIFF
--- a/backend/app/services/nutrition/enrich.py
+++ b/backend/app/services/nutrition/enrich.py
@@ -29,9 +29,13 @@ def enrich_analysis(db: Session, analysis: DietAnalysis, enabled: bool = True) -
     for food in analysis.foods:
         match = match_in_rows(rows, food.name)
         if match is not None:
+            # 칼로리·나트륨은 계약상 정수라 반올림이 맞다. 당류만 소수다
+            # (#296) — 여기서 int 로 깎으면 공공 DB 가 실데이터(8.5g 등)로
+            # 채워지는 순간 컬럼·스키마·클라이언트까지 소수로 통일해 둔 것이
+            # 이 한 줄에서 되돌려진다.
             food.calories = int(round(match.calories or 0))
             food.sodium_mg = int(round(match.sodium_mg or 0))
-            food.sugar_g = int(round(match.sugar_g or 0))
+            food.sugar_g = float(match.sugar_g or 0)
             kept_recognizer_value = False
             for field in ("carbs_g", "protein_g", "fat_g"):
                 db_value = getattr(match, field)

--- a/backend/tests/test_nutrition.py
+++ b/backend/tests/test_nutrition.py
@@ -68,3 +68,40 @@ def test_enrich_overrides_matched_keeps_unmatched(db_session):
     # 합계 재계산
     assert analysis.total_sodium_mg == matched.sodium_mg + unmatched.sodium_mg
     assert analysis.total_calories == matched.calories + unmatched.calories
+
+
+def test_enrich_keeps_fractional_sugar_from_the_public_db(db_session):
+    """#296 회귀: 보정 단계가 당류를 int 로 깎으면 안 된다.
+
+    컬럼·스키마·클라이언트를 전부 소수로 통일했는데(#362, #368) 보정이
+    `int(round(...))` 로 되돌리고 있었다. 시드가 마침 정수뿐이라 드러나지
+    않았을 뿐, 식약처 실데이터는 8.5g 같은 소수가 정상이다.
+    """
+    from app.models.models import FoodNutrient
+    from app.schemas.diet import DietAnalysis, RecognizedFood
+    from app.services.nutrition.enrich import enrich_analysis
+    from app.services.nutrition.matcher import normalize
+
+    db_session.add(
+        FoodNutrient(
+            name="소수당류식품",
+            name_norm=normalize("소수당류식품"),
+            calories=100,
+            sodium_mg=10,
+            sugar_g=8.5,
+        )
+    )
+    db_session.commit()
+
+    analysis = DietAnalysis(
+        engine="gemini",
+        foods=[RecognizedFood(name="소수당류식품", calories=1, sodium_mg=1, sugar_g=1)],
+    )
+    enrich_analysis(db_session, analysis)
+
+    food = analysis.foods[0]
+    assert food.source == "db"
+    # 예전에는 round(8.5) → 8 (은행가 반올림) 이었다.
+    assert food.sugar_g == 8.5
+    assert analysis.total_sugar_g == 8.5
+


### PR DESCRIPTION
## Summary

`enrich_analysis` 가 인식 결과를 공공 식품영양성분 DB 값으로 교체하면서 **당류까지 `int(round(...))` 로 캐스팅**했습니다. 칼로리·나트륨은 계약상 정수라 맞지만, 당류는 #296 에서 소수로 통일한 필드입니다.

```
FoodNutrient.sugar_g      Float   (1인분 g)
RecognizedFood.sugar_g    float   (#362 에서 확장)
enrich_analysis           int(round(...))   ← 여기서 되돌아감
```

## 왜 지금 고치나

**지금은 드러나지 않는 잠복 버그입니다.** 시드 40건의 당류가 전부 정수라 손실이 보이지 않습니다.

그런데 식약처 실데이터는 `8.5g` 같은 소수가 정상입니다. 즉 **공공 DB 를 실제 값으로 채우는 바로 그 시점에** 소수가 조용히 사라집니다 — 컬럼(#362)·클라이언트(#368)까지 소수로 맞춰 둔 작업이 이 한 줄에서 무효가 됩니다.

게다가 파이썬 `round` 는 은행가 반올림이라 `round(8.5) == 8` 입니다. 절삭도 반올림도 아닌 값이 나옵니다.

## Changes

```diff
-            food.sugar_g = int(round(match.sugar_g or 0))
+            food.sugar_g = float(match.sugar_g or 0)
```

칼로리·나트륨의 `int(round(...))` 는 계약상 정수라 그대로 두고, 왜 당류만 다른지 주석으로 남겼습니다.

## Verification

소수 당류를 가진 `food_nutrients` 행을 넣고 보정 후에도 값이 보존되는지 확인하는 회귀 테스트를 추가했습니다. **수정 전 코드에서 실제로 실패합니다:**

```
assert food.sugar_g == 8.5
E  AssertionError: assert 8 == 8.5
E   +  where 8 = RecognizedFood(..., sugar_g=8, source='db').sugar_g
```

백엔드 **323 passed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 식품 영양 정보에서 당류 값을 정수로 반올림하지 않고 소수점까지 정확하게 저장합니다.
  * 당류 분석 및 합계 결과에도 원본 소수점 값이 유지됩니다.
  * 칼로리와 나트륨 값의 기존 반올림 방식은 변경되지 않았습니다.

* **테스트**
  * 소수점 당류 값이 정확히 보존되는 회귀 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->