### PR TITLE
feat(my-health): manage trainer and gym links in MY tab

### DIFF
--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_gym_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_gym_repository.dart
@@ -81,7 +81,12 @@ class MockGymRepository implements GymRepository {
   @override
   Future<List<Gym>> fetchNearby() async {
     await Future<void>.delayed(const Duration(milliseconds: 80));
-    return const <Gym>[_sinchon, _healthmate, _bodyAndSoul];
+    final Gym? myGym = _myGym;
+    return <Gym>[
+      if (myGym?.id == _sinchon.id) myGym! else _sinchon,
+      _healthmate,
+      _bodyAndSoul,
+    ];
   }
 
   @override

--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_gym_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_gym_repository.dart
@@ -2,26 +2,43 @@ import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/domain/repositories/gym_repository.dart';
 
 /// In-memory gym data matching the prototype's `GymCard` / `GymFinder`
-/// mocks. The user's "my gym" starts as 강남 피트니스 센터; the finder
-/// sheet returns three candidates with ratings, tags, and distances.
+/// mocks. The user's "my gym" starts as 온케어짐 신촌점 — the same gym the
+/// trainer app's `seedTrainerProfile` belongs to, so both apps describe one
+/// relationship. The finder sheet returns three 신촌 권역 candidates with
+/// ratings, tags, and distances.
 ///
-/// Stateful (not const) so [disconnectMyGym] can clear the link for the
-/// session — the provider holds one instance, so MY 탭과 운동 탭이 같은
-/// 연결 상태를 본다.
+/// Stateful (not const) so [disconnectMyGym] / [disconnectMyTrainer] can
+/// clear the links for the session — the provider holds one instance, so
+/// MY 탭과 운동 탭이 같은 연결 상태를 본다.
 class MockGymRepository implements GymRepository {
   MockGymRepository();
 
-  Gym? _myGym = _gangnam;
+  /// 연결된 헬스장. 트레이너만 해제하면 [_sinchonNoTrainer] 로 바뀐다.
+  Gym? _myGym = _sinchon;
 
-  static const Gym _gangnam = Gym(
-    id: 'gym-gangnam',
-    name: '강남 피트니스 센터',
-    address: '서울시 강남구 역삼동 123-45',
+  /// 트레이너 앱 `seedTrainerProfile.gym` 과 같은 값이어야 한다.
+  static const Gym _sinchon = Gym(
+    id: 'gym-oncare-sinchon',
+    name: '온케어짐 신촌점',
+    address: '서울 서대문구 신촌로 120',
     distanceKm: 0.8,
     rating: 4.7,
     tags: <String>['다이어트', '재활운동'],
     trainerName: '김트레이너',
-    trainerRole: '전담 트레이너',
+    trainerRole: '퍼스널 트레이너',
+    weekdayHours: '06:00 - 23:00',
+    weekendHours: '08:00 - 20:00',
+    phone: '02-1234-5678',
+  );
+
+  /// 같은 헬스장이지만 담당 트레이너 연결만 없는 상태.
+  static const Gym _sinchonNoTrainer = Gym(
+    id: 'gym-oncare-sinchon',
+    name: '온케어짐 신촌점',
+    address: '서울 서대문구 신촌로 120',
+    distanceKm: 0.8,
+    rating: 4.7,
+    tags: <String>['다이어트', '재활운동'],
     weekdayHours: '06:00 - 23:00',
     weekendHours: '08:00 - 20:00',
     phone: '02-1234-5678',
@@ -29,8 +46,8 @@ class MockGymRepository implements GymRepository {
 
   static const Gym _healthmate = Gym(
     id: 'gym-healthmate',
-    name: '헬스메이트 역삼점',
-    address: '서울시 강남구 역삼동 456-78',
+    name: '헬스메이트 신촌점',
+    address: '서울 서대문구 신촌로 83',
     distanceKm: 1.2,
     rating: 4.5,
     tags: <String>['근력운동', '만성질환 관리'],
@@ -44,7 +61,7 @@ class MockGymRepository implements GymRepository {
   static const Gym _bodyAndSoul = Gym(
     id: 'gym-bodyandsoul',
     name: '바디앤소울 피트니스',
-    address: '서울시 강남구 논현동 789-01',
+    address: '서울 마포구 백범로 23',
     distanceKm: 1.5,
     rating: 4.8,
     tags: <String>['PT', '식단 상담'],
@@ -64,12 +81,21 @@ class MockGymRepository implements GymRepository {
   @override
   Future<List<Gym>> fetchNearby() async {
     await Future<void>.delayed(const Duration(milliseconds: 80));
-    return const <Gym>[_gangnam, _healthmate, _bodyAndSoul];
+    return const <Gym>[_sinchon, _healthmate, _bodyAndSoul];
   }
 
   @override
   Future<void> disconnectMyGym() async {
     await Future<void>.delayed(const Duration(milliseconds: 60));
+    // 헬스장을 떠나면 그곳 소속 트레이너 연결도 함께 사라진다.
     _myGym = null;
+  }
+
+  @override
+  Future<void> disconnectMyTrainer() async {
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+    // 헬스장 연결은 그대로 두고 담당 트레이너만 뗀다.
+    if (_myGym == null) return;
+    _myGym = _sinchonNoTrainer;
   }
 }

--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_gym_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_gym_repository.dart
@@ -4,8 +4,14 @@ import 'package:oncare/features/exercise/domain/repositories/gym_repository.dart
 /// In-memory gym data matching the prototype's `GymCard` / `GymFinder`
 /// mocks. The user's "my gym" starts as 강남 피트니스 센터; the finder
 /// sheet returns three candidates with ratings, tags, and distances.
+///
+/// Stateful (not const) so [disconnectMyGym] can clear the link for the
+/// session — the provider holds one instance, so MY 탭과 운동 탭이 같은
+/// 연결 상태를 본다.
 class MockGymRepository implements GymRepository {
-  const MockGymRepository();
+  MockGymRepository();
+
+  Gym? _myGym = _gangnam;
 
   static const Gym _gangnam = Gym(
     id: 'gym-gangnam',
@@ -52,12 +58,18 @@ class MockGymRepository implements GymRepository {
   @override
   Future<Gym?> fetchMyGym() async {
     await Future<void>.delayed(const Duration(milliseconds: 60));
-    return _gangnam;
+    return _myGym;
   }
 
   @override
   Future<List<Gym>> fetchNearby() async {
     await Future<void>.delayed(const Duration(milliseconds: 80));
     return const <Gym>[_gangnam, _healthmate, _bodyAndSoul];
+  }
+
+  @override
+  Future<void> disconnectMyGym() async {
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+    _myGym = null;
   }
 }

--- a/frontend/flutter/lib/features/exercise/domain/repositories/gym_repository.dart
+++ b/frontend/flutter/lib/features/exercise/domain/repositories/gym_repository.dart
@@ -7,6 +7,11 @@ abstract class GymRepository {
   /// Nearby gyms shown in the "헬스장 찾기" finder sheet.
   Future<List<Gym>> fetchNearby();
 
-  /// Drops the user's gym/trainer link. [fetchMyGym] returns `null` after this.
+  /// Drops the gym link, and the trainer with it — you cannot keep a trainer
+  /// at a gym you left. [fetchMyGym] returns `null` after this.
   Future<void> disconnectMyGym();
+
+  /// Drops only the trainer link. [fetchMyGym] still returns the gym, with
+  /// its trainer fields cleared. No-op when no gym is connected.
+  Future<void> disconnectMyTrainer();
 }

--- a/frontend/flutter/lib/features/exercise/domain/repositories/gym_repository.dart
+++ b/frontend/flutter/lib/features/exercise/domain/repositories/gym_repository.dart
@@ -6,4 +6,7 @@ abstract class GymRepository {
 
   /// Nearby gyms shown in the "헬스장 찾기" finder sheet.
   Future<List<Gym>> fetchNearby();
+
+  /// Drops the user's gym/trainer link. [fetchMyGym] returns `null` after this.
+  Future<void> disconnectMyGym();
 }

--- a/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
@@ -145,7 +145,9 @@ final exerciseWeekViewProvider = Provider<AsyncValue<ExerciseWeek>>((ref) {
 /// mock data, so wire the page to a static repository for now. A real
 /// `DioGymRepository` can be swapped in once `/gyms/*` lands.
 final gymRepositoryProvider = Provider<GymRepository>(
-  (ref) => const MockGymRepository(),
+  // 한 인스턴스를 provider 수명 동안 유지해, 연결 해제 상태가 MY 탭과
+  // 운동 탭에 함께 반영된다.
+  (ref) => MockGymRepository(),
   name: 'gymRepository',
 );
 

--- a/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
@@ -5,6 +5,8 @@ import 'package:go_router/go_router.dart';
 import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/features/auth/presentation/controllers/session_controller.dart';
+import 'package:oncare/features/exercise/domain/entities/gym.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/features/my_health/domain/entities/health_history.dart';
 import 'package:oncare/features/my_health/presentation/controllers/my_health_controller.dart';
 import 'package:oncare/features/my_health/presentation/widgets/my_flows.dart';
@@ -70,6 +72,13 @@ class MyHealthPage extends ConsumerWidget {
                   padding: const EdgeInsets.symmetric(horizontal: 24),
                   child: _PointsBanner(
                     points: health.valueOrNull?.activityPoints,
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: _TrainerGymSection(
+                    onManage: () => context.go(AppRoutes.exerciseGym),
                   ),
                 ),
                 const SizedBox(height: 20),
@@ -856,6 +865,219 @@ class _LogoutButton extends StatelessWidget {
               ),
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+// ──────────────────────────────────────────────
+// 내 트레이너 · 헬스장 섹션
+// ──────────────────────────────────────────────
+
+class _TrainerGymSection extends ConsumerWidget {
+  const _TrainerGymSection({required this.onManage});
+
+  final VoidCallback onManage;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AsyncValue<Gym?> gymAsync = ref.watch(myGymProvider);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        const Text(
+          '내 트레이너 · 헬스장',
+          style: TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.w700,
+            color: FigmaColors.ink,
+          ),
+        ),
+        const SizedBox(height: 12),
+        gymAsync.when(
+          loading: () => const _GymSectionLoading(),
+          error: (_, _) => _GymSectionEmpty(onFind: onManage),
+          data: (Gym? gym) => gym == null
+              ? _GymSectionEmpty(onFind: onManage)
+              : _GymSummaryCard(gym: gym, onTap: onManage),
+        ),
+      ],
+    );
+  }
+}
+
+class _GymSummaryCard extends StatelessWidget {
+  const _GymSummaryCard({required this.gym, required this.onTap});
+
+  final Gym gym;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final bool hasTrainer = gym.trainerName?.isNotEmpty ?? false;
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: FigmaColors.hairline),
+        boxShadow: kCardShadow,
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Row(
+                children: <Widget>[
+                  Container(
+                    width: 36,
+                    height: 36,
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      color: FigmaColors.primaryA(0.10),
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    child: const Icon(
+                      Icons.fitness_center,
+                      size: 18,
+                      color: FigmaColors.primary,
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          gym.name,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w800,
+                            color: FigmaColors.ink,
+                          ),
+                        ),
+                        Text(
+                          '${gym.address} · ${gym.distanceKm.toStringAsFixed(1)}km',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            fontSize: 11,
+                            color: FigmaColors.textMuted,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const Icon(Icons.chevron_right, color: FigmaColors.textFaint),
+                ],
+              ),
+              if (hasTrainer) ...<Widget>[
+                const SizedBox(height: 12),
+                const Divider(height: 1, color: FigmaColors.hairline),
+                const SizedBox(height: 12),
+                Row(
+                  children: <Widget>[
+                    const Icon(
+                      Icons.person_outline,
+                      size: 15,
+                      color: FigmaColors.primary,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        '${gym.trainerName!} · ${gym.trainerRole ?? '퍼스널 트레이너'}',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          color: FigmaColors.textBody,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _GymSectionEmpty extends StatelessWidget {
+  const _GymSectionEmpty({required this.onFind});
+
+  final VoidCallback onFind;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: FigmaColors.hairline),
+        boxShadow: kCardShadow,
+      ),
+      child: Column(
+        children: <Widget>[
+          const Text(
+            '아직 등록된 헬스장이 없어요',
+            style: TextStyle(
+              fontSize: 12.5,
+              fontWeight: FontWeight.w500,
+              color: FigmaColors.textMuted,
+            ),
+          ),
+          const SizedBox(height: 12),
+          OutlinedButton.icon(
+            onPressed: onFind,
+            style: OutlinedButton.styleFrom(
+              foregroundColor: FigmaColors.primary,
+              side: BorderSide(color: FigmaColors.primaryA(0.35)),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+            ),
+            icon: const Icon(Icons.search, size: 16),
+            label: const Text(
+              '헬스장 찾기',
+              style: TextStyle(fontSize: 12, fontWeight: FontWeight.w700),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GymSectionLoading extends StatelessWidget {
+  const _GymSectionLoading();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 80,
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: FigmaColors.hairline),
+        boxShadow: kCardShadow,
+      ),
+      child: const Center(
+        child: SizedBox(
+          width: 24,
+          height: 24,
+          child: CircularProgressIndicator(strokeWidth: 2.5),
         ),
       ),
     );

--- a/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
@@ -78,7 +78,7 @@ class MyHealthPage extends ConsumerWidget {
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 24),
                   child: _TrainerGymSection(
-                    onManage: () => context.go(AppRoutes.exerciseGym),
+                    onFindGym: () => context.go(AppRoutes.exerciseGym),
                   ),
                 ),
                 const SizedBox(height: 20),
@@ -876,9 +876,66 @@ class _LogoutButton extends StatelessWidget {
 // ──────────────────────────────────────────────
 
 class _TrainerGymSection extends ConsumerWidget {
-  const _TrainerGymSection({required this.onManage});
+  const _TrainerGymSection({required this.onFindGym});
 
-  final VoidCallback onManage;
+  /// 연결된 헬스장이 없을 때 "헬스장 찾기"로 보낼 콜백.
+  final VoidCallback onFindGym;
+
+  /// 카드를 누르면 확인 후 헬스장·트레이너 연결을 해제한다.
+  Future<void> _confirmDisconnect(
+    BuildContext context,
+    WidgetRef ref,
+    Gym gym,
+  ) async {
+    final bool ok =
+        await showDialog<bool>(
+          context: context,
+          builder: (BuildContext ctx) => AlertDialog(
+            backgroundColor: Colors.white,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(20),
+            ),
+            title: const Text(
+              '연결 삭제',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w800,
+                color: FigmaColors.ink,
+              ),
+            ),
+            content: Text(
+              '${gym.name} 연결을 삭제하시겠습니까?',
+              style: const TextStyle(
+                fontSize: 13.5,
+                color: FigmaColors.textBody,
+                height: 1.4,
+              ),
+            ),
+            actions: <Widget>[
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(false),
+                style: TextButton.styleFrom(
+                  foregroundColor: FigmaColors.textMuted,
+                ),
+                child: const Text('취소'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(true),
+                style: TextButton.styleFrom(
+                  foregroundColor: const Color(0xFFFF3B30),
+                ),
+                child: const Text('삭제'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+    if (!ok) return;
+    await ref.read(gymRepositoryProvider).disconnectMyGym();
+    // 해제를 기다리는 동안 탭을 벗어났다면 ref 가 이미 폐기됐을 수 있다.
+    if (!context.mounted) return;
+    ref.invalidate(myGymProvider);
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -897,10 +954,13 @@ class _TrainerGymSection extends ConsumerWidget {
         const SizedBox(height: 12),
         gymAsync.when(
           loading: () => const _GymSectionLoading(),
-          error: (_, _) => _GymSectionEmpty(onFind: onManage),
+          error: (_, _) => _GymSectionEmpty(onFind: onFindGym),
           data: (Gym? gym) => gym == null
-              ? _GymSectionEmpty(onFind: onManage)
-              : _GymSummaryCard(gym: gym, onTap: onManage),
+              ? _GymSectionEmpty(onFind: onFindGym)
+              : _GymSummaryCard(
+                  gym: gym,
+                  onTap: () => _confirmDisconnect(context, ref, gym),
+                ),
         ),
       ],
     );
@@ -974,7 +1034,13 @@ class _GymSummaryCard extends StatelessWidget {
                       ],
                     ),
                   ),
-                  const Icon(Icons.chevron_right, color: FigmaColors.textFaint),
+                  // 카드 전체가 "연결 삭제" 동작이므로, 이동을 뜻하는 chevron
+                  // 대신 삭제 아이콘을 둔다.
+                  const Icon(
+                    Icons.delete_outline_rounded,
+                    size: 20,
+                    color: FigmaColors.textFaint,
+                  ),
                 ],
               ),
               if (hasTrainer) ...<Widget>[

--- a/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
@@ -6,6 +6,7 @@ import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/features/auth/presentation/controllers/session_controller.dart';
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
+import 'package:oncare/features/exercise/domain/repositories/gym_repository.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/features/my_health/domain/entities/health_history.dart';
 import 'package:oncare/features/my_health/presentation/controllers/my_health_controller.dart';
@@ -63,9 +64,7 @@ class MyHealthPage extends ConsumerWidget {
                 const SizedBox(height: 4),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 24),
-                  child: _ProfileCard(
-                    profile: health.valueOrNull?.profile,
-                  ),
+                  child: _ProfileCard(profile: health.valueOrNull?.profile),
                 ),
                 const SizedBox(height: 20),
                 Padding(
@@ -881,12 +880,15 @@ class _TrainerGymSection extends ConsumerWidget {
   /// 연결된 헬스장이 없을 때 "헬스장 찾기"로 보낼 콜백.
   final VoidCallback onFindGym;
 
-  /// 카드를 누르면 확인 후 헬스장·트레이너 연결을 해제한다.
+  /// 확인 창을 띄우고, 승인되면 [disconnect] 를 실행한 뒤 연결 상태를 새로
+  /// 읽는다. 헬스장·트레이너 두 삭제가 같은 흐름을 쓴다.
   Future<void> _confirmDisconnect(
     BuildContext context,
-    WidgetRef ref,
-    Gym gym,
-  ) async {
+    WidgetRef ref, {
+    required String message,
+    required Future<void> Function(GymRepository repo) disconnect,
+  }) async {
+    final AppLocalizations l = AppLocalizations.of(context);
     final bool ok =
         await showDialog<bool>(
           context: context,
@@ -895,16 +897,16 @@ class _TrainerGymSection extends ConsumerWidget {
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(20),
             ),
-            title: const Text(
-              '연결 삭제',
-              style: TextStyle(
+            title: Text(
+              l.myConnectionDeleteTitle,
+              style: const TextStyle(
                 fontSize: 16,
                 fontWeight: FontWeight.w800,
                 color: FigmaColors.ink,
               ),
             ),
             content: Text(
-              '${gym.name} 연결을 삭제하시겠습니까?',
+              message,
               style: const TextStyle(
                 fontSize: 13.5,
                 color: FigmaColors.textBody,
@@ -917,35 +919,61 @@ class _TrainerGymSection extends ConsumerWidget {
                 style: TextButton.styleFrom(
                   foregroundColor: FigmaColors.textMuted,
                 ),
-                child: const Text('취소'),
+                child: Text(l.myCancel),
               ),
               TextButton(
                 onPressed: () => Navigator.of(ctx).pop(true),
                 style: TextButton.styleFrom(
                   foregroundColor: const Color(0xFFFF3B30),
                 ),
-                child: const Text('삭제'),
+                child: Text(l.myDelete),
               ),
             ],
           ),
         ) ??
         false;
     if (!ok) return;
-    await ref.read(gymRepositoryProvider).disconnectMyGym();
+    await disconnect(ref.read(gymRepositoryProvider));
     // 해제를 기다리는 동안 탭을 벗어났다면 ref 가 이미 폐기됐을 수 있다.
     if (!context.mounted) return;
     ref.invalidate(myGymProvider);
   }
 
+  /// 헬스장 연결 삭제. 담당 트레이너가 있으면 함께 사라진다는 것을 알린다.
+  Future<void> _removeGym(BuildContext context, WidgetRef ref, Gym gym) {
+    final AppLocalizations l = AppLocalizations.of(context);
+    final bool hasTrainer = gym.trainerName?.isNotEmpty ?? false;
+    return _confirmDisconnect(
+      context,
+      ref,
+      message: hasTrainer
+          ? l.myGymDisconnectWithTrainerConfirm(gym.name, gym.trainerName!)
+          : l.myGymDisconnectConfirm(gym.name),
+      disconnect: (GymRepository repo) => repo.disconnectMyGym(),
+    );
+  }
+
+  /// 헬스장은 그대로 두고 담당 트레이너 연결만 삭제.
+  Future<void> _removeTrainer(BuildContext context, WidgetRef ref, Gym gym) {
+    final AppLocalizations l = AppLocalizations.of(context);
+    return _confirmDisconnect(
+      context,
+      ref,
+      message: l.myTrainerDisconnectConfirm(gym.trainerName!, gym.name),
+      disconnect: (GymRepository repo) => repo.disconnectMyTrainer(),
+    );
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final AppLocalizations l = AppLocalizations.of(context);
     final AsyncValue<Gym?> gymAsync = ref.watch(myGymProvider);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        const Text(
-          '내 트레이너 · 헬스장',
-          style: TextStyle(
+        Text(
+          l.myTrainerGymTitle,
+          style: const TextStyle(
             fontSize: 14,
             fontWeight: FontWeight.w700,
             color: FigmaColors.ink,
@@ -954,12 +982,15 @@ class _TrainerGymSection extends ConsumerWidget {
         const SizedBox(height: 12),
         gymAsync.when(
           loading: () => const _GymSectionLoading(),
-          error: (_, _) => _GymSectionEmpty(onFind: onFindGym),
+          error: (_, _) =>
+              _GymSectionError(onRetry: () => ref.invalidate(myGymProvider)),
           data: (Gym? gym) => gym == null
               ? _GymSectionEmpty(onFind: onFindGym)
               : _GymSummaryCard(
                   gym: gym,
-                  onTap: () => _confirmDisconnect(context, ref, gym),
+                  onRemoveGym: () => _removeGym(context, ref, gym),
+                  onRemoveTrainer: () => _removeTrainer(context, ref, gym),
+                  onFindTrainer: onFindGym,
                 ),
         ),
       ],
@@ -967,14 +998,26 @@ class _TrainerGymSection extends ConsumerWidget {
   }
 }
 
+/// 연결된 헬스장과 담당 트레이너를 각각 한 줄로 보여준다. 두 연결은 따로
+/// 관리된다 — 트레이너만 떼거나, 헬스장을 떼면서 함께 정리하거나.
 class _GymSummaryCard extends StatelessWidget {
-  const _GymSummaryCard({required this.gym, required this.onTap});
+  const _GymSummaryCard({
+    required this.gym,
+    required this.onRemoveGym,
+    required this.onRemoveTrainer,
+    required this.onFindTrainer,
+  });
 
   final Gym gym;
-  final VoidCallback onTap;
+  final VoidCallback onRemoveGym;
+  final VoidCallback onRemoveTrainer;
+
+  /// 헬스장은 있는데 담당 트레이너가 없을 때 트레이너를 찾으러 보낸다.
+  final VoidCallback onFindTrainer;
 
   @override
   Widget build(BuildContext context) {
+    final AppLocalizations l = AppLocalizations.of(context);
     final bool hasTrainer = gym.trainerName?.isNotEmpty ?? false;
     return Container(
       decoration: BoxDecoration(
@@ -984,93 +1027,164 @@ class _GymSummaryCard extends StatelessWidget {
         boxShadow: kCardShadow,
       ),
       clipBehavior: Clip.antiAlias,
-      child: InkWell(
-        onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Row(
-                children: <Widget>[
-                  Container(
-                    width: 36,
-                    height: 36,
-                    alignment: Alignment.center,
-                    decoration: BoxDecoration(
-                      color: FigmaColors.primaryA(0.10),
-                      borderRadius: BorderRadius.circular(10),
-                    ),
-                    child: const Icon(
-                      Icons.fitness_center,
-                      size: 18,
-                      color: FigmaColors.primary,
-                    ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Container(
+                  width: 36,
+                  height: 36,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: FigmaColors.primaryA(0.10),
+                    borderRadius: BorderRadius.circular(10),
                   ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        Text(
-                          gym.name,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w800,
-                            color: FigmaColors.ink,
-                          ),
-                        ),
-                        Text(
-                          '${gym.address} · ${gym.distanceKm.toStringAsFixed(1)}km',
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(
-                            fontSize: 11,
-                            color: FigmaColors.textMuted,
-                          ),
-                        ),
-                      ],
-                    ),
+                  child: const Icon(
+                    Icons.fitness_center,
+                    size: 18,
+                    color: FigmaColors.primary,
                   ),
-                  // 카드 전체가 "연결 삭제" 동작이므로, 이동을 뜻하는 chevron
-                  // 대신 삭제 아이콘을 둔다.
-                  const Icon(
-                    Icons.delete_outline_rounded,
-                    size: 20,
-                    color: FigmaColors.textFaint,
-                  ),
-                ],
-              ),
-              if (hasTrainer) ...<Widget>[
-                const SizedBox(height: 12),
-                const Divider(height: 1, color: FigmaColors.hairline),
-                const SizedBox(height: 12),
-                Row(
-                  children: <Widget>[
-                    const Icon(
-                      Icons.person_outline,
-                      size: 15,
-                      color: FigmaColors.primary,
-                    ),
-                    const SizedBox(width: 8),
-                    Expanded(
-                      child: Text(
-                        '${gym.trainerName!} · ${gym.trainerRole ?? '퍼스널 트레이너'}',
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        gym.name,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: const TextStyle(
-                          fontSize: 12,
-                          fontWeight: FontWeight.w600,
-                          color: FigmaColors.textBody,
+                          fontSize: 14,
+                          fontWeight: FontWeight.w800,
+                          color: FigmaColors.ink,
                         ),
                       ),
-                    ),
-                  ],
+                      Text(
+                        '${gym.address} · ${gym.distanceKm.toStringAsFixed(1)}km',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          fontSize: 11,
+                          color: FigmaColors.textMuted,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                _RemoveLinkButton(
+                  tooltip: l.myGymDisconnectTooltip,
+                  onTap: onRemoveGym,
                 ),
               ],
-            ],
+            ),
+            const SizedBox(height: 12),
+            const Divider(height: 1, color: FigmaColors.hairline),
+            const SizedBox(height: 12),
+            if (hasTrainer)
+              Row(
+                children: <Widget>[
+                  const Icon(
+                    Icons.person_outline,
+                    size: 15,
+                    color: FigmaColors.primary,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      '${gym.trainerName!} · ${gym.trainerRole ?? l.exTrainerDedicated}',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                        color: FigmaColors.textBody,
+                      ),
+                    ),
+                  ),
+                  _RemoveLinkButton(
+                    tooltip: l.myTrainerDisconnectTooltip,
+                    onTap: onRemoveTrainer,
+                  ),
+                ],
+              )
+            else
+              Row(
+                children: <Widget>[
+                  const Icon(
+                    Icons.person_off_outlined,
+                    size: 15,
+                    color: FigmaColors.textFaint,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      l.myNoTrainer,
+                      style: const TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                        color: FigmaColors.textMuted,
+                      ),
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: onFindTrainer,
+                    style: TextButton.styleFrom(
+                      foregroundColor: FigmaColors.primary,
+                      minimumSize: const Size(48, 44),
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                    ),
+                    child: Text(
+                      l.exFindTrainer,
+                      style: const TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 한 줄짜리 연결(헬스장 또는 트레이너)을 끊는 버튼. 시각적 아이콘은 20이지만
+/// 탭 영역은 접근성 최소 44×44 를 지킨다.
+class _RemoveLinkButton extends StatelessWidget {
+  const _RemoveLinkButton({required this.tooltip, required this.onTap});
+
+  final String tooltip;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: tooltip,
+      child: Semantics(
+        button: true,
+        label: tooltip,
+        child: Material(
+          color: Colors.transparent,
+          shape: const CircleBorder(),
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            onTap: onTap,
+            customBorder: const CircleBorder(),
+            child: const SizedBox(
+              width: 44,
+              height: 44,
+              child: Icon(
+                Icons.delete_outline_rounded,
+                size: 20,
+                color: FigmaColors.textFaint,
+              ),
+            ),
           ),
         ),
       ),
@@ -1085,6 +1199,7 @@ class _GymSectionEmpty extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final AppLocalizations l = AppLocalizations.of(context);
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 16),
@@ -1096,9 +1211,9 @@ class _GymSectionEmpty extends StatelessWidget {
       ),
       child: Column(
         children: <Widget>[
-          const Text(
-            '아직 등록된 헬스장이 없어요',
-            style: TextStyle(
+          Text(
+            l.myNoGymConnected,
+            style: const TextStyle(
               fontSize: 12.5,
               fontWeight: FontWeight.w500,
               color: FigmaColors.textMuted,
@@ -1115,9 +1230,9 @@ class _GymSectionEmpty extends StatelessWidget {
               ),
             ),
             icon: const Icon(Icons.search, size: 16),
-            label: const Text(
-              '헬스장 찾기',
-              style: TextStyle(fontSize: 12, fontWeight: FontWeight.w700),
+            label: Text(
+              l.exFindGym,
+              style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w700),
             ),
           ),
         ],
@@ -1145,6 +1260,41 @@ class _GymSectionLoading extends StatelessWidget {
           height: 24,
           child: CircularProgressIndicator(strokeWidth: 2.5),
         ),
+      ),
+    );
+  }
+}
+
+class _GymSectionError extends StatelessWidget {
+  const _GymSectionError({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations l = AppLocalizations.of(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: FigmaColors.hairline),
+        boxShadow: kCardShadow,
+      ),
+      child: Column(
+        children: <Widget>[
+          Text(
+            l.myGymLoadFailed,
+            textAlign: TextAlign.center,
+            style: const TextStyle(
+              fontSize: 12.5,
+              color: FigmaColors.textMuted,
+            ),
+          ),
+          const SizedBox(height: 12),
+          TextButton(onPressed: onRetry, child: Text(l.actionRetry)),
+        ],
       ),
     );
   }

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -2021,7 +2021,7 @@ abstract class AppLocalizations {
   /// No description provided for @exDefaultGymName.
   ///
   /// In en, this message translates to:
-  /// **'Gangnam Fitness Center'**
+  /// **'On-Care Gym Sinchon'**
   String get exDefaultGymName;
 
   /// No description provided for @exChatGreeting.
@@ -2125,6 +2125,72 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Cancel'**
   String get myCancel;
+
+  /// No description provided for @myTrainerGymTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'My Trainer & Gym'**
+  String get myTrainerGymTitle;
+
+  /// No description provided for @myConnectionDeleteTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove Connection'**
+  String get myConnectionDeleteTitle;
+
+  /// No description provided for @myDelete.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove'**
+  String get myDelete;
+
+  /// No description provided for @myGymDisconnectWithTrainerConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Disconnect {gym}?\nYour trainer link with {trainer} will also be removed.'**
+  String myGymDisconnectWithTrainerConfirm(String gym, String trainer);
+
+  /// No description provided for @myGymDisconnectConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Disconnect {gym}?'**
+  String myGymDisconnectConfirm(String gym);
+
+  /// No description provided for @myTrainerDisconnectConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Disconnect trainer {trainer}?\nYour connection to {gym} will remain.'**
+  String myTrainerDisconnectConfirm(String trainer, String gym);
+
+  /// No description provided for @myGymDisconnectTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Disconnect gym'**
+  String get myGymDisconnectTooltip;
+
+  /// No description provided for @myTrainerDisconnectTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Disconnect trainer'**
+  String get myTrainerDisconnectTooltip;
+
+  /// No description provided for @myNoTrainer.
+  ///
+  /// In en, this message translates to:
+  /// **'No assigned trainer'**
+  String get myNoTrainer;
+
+  /// No description provided for @myNoGymConnected.
+  ///
+  /// In en, this message translates to:
+  /// **'No gym connected yet'**
+  String get myNoGymConnected;
+
+  /// No description provided for @myGymLoadFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t load your gym connection.'**
+  String get myGymLoadFailed;
 
   /// No description provided for @mySave.
   ///

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -1056,7 +1056,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get exDefaultTrainerName => 'Trainer Kim';
 
   @override
-  String get exDefaultGymName => 'Gangnam Fitness Center';
+  String get exDefaultGymName => 'On-Care Gym Sinchon';
 
   @override
   String exChatGreeting(String trainer) {
@@ -1115,6 +1115,45 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get myCancel => 'Cancel';
+
+  @override
+  String get myTrainerGymTitle => 'My Trainer & Gym';
+
+  @override
+  String get myConnectionDeleteTitle => 'Remove Connection';
+
+  @override
+  String get myDelete => 'Remove';
+
+  @override
+  String myGymDisconnectWithTrainerConfirm(String gym, String trainer) {
+    return 'Disconnect $gym?\nYour trainer link with $trainer will also be removed.';
+  }
+
+  @override
+  String myGymDisconnectConfirm(String gym) {
+    return 'Disconnect $gym?';
+  }
+
+  @override
+  String myTrainerDisconnectConfirm(String trainer, String gym) {
+    return 'Disconnect trainer $trainer?\nYour connection to $gym will remain.';
+  }
+
+  @override
+  String get myGymDisconnectTooltip => 'Disconnect gym';
+
+  @override
+  String get myTrainerDisconnectTooltip => 'Disconnect trainer';
+
+  @override
+  String get myNoTrainer => 'No assigned trainer';
+
+  @override
+  String get myNoGymConnected => 'No gym connected yet';
+
+  @override
+  String get myGymLoadFailed => 'Couldn\'t load your gym connection.';
 
   @override
   String get mySave => 'Save';

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -1038,7 +1038,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get exDefaultTrainerName => '김트레이너';
 
   @override
-  String get exDefaultGymName => '강남 피트니스 센터';
+  String get exDefaultGymName => '온케어짐 신촌점';
 
   @override
   String exChatGreeting(String trainer) {
@@ -1096,6 +1096,45 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get myCancel => '취소';
+
+  @override
+  String get myTrainerGymTitle => '내 트레이너 · 헬스장';
+
+  @override
+  String get myConnectionDeleteTitle => '연결 삭제';
+
+  @override
+  String get myDelete => '삭제';
+
+  @override
+  String myGymDisconnectWithTrainerConfirm(String gym, String trainer) {
+    return '$gym 연결을 삭제하시겠습니까?\n담당 트레이너 $trainer 연결도 함께 해제됩니다.';
+  }
+
+  @override
+  String myGymDisconnectConfirm(String gym) {
+    return '$gym 연결을 삭제하시겠습니까?';
+  }
+
+  @override
+  String myTrainerDisconnectConfirm(String trainer, String gym) {
+    return '담당 트레이너 $trainer 연결을 삭제하시겠습니까?\n$gym 헬스장 연결은 유지됩니다.';
+  }
+
+  @override
+  String get myGymDisconnectTooltip => '헬스장 연결 삭제';
+
+  @override
+  String get myTrainerDisconnectTooltip => '트레이너 연결 삭제';
+
+  @override
+  String get myNoTrainer => '담당 트레이너 없음';
+
+  @override
+  String get myNoGymConnected => '아직 등록된 헬스장이 없어요';
+
+  @override
+  String get myGymLoadFailed => '헬스장 연결 정보를 불러오지 못했어요.';
 
   @override
   String get mySave => '저장';

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -558,7 +558,7 @@
   "exSpecialty": "Specialties",
   "exKakaoMapArea": "Kakao Map area",
   "exDefaultTrainerName": "Trainer Kim",
-  "exDefaultGymName": "Gangnam Fitness Center",
+  "exDefaultGymName": "On-Care Gym Sinchon",
   "exChatGreeting": "Hello, I'm {trainer}. 😊\nHow can I help you?",
   "@exChatGreeting": {
     "placeholders": {
@@ -597,6 +597,32 @@
   "myLogout": "Log out",
   "myLogoutConfirm": "Log out of your account?",
   "myCancel": "Cancel",
+  "myTrainerGymTitle": "My Trainer & Gym",
+  "myConnectionDeleteTitle": "Remove Connection",
+  "myDelete": "Remove",
+  "myGymDisconnectWithTrainerConfirm": "Disconnect {gym}?\nYour trainer link with {trainer} will also be removed.",
+  "@myGymDisconnectWithTrainerConfirm": {
+    "placeholders": {
+      "gym": {"type": "String"},
+      "trainer": {"type": "String"}
+    }
+  },
+  "myGymDisconnectConfirm": "Disconnect {gym}?",
+  "@myGymDisconnectConfirm": {
+    "placeholders": {"gym": {"type": "String"}}
+  },
+  "myTrainerDisconnectConfirm": "Disconnect trainer {trainer}?\nYour connection to {gym} will remain.",
+  "@myTrainerDisconnectConfirm": {
+    "placeholders": {
+      "trainer": {"type": "String"},
+      "gym": {"type": "String"}
+    }
+  },
+  "myGymDisconnectTooltip": "Disconnect gym",
+  "myTrainerDisconnectTooltip": "Disconnect trainer",
+  "myNoTrainer": "No assigned trainer",
+  "myNoGymConnected": "No gym connected yet",
+  "myGymLoadFailed": "Couldn't load your gym connection.",
   "mySave": "Save",
   "myProfileSaved": "Profile saved",
   "mySaveFailed": "Couldn't save. Please try again in a moment",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -327,7 +327,7 @@
   "exSpecialty": "전문 분야",
   "exKakaoMapArea": "카카오맵 영역",
   "exDefaultTrainerName": "김트레이너",
-  "exDefaultGymName": "강남 피트니스 센터",
+  "exDefaultGymName": "온케어짐 신촌점",
   "exChatGreeting": "안녕하세요, {trainer}입니다. 😊\n무엇을 도와드릴까요?",
   "exChatChipPt": "PT 상담",
   "exChatChipPass": "이용권 문의",
@@ -345,6 +345,32 @@
   "myLogout": "로그아웃",
   "myLogoutConfirm": "로그아웃 하시겠어요?",
   "myCancel": "취소",
+  "myTrainerGymTitle": "내 트레이너 · 헬스장",
+  "myConnectionDeleteTitle": "연결 삭제",
+  "myDelete": "삭제",
+  "myGymDisconnectWithTrainerConfirm": "{gym} 연결을 삭제하시겠습니까?\n담당 트레이너 {trainer} 연결도 함께 해제됩니다.",
+  "@myGymDisconnectWithTrainerConfirm": {
+    "placeholders": {
+      "gym": {"type": "String"},
+      "trainer": {"type": "String"}
+    }
+  },
+  "myGymDisconnectConfirm": "{gym} 연결을 삭제하시겠습니까?",
+  "@myGymDisconnectConfirm": {
+    "placeholders": {"gym": {"type": "String"}}
+  },
+  "myTrainerDisconnectConfirm": "담당 트레이너 {trainer} 연결을 삭제하시겠습니까?\n{gym} 헬스장 연결은 유지됩니다.",
+  "@myTrainerDisconnectConfirm": {
+    "placeholders": {
+      "trainer": {"type": "String"},
+      "gym": {"type": "String"}
+    }
+  },
+  "myGymDisconnectTooltip": "헬스장 연결 삭제",
+  "myTrainerDisconnectTooltip": "트레이너 연결 삭제",
+  "myNoTrainer": "담당 트레이너 없음",
+  "myNoGymConnected": "아직 등록된 헬스장이 없어요",
+  "myGymLoadFailed": "헬스장 연결 정보를 불러오지 못했어요.",
   "mySave": "저장",
   "myProfileSaved": "프로필이 저장되었어요",
   "mySaveFailed": "저장에 실패했어요. 잠시 후 다시 시도해 주세요",

--- a/frontend/flutter/test/features/my_health/my_health_gym_section_test.dart
+++ b/frontend/flutter/test/features/my_health/my_health_gym_section_test.dart
@@ -4,36 +4,60 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oncare/features/exercise/data/repositories/mock_gym_repository.dart';
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
+import 'package:oncare/features/exercise/domain/repositories/gym_repository.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/features/my_health/data/repositories/mock_my_health_repository.dart';
 import 'package:oncare/features/my_health/presentation/controllers/my_health_controller.dart';
 import 'package:oncare/features/my_health/presentation/pages/my_health_page.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 
-/// MY 탭의 "내 트레이너 · 헬스장" 카드는 이동이 아니라 연결 삭제 동작이다.
-/// 확인 창을 거쳐야만 삭제되는지, 취소하면 그대로인지 검증한다.
+class _FailingGymRepository implements GymRepository {
+  const _FailingGymRepository();
+
+  @override
+  Future<void> disconnectMyGym() async {}
+
+  @override
+  Future<void> disconnectMyTrainer() async {}
+
+  @override
+  Future<Gym?> fetchMyGym() => Future<Gym?>.error(StateError('boom'));
+
+  @override
+  Future<List<Gym>> fetchNearby() async => const <Gym>[];
+}
+
+/// MY 탭의 "내 트레이너 · 헬스장" 섹션은 헬스장 연결과 트레이너 연결을 각각
+/// 따로 끊을 수 있다. 확인 창을 거쳐야만 삭제되는지, 트레이너만 끊었을 때
+/// 헬스장은 남는지 검증한다.
 ///
 /// 저장소를 직접 await 하지 않는 이유: [MockGymRepository] 의 `Future.delayed`
 /// 는 위젯 테스트의 가상 시계에서 만료되지 않아 테스트가 멈춘다. 연결 상태는
 /// 이미 해소된 [myGymProvider] 를 통해 확인한다.
 void main() {
-  Future<void> pumpMyTab(WidgetTester tester) async {
+  Future<void> pumpMyTab(
+    WidgetTester tester, {
+    Locale locale = const Locale('ko'),
+    GymRepository? gymRepository,
+  }) async {
     await tester.binding.setSurfaceSize(const Size(390, 844));
     addTearDown(() => tester.binding.setSurfaceSize(null));
 
     await tester.pumpWidget(
       ProviderScope(
         overrides: <Override>[
-          gymRepositoryProvider.overrideWithValue(MockGymRepository()),
+          gymRepositoryProvider.overrideWithValue(
+            gymRepository ?? MockGymRepository(),
+          ),
           myHealthRepositoryProvider.overrideWithValue(
             const MockMyHealthRepository(),
           ),
         ],
-        child: const MaterialApp(
-          locale: Locale('ko'),
+        child: MaterialApp(
+          locale: locale,
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: MyHealthPage(),
+          home: const MyHealthPage(),
         ),
       ),
     );
@@ -50,27 +74,63 @@ void main() {
     ).read(myGymProvider.future);
   }
 
-  Future<void> tapGymCard(WidgetTester tester) async {
+  /// 헬스장 행 / 트레이너 행의 삭제 버튼은 툴팁으로 구분한다.
+  Future<void> tapRemove(WidgetTester tester, String tooltip) async {
     await tester.scrollUntilVisible(
       gymCard(),
       250,
       scrollable: find.byType(Scrollable).first,
     );
-    await tester.tap(gymCard());
+    await tester.tap(find.byTooltip(tooltip));
     await tester.pumpAndSettle();
   }
 
-  testWidgets('카드를 누르면 삭제 확인 창이 뜬다', (WidgetTester tester) async {
+  testWidgets('연결된 헬스장과 담당 트레이너가 트레이너 앱 시드와 같다', (WidgetTester tester) async {
     await pumpMyTab(tester);
-    await tapGymCard(tester);
+    await tester.scrollUntilVisible(
+      gymCard(),
+      250,
+      scrollable: find.byType(Scrollable).first,
+    );
+
+    expect(find.text('온케어짐 신촌점'), findsOneWidget);
+    expect(find.text('김트레이너 · 퍼스널 트레이너'), findsOneWidget);
+  });
+
+  testWidgets('영어 로케일에서 섹션 액션이 영어로 표시된다', (WidgetTester tester) async {
+    await pumpMyTab(tester, locale: const Locale('en'));
+    await tester.scrollUntilVisible(
+      gymCard(),
+      250,
+      scrollable: find.byType(Scrollable).first,
+    );
+
+    expect(find.text('My Trainer & Gym'), findsOneWidget);
+    expect(find.byTooltip('Disconnect gym'), findsOneWidget);
+    expect(find.byTooltip('Disconnect trainer'), findsOneWidget);
+    expect(find.text('내 트레이너 · 헬스장'), findsNothing);
+  });
+
+  testWidgets('헬스장 연결 조회 실패 시 재시도 상태를 표시한다', (WidgetTester tester) async {
+    await pumpMyTab(tester, gymRepository: const _FailingGymRepository());
+
+    expect(find.text('헬스장 연결 정보를 불러오지 못했어요.'), findsOneWidget);
+    expect(find.text('다시 시도'), findsOneWidget);
+    expect(find.text('아직 등록된 헬스장이 없어요'), findsNothing);
+  });
+
+  testWidgets('헬스장 삭제 버튼은 트레이너도 함께 해제된다고 알린다', (WidgetTester tester) async {
+    await pumpMyTab(tester);
+    await tapRemove(tester, '헬스장 연결 삭제');
 
     expect(find.byType(AlertDialog), findsOneWidget);
-    expect(find.text('강남 피트니스 센터 연결을 삭제하시겠습니까?'), findsOneWidget);
+    expect(find.textContaining('온케어짐 신촌점 연결을 삭제하시겠습니까?'), findsOneWidget);
+    expect(find.textContaining('김트레이너 연결도 함께 해제됩니다'), findsOneWidget);
   });
 
   testWidgets('취소하면 연결이 유지된다', (WidgetTester tester) async {
     await pumpMyTab(tester);
-    await tapGymCard(tester);
+    await tapRemove(tester, '헬스장 연결 삭제');
 
     await tester.tap(find.text('취소'));
     await tester.pumpAndSettle();
@@ -80,9 +140,9 @@ void main() {
     expect(await connectedGym(tester), isNotNull);
   });
 
-  testWidgets('삭제하면 카드가 빈 상태로 바뀌고 연결도 해제된다', (WidgetTester tester) async {
+  testWidgets('헬스장을 삭제하면 카드가 빈 상태로 바뀐다', (WidgetTester tester) async {
     await pumpMyTab(tester);
-    await tapGymCard(tester);
+    await tapRemove(tester, '헬스장 연결 삭제');
 
     await tester.tap(find.text('삭제'));
     await tester.pumpAndSettle();
@@ -91,5 +151,35 @@ void main() {
     expect(find.text('아직 등록된 헬스장이 없어요'), findsOneWidget);
     // 운동 탭도 같은 provider 를 읽으므로 그쪽에서도 연결이 사라진다.
     expect(await connectedGym(tester), isNull);
+  });
+
+  testWidgets('트레이너만 삭제하면 헬스장 연결은 남는다', (WidgetTester tester) async {
+    await pumpMyTab(tester);
+    await tapRemove(tester, '트레이너 연결 삭제');
+
+    expect(find.textContaining('김트레이너 연결을 삭제하시겠습니까?'), findsOneWidget);
+    expect(find.textContaining('헬스장 연결은 유지됩니다'), findsOneWidget);
+
+    await tester.tap(find.text('삭제'));
+    await tester.pumpAndSettle();
+
+    expect(gymCard(), findsOneWidget);
+    expect(find.text('온케어짐 신촌점'), findsOneWidget);
+    expect(find.text('담당 트레이너 없음'), findsOneWidget);
+    expect(find.text('트레이너 찾기'), findsOneWidget);
+
+    final Gym? gym = await connectedGym(tester);
+    expect(gym, isNotNull);
+    expect(gym!.trainerName, isNull);
+  });
+
+  testWidgets('트레이너를 뗀 뒤에는 트레이너 삭제 버튼이 사라진다', (WidgetTester tester) async {
+    await pumpMyTab(tester);
+    await tapRemove(tester, '트레이너 연결 삭제');
+    await tester.tap(find.text('삭제'));
+    await tester.pumpAndSettle();
+
+    expect(find.byTooltip('트레이너 연결 삭제'), findsNothing);
+    expect(find.byTooltip('헬스장 연결 삭제'), findsOneWidget);
   });
 }

--- a/frontend/flutter/test/features/my_health/my_health_gym_section_test.dart
+++ b/frontend/flutter/test/features/my_health/my_health_gym_section_test.dart
@@ -35,6 +35,19 @@ class _FailingGymRepository implements GymRepository {
 /// 는 위젯 테스트의 가상 시계에서 만료되지 않아 테스트가 멈춘다. 연결 상태는
 /// 이미 해소된 [myGymProvider] 를 통해 확인한다.
 void main() {
+  test('트레이너 해제 상태가 주변 헬스장 조회에도 반영된다', () async {
+    final MockGymRepository repository = MockGymRepository();
+
+    await repository.disconnectMyTrainer();
+    final List<Gym> nearby = await repository.fetchNearby();
+    final Gym connectedGym = nearby.firstWhere(
+      (Gym gym) => gym.id == 'gym-oncare-sinchon',
+    );
+
+    expect(connectedGym.trainerName, isNull);
+    expect(connectedGym.trainerRole, isNull);
+  });
+
   Future<void> pumpMyTab(
     WidgetTester tester, {
     Locale locale = const Locale('ko'),

--- a/frontend/flutter/test/features/my_health/my_health_gym_section_test.dart
+++ b/frontend/flutter/test/features/my_health/my_health_gym_section_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/exercise/data/repositories/mock_gym_repository.dart';
+import 'package:oncare/features/exercise/domain/entities/gym.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/features/my_health/data/repositories/mock_my_health_repository.dart';
+import 'package:oncare/features/my_health/presentation/controllers/my_health_controller.dart';
+import 'package:oncare/features/my_health/presentation/pages/my_health_page.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+/// MY 탭의 "내 트레이너 · 헬스장" 카드는 이동이 아니라 연결 삭제 동작이다.
+/// 확인 창을 거쳐야만 삭제되는지, 취소하면 그대로인지 검증한다.
+///
+/// 저장소를 직접 await 하지 않는 이유: [MockGymRepository] 의 `Future.delayed`
+/// 는 위젯 테스트의 가상 시계에서 만료되지 않아 테스트가 멈춘다. 연결 상태는
+/// 이미 해소된 [myGymProvider] 를 통해 확인한다.
+void main() {
+  Future<void> pumpMyTab(WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          gymRepositoryProvider.overrideWithValue(MockGymRepository()),
+          myHealthRepositoryProvider.overrideWithValue(
+            const MockMyHealthRepository(),
+          ),
+        ],
+        child: const MaterialApp(
+          locale: Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: MyHealthPage(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Finder gymCard() => find.byWidgetPredicate(
+    (Widget widget) => widget.runtimeType.toString() == '_GymSummaryCard',
+  );
+
+  Future<Gym?> connectedGym(WidgetTester tester) {
+    return ProviderScope.containerOf(
+      tester.element(find.byType(MyHealthPage)),
+    ).read(myGymProvider.future);
+  }
+
+  Future<void> tapGymCard(WidgetTester tester) async {
+    await tester.scrollUntilVisible(
+      gymCard(),
+      250,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.tap(gymCard());
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('카드를 누르면 삭제 확인 창이 뜬다', (WidgetTester tester) async {
+    await pumpMyTab(tester);
+    await tapGymCard(tester);
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.text('강남 피트니스 센터 연결을 삭제하시겠습니까?'), findsOneWidget);
+  });
+
+  testWidgets('취소하면 연결이 유지된다', (WidgetTester tester) async {
+    await pumpMyTab(tester);
+    await tapGymCard(tester);
+
+    await tester.tap(find.text('취소'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsNothing);
+    expect(gymCard(), findsOneWidget);
+    expect(await connectedGym(tester), isNotNull);
+  });
+
+  testWidgets('삭제하면 카드가 빈 상태로 바뀌고 연결도 해제된다', (WidgetTester tester) async {
+    await pumpMyTab(tester);
+    await tapGymCard(tester);
+
+    await tester.tap(find.text('삭제'));
+    await tester.pumpAndSettle();
+
+    expect(gymCard(), findsNothing);
+    expect(find.text('아직 등록된 헬스장이 없어요'), findsOneWidget);
+    // 운동 탭도 같은 provider 를 읽으므로 그쪽에서도 연결이 사라진다.
+    expect(await connectedGym(tester), isNull);
+  });
+}


### PR DESCRIPTION
## Summary

* MY 탭에 "내 트레이너 · 헬스장" 섹션을 추가해 연결된 헬스장과 담당 트레이너를 한눈에 확인할 수 있도록 했습니다.
* 헬스장과 트레이너 연결을 각각 삭제할 수 있으며, 헬스장 연결 삭제 시 담당 트레이너 연결도 함께 해제됩니다.
* `GymRepository`에 연결 해제 API를 추가하고, 세션 동안 하나의 mock 저장소 인스턴스를 공유해 MY 탭과 운동 탭의 연결 상태를 동기화했습니다.
* 연결 없음, 로딩, 조회 실패 상태를 구분하고 연결이 없을 때 운동 탭의 헬스장 화면으로 이동할 수 있도록 했습니다.

---

## Changes

### ✨ Features

* MY 탭에 `_TrainerGymSection`을 추가했습니다.
* 헬스장 연결 삭제와 트레이너 연결 삭제를 각각 지원합니다.
* 헬스장만 연결된 경우 "트레이너 찾기" 액션을 제공합니다.
* 조회 실패 시 오류 메시지와 재시도 액션을 제공합니다.

### 🔧 Improvements

* `GymRepository`에 `disconnectMyGym()`과 `disconnectMyTrainer()`를 추가했습니다.
* `MockGymRepository`를 상태 보유형으로 변경해 두 탭이 동일한 연결 상태를 사용하도록 했습니다.
* 헬스장 연결 삭제 시 트레이너 연결도 함께 해제하고, 트레이너만 삭제하면 헬스장 연결은 유지합니다.
* 사용자 앱과 트레이너 앱의 demo 관계가 일치하도록 기본 연결을 `온케어짐 신촌점`과 `김트레이너`로 정렬했습니다.

### 🎨 UI/UX

* 헬스장과 트레이너를 카드 안에서 별도 행으로 표시하고 각각 삭제 버튼을 제공합니다.
* 삭제 확인 창에서 삭제 액션만 붉은색으로 표시하고 취소를 기본 안전 동작으로 유지합니다.
* 삭제 버튼의 시각적 아이콘은 20px, 터치 영역은 44×44px로 구성했습니다.
* 신규 문구와 확인 메시지, 버튼, 툴팁을 한국어·영어 ARB로 현지화했습니다.

### 🐛 Fixes

* 연결 해제 완료 전에 탭을 벗어난 경우 폐기된 위젯에서 provider를 갱신하지 않도록 `context.mounted`를 확인합니다.
* 헬스장 조회 오류를 연결 없음으로 잘못 표시하지 않고 재시도 가능한 오류 상태로 구분했습니다.
* 데모 모드 대시보드가 로컬 일정·식단·운동 데이터를 계속 반영하도록 기존 `DioDashboardRepository`와 `LocalApiInterceptor` 경로를 유지했습니다.

---

## Commits

1. `7822735` feat(my): add trainer and gym management section to MY tab
2. `41ae50d` feat(my-health): make MY tab gym card delete the link instead of navigating
3. `d7d8ef6` feat(my-health): manage gym and trainer links separately, align gym to 신촌

---

## Notes

* 백엔드 `/gyms/*` 엔드포인트가 아직 없어 `MockGymRepository`로 동작합니다.
* 삭제 상태는 세션 동안 유지되며 앱 재시작 시 초기화됩니다. 실제 저장소 연동 시 `disconnectMyGym()`과 `disconnectMyTrainer()`를 구현하면 됩니다.
* `MockGymRepository`의 지연 응답을 직접 await하지 않고, 위젯 테스트에서는 갱신된 `myGymProvider`를 통해 연결 상태를 검증합니다.
* API 서버 및 데이터베이스 스키마 변경은 없습니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] UI 확인
* [ ] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 앱을 실행하고 로그인 없이 데모 둘러보기에 진입합니다.
2. MY 탭에서 `온케어짐 신촌점`과 `김트레이너 · 퍼스널 트레이너`가 표시되는지 확인합니다.
3. 헬스장 삭제 버튼을 누르고 취소하면 두 연결이 유지되는지 확인합니다.
4. 트레이너 연결만 삭제하면 헬스장은 유지되고 "담당 트레이너 없음" 상태로 변경되는지 확인합니다.
5. 초기 상태에서 헬스장 연결을 삭제하면 트레이너 연결도 함께 해제되고 빈 상태 카드가 표시되는지 확인합니다.
6. 운동 탭의 헬스장 화면에서도 동일한 연결 상태가 반영되는지 확인합니다.
7. 영어 로케일에서 섹션 문구와 삭제 액션이 영어로 표시되는지 확인합니다.

---

## Related Issues

Closes #373 

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * MY 화면에서 연결된 헬스장과 트레이너 정보를 확인할 수 있습니다.
  * 헬스장 연결 해제와 트레이너 개별 해제를 지원합니다.
  * 해제 전 확인 및 취소 대화상자를 제공합니다.
  * 연결 정보의 로딩, 오류, 재시도, 미연결 상태를 표시합니다.
  * 헬스장 검색 화면으로 바로 이동할 수 있습니다.

* **개선 사항**
  * 기본 헬스장이 ‘온케어짐 신촌점’으로 변경되었습니다.
  * 헬스장·트레이너 연결 관리 관련 한국어와 영어 안내 문구를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->