### PR TITLE
feat(diet): 오늘의 영양 요약 시각화를 개선

### DIFF
--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -1,5 +1,3 @@
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -498,21 +496,19 @@ class NutritionSummary extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 10),
-          Container(
-            padding: const EdgeInsets.all(16),
-            decoration: BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.circular(20),
-              boxShadow: kCardShadow,
-            ),
-            child: _CircularNutritionCard(
-              calories: items[0],
-              sodium: items[1],
-              sugar: items[2],
-              protein: items[3],
-              fat: items[4],
-              carbs: items[5],
-            ),
+          _NutritionSummaryCard(
+            calories: items[0],
+            calorieDifference: _formatInt((kcal - _calorieGoal).abs().round()),
+            carbs: items[5],
+            protein: items[3],
+            fat: items[4],
+          ),
+          const SizedBox(height: 12),
+          _NutritionStatusCards(
+            sodium: items[1],
+            sodiumDifference: _formatInt((sodium - _sodiumGoal).abs().round()),
+            sugar: items[2],
+            sugarDifference: _formatG((sugar - _sugarGoal).abs()),
           ),
         ],
       ),
@@ -543,153 +539,190 @@ class _NutritionSummaryItem {
   final bool isOverGoal;
 }
 
-class _CircularNutritionCard extends StatelessWidget {
-  const _CircularNutritionCard({
+class _NutritionSummaryCard extends StatelessWidget {
+  const _NutritionSummaryCard({
     required this.calories,
-    required this.sodium,
-    required this.sugar,
+    required this.calorieDifference,
     required this.carbs,
     required this.protein,
     required this.fat,
   });
 
   final _NutritionSummaryItem calories;
-  final _NutritionSummaryItem sodium;
-  final _NutritionSummaryItem sugar;
+  final String calorieDifference;
   final _NutritionSummaryItem carbs;
   final _NutritionSummaryItem protein;
   final _NutritionSummaryItem fat;
 
   @override
   Widget build(BuildContext context) {
-    final List<_MacroProgress> macros = <_MacroProgress>[
-      _MacroProgress(item: carbs, color: FigmaColors.primary),
-      _MacroProgress(item: protein, color: FigmaColors.sleepPurple),
-      _MacroProgress(item: fat, color: FigmaColors.green),
+    final Color macroProgressColor = FigmaColors.primaryA(0.65);
+    final List<_MacroProgressData> macros = <_MacroProgressData>[
+      _MacroProgressData(item: carbs, color: macroProgressColor),
+      _MacroProgressData(item: protein, color: macroProgressColor),
+      _MacroProgressData(item: fat, color: macroProgressColor),
     ];
-
-    return Column(
-      key: const Key('nutrition-circular-summary'),
-      children: <Widget>[
-        LayoutBuilder(
-          builder: (BuildContext context, BoxConstraints constraints) {
-            final double graphSize = (constraints.maxWidth * 0.58).clamp(
-              172.0,
-              190.0,
-            );
-            final double gap = (constraints.maxWidth * 0.02).clamp(6.0, 10.0);
-            final double legendWidth = math.min(
-              140,
-              constraints.maxWidth - graphSize - gap,
-            );
-            return Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                SizedBox(
-                  width: legendWidth,
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: <Widget>[
-                      for (final _MacroProgress macro in macros) ...<Widget>[
-                        _MacroLegendItem(macro: macro),
-                        if (macro != macros.last) const SizedBox(height: 16),
-                      ],
+    final AppLocalizations l = AppLocalizations.of(context);
+    final Color calorieColor = calories.isOverGoal
+        ? FigmaColors.dangerRed
+        : FigmaColors.primary;
+    final String calorieStatus = calories.isOverGoal
+        ? l.dietAmountOver('$calorieDifference ${calories.unit}')
+        : l.dietAmountRemaining('$calorieDifference ${calories.unit}');
+    return Container(
+      key: const Key('nutrition-summary-card'),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: kCardShadow,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      l.homeCalorieIntake,
+                      style: const TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w600,
+                        color: FigmaColors.textSub,
+                      ),
+                    ),
+                    const SizedBox(height: 5),
+                    FittedBox(
+                      fit: BoxFit.scaleDown,
+                      alignment: Alignment.centerLeft,
+                      child: Text.rich(
+                        TextSpan(
+                          children: <InlineSpan>[
+                            TextSpan(
+                              text: calories.value,
+                              style: TextStyle(
+                                fontSize: 24,
+                                fontWeight: FontWeight.w800,
+                                color: calorieColor,
+                                letterSpacing: -0.5,
+                              ),
+                            ),
+                            TextSpan(
+                              text: ' / ${calories.goal} ${calories.unit}',
+                              style: const TextStyle(
+                                fontSize: 13,
+                                fontWeight: FontWeight.w600,
+                                color: FigmaColors.textMuted,
+                              ),
+                            ),
+                          ],
+                        ),
+                        maxLines: 1,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      calorieStatus,
+                      style: TextStyle(
+                        fontSize: 10,
+                        fontWeight: FontWeight.w600,
+                        color: calories.isOverGoal
+                            ? FigmaColors.dangerRed
+                            : FigmaColors.textSub,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 14),
+              _CalorieCircularProgress(calories: calories, color: calorieColor),
+            ],
+          ),
+          const SizedBox(height: 16),
+          const Divider(height: 1, thickness: 1, color: FigmaColors.hairline),
+          const SizedBox(height: 14),
+          LayoutBuilder(
+            builder: (BuildContext context, BoxConstraints constraints) {
+              if (constraints.maxWidth < 280) {
+                return Column(
+                  children: <Widget>[
+                    for (final _MacroProgressData macro in macros) ...<Widget>[
+                      _MacroProgressItem(macro: macro),
+                      if (macro != macros.last) const SizedBox(height: 12),
                     ],
-                  ),
-                ),
-                SizedBox(width: gap),
-                _CircularNutritionGraph(
-                  calories: calories,
-                  macros: macros,
-                  size: graphSize,
-                ),
-              ],
-            );
-          },
-        ),
-        const SizedBox(height: 14),
-        const Divider(height: 1, thickness: 1, color: FigmaColors.hairline),
-        const SizedBox(height: 12),
-        Row(
-          children: <Widget>[
-            Expanded(child: _NutritionStatusItem(item: sodium)),
-            const SizedBox(width: 8),
-            Expanded(child: _NutritionStatusItem(item: sugar)),
-          ],
-        ),
-      ],
+                  ],
+                );
+              }
+              return Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  for (
+                    int index = 0;
+                    index < macros.length;
+                    index++
+                  ) ...<Widget>[
+                    Expanded(child: _MacroProgressItem(macro: macros[index])),
+                    if (index < macros.length - 1) const SizedBox(width: 10),
+                  ],
+                ],
+              );
+            },
+          ),
+        ],
+      ),
     );
   }
 }
 
-class _CircularNutritionGraph extends StatelessWidget {
-  const _CircularNutritionGraph({
-    required this.calories,
-    required this.macros,
-    required this.size,
-  });
+class _CalorieCircularProgress extends StatelessWidget {
+  const _CalorieCircularProgress({required this.calories, required this.color});
 
   final _NutritionSummaryItem calories;
-  final List<_MacroProgress> macros;
-  final double size;
+  final Color color;
 
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
-    final Color calorieColor = calories.isOverGoal
-        ? FigmaColors.dangerRed
-        : FigmaColors.ink;
     return SizedBox.square(
-      dimension: size,
+      dimension: 92,
       child: Stack(
         alignment: Alignment.center,
         children: <Widget>[
-          CustomPaint(
-            size: Size.square(size),
-            painter: _ConcentricNutritionRingPainter(macros),
+          SizedBox.square(
+            dimension: 92,
+            child: CircularProgressIndicator(
+              key: const Key('nutrition-calorie-progress'),
+              value: calories.ratio,
+              strokeWidth: 9,
+              strokeCap: StrokeCap.round,
+              backgroundColor: FigmaColors.track,
+              valueColor: AlwaysStoppedAnimation<Color>(color),
+            ),
           ),
           Column(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               Text(
-                calories.label,
-                style: const TextStyle(
-                  fontSize: 10,
-                  fontWeight: FontWeight.w600,
-                  color: FigmaColors.textSub,
-                ),
-              ),
-              const SizedBox(height: 3),
-              Text(
-                '${calories.value} ${calories.unit}',
+                '${(calories.ratio * 100).round()}%',
                 style: TextStyle(
-                  fontSize: 21,
+                  fontSize: 18,
                   fontWeight: FontWeight.w800,
-                  color: calorieColor,
+                  color: color,
                   height: 1,
-                  letterSpacing: -0.5,
                 ),
               ),
-              const SizedBox(height: 5),
+              const SizedBox(height: 4),
               Text(
-                '${l.homeGoal} ${calories.goal} ${calories.unit}',
+                l.homeAchieveRate,
                 style: const TextStyle(
-                  fontSize: 9.5,
+                  fontSize: 9,
                   fontWeight: FontWeight.w600,
                   color: FigmaColors.textMuted,
                 ),
               ),
-              if (calories.isOverGoal) ...<Widget>[
-                const SizedBox(height: 3),
-                Text(
-                  '${l.homeGoal} ${l.homeMetricOver}',
-                  style: const TextStyle(
-                    fontSize: 9,
-                    fontWeight: FontWeight.w700,
-                    color: FigmaColors.dangerRed,
-                  ),
-                ),
-              ],
             ],
           ),
         ],
@@ -698,92 +731,176 @@ class _CircularNutritionGraph extends StatelessWidget {
   }
 }
 
-class _MacroProgress {
-  const _MacroProgress({required this.item, required this.color});
+class _MacroProgressData {
+  const _MacroProgressData({required this.item, required this.color});
 
   final _NutritionSummaryItem item;
   final Color color;
 }
 
-class _MacroLegendItem extends StatelessWidget {
-  const _MacroLegendItem({required this.macro});
+class _MacroProgressItem extends StatelessWidget {
+  const _MacroProgressItem({required this.macro});
 
-  final _MacroProgress macro;
+  final _MacroProgressData macro;
 
   @override
   Widget build(BuildContext context) {
-    final AppLocalizations l = AppLocalizations.of(context);
-    return Row(
+    return Column(
+      key: Key('nutrition-macro-${macro.item.label}'),
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Container(
-          width: 8,
-          height: 8,
-          margin: const EdgeInsets.only(top: 3),
-          decoration: BoxDecoration(color: macro.color, shape: BoxShape.circle),
-        ),
-        const SizedBox(width: 6),
-        Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Text(
-                macro.item.label,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
-                  fontSize: 10,
-                  fontWeight: FontWeight.w600,
-                  color: FigmaColors.textSub,
-                ),
-              ),
-              const SizedBox(height: 2),
-              FittedBox(
-                fit: BoxFit.scaleDown,
-                alignment: Alignment.centerLeft,
-                child: Text.rich(
-                  TextSpan(
-                    children: <InlineSpan>[
-                      TextSpan(
-                        text: macro.item.value,
-                        style: TextStyle(
-                          fontSize: 12,
-                          fontWeight: FontWeight.w800,
-                          color: macro.item.isOverGoal
-                              ? FigmaColors.dangerRed
-                              : macro.color,
-                        ),
-                      ),
-                      TextSpan(
-                        text: ' /${macro.item.goal}${macro.item.unit}',
-                        style: kGoalSuffixStyle,
-                      ),
-                    ],
-                  ),
-                  maxLines: 1,
-                ),
-              ),
-              if (macro.item.isOverGoal)
-                Text(
-                  '${l.homeGoal} ${l.homeMetricOver}',
-                  style: const TextStyle(
-                    fontSize: 9,
-                    fontWeight: FontWeight.w700,
-                    color: FigmaColors.dangerRed,
-                  ),
-                ),
-            ],
+        Text(
+          macro.item.label,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: const TextStyle(
+            fontSize: 10,
+            fontWeight: FontWeight.w700,
+            color: FigmaColors.textSub,
           ),
+        ),
+        const SizedBox(height: 4),
+        FittedBox(
+          fit: BoxFit.scaleDown,
+          alignment: Alignment.centerLeft,
+          child: Text.rich(
+            TextSpan(
+              children: <InlineSpan>[
+                TextSpan(
+                  text: macro.item.value,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w800,
+                    color: FigmaColors.ink,
+                  ),
+                ),
+                TextSpan(
+                  text: ' / ${macro.item.goal}${macro.item.unit}',
+                  style: kGoalSuffixStyle,
+                ),
+              ],
+            ),
+            maxLines: 1,
+          ),
+        ),
+        const SizedBox(height: 7),
+        _NutritionProgressBar(
+          key: Key('nutrition-macro-progress-${macro.item.label}'),
+          progress: macro.item.ratio,
+          color: macro.color,
         ),
       ],
     );
   }
 }
 
-class _NutritionStatusItem extends StatelessWidget {
-  const _NutritionStatusItem({required this.item});
+class _NutritionProgressBar extends StatelessWidget {
+  const _NutritionProgressBar({
+    required this.progress,
+    required this.color,
+    super.key,
+  });
+
+  final double progress;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    const double barHeight = 6;
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        return ClipRRect(
+          borderRadius: BorderRadius.circular(999),
+          child: SizedBox(
+            height: barHeight,
+            child: Stack(
+              children: <Widget>[
+                const Positioned.fill(
+                  child: ColoredBox(color: FigmaColors.track),
+                ),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: SizedBox(
+                    width: constraints.maxWidth * progress.clamp(0.0, 1.0),
+                    height: barHeight,
+                    child: ColoredBox(color: color),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _NutritionStatusCards extends StatelessWidget {
+  const _NutritionStatusCards({
+    required this.sodium,
+    required this.sodiumDifference,
+    required this.sugar,
+    required this.sugarDifference,
+  });
+
+  final _NutritionSummaryItem sodium;
+  final String sodiumDifference;
+  final _NutritionSummaryItem sugar;
+  final String sugarDifference;
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget sodiumCard = _NutritionStatusCard(
+      key: const Key('nutrition-sodium-status'),
+      item: sodium,
+      difference: sodiumDifference,
+      progressColor: sodium.isOverGoal
+          ? FigmaColors.dangerRed
+          : FigmaColors.primaryDeep,
+    );
+    final Widget sugarCard = _NutritionStatusCard(
+      key: const Key('nutrition-sugar-status'),
+      item: sugar,
+      difference: sugarDifference,
+      progressColor: sugar.isOverGoal
+          ? FigmaColors.dangerRed
+          : FigmaColors.greenText,
+    );
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        if (constraints.maxWidth < 310) {
+          return Column(
+            children: <Widget>[
+              sodiumCard,
+              const SizedBox(height: 10),
+              sugarCard,
+            ],
+          );
+        }
+        return Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Expanded(child: sodiumCard),
+            const SizedBox(width: 10),
+            Expanded(child: sugarCard),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _NutritionStatusCard extends StatelessWidget {
+  const _NutritionStatusCard({
+    required this.item,
+    required this.difference,
+    required this.progressColor,
+    super.key,
+  });
 
   final _NutritionSummaryItem item;
+  final String difference;
+  final Color progressColor;
 
   @override
   Widget build(BuildContext context) {
@@ -791,65 +908,120 @@ class _NutritionStatusItem extends StatelessWidget {
     final Color statusColor = item.isOverGoal
         ? FigmaColors.dangerRed
         : FigmaColors.greenText;
+    final String differenceText = item.isOverGoal
+        ? l.dietAmountOver('$difference${item.unit}')
+        : l.dietAmountRemaining('$difference${item.unit}');
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 9),
+      padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
-        color: FigmaColors.statBg,
-        borderRadius: BorderRadius.circular(12),
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: item.isOverGoal
+              ? FigmaColors.dangerRed.withValues(alpha: 0.32)
+              : FigmaColors.primaryA(0.18),
+        ),
+        boxShadow: kCardShadow,
       ),
-      child: Column(
+      child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          Text(
-            item.label,
-            style: const TextStyle(
-              fontSize: 10,
-              fontWeight: FontWeight.w600,
-              color: FigmaColors.textSub,
-            ),
+          _VerticalNutritionProgressBar(
+            key: Key('nutrition-status-vertical-progress-${item.label}'),
+            progress: item.ratio,
+            color: progressColor,
           ),
-          const SizedBox(height: 3),
-          FittedBox(
-            fit: BoxFit.scaleDown,
-            alignment: Alignment.centerLeft,
-            child: Text.rich(
-              TextSpan(
-                children: <InlineSpan>[
-                  TextSpan(
-                    text: item.value,
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    Icon(
+                      item.isOverGoal
+                          ? Icons.warning_amber_rounded
+                          : Icons.check_circle_outline_rounded,
+                      size: 16,
+                      color: statusColor,
+                    ),
+                    const SizedBox(width: 5),
+                    Expanded(
+                      child: Text(
+                        item.label,
+                        style: const TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w700,
+                          color: FigmaColors.textSub,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 7),
+                FittedBox(
+                  fit: BoxFit.scaleDown,
+                  alignment: Alignment.centerLeft,
+                  child: Text.rich(
+                    TextSpan(
+                      children: <InlineSpan>[
+                        TextSpan(
+                          text: item.value,
+                          style: TextStyle(
+                            fontSize: 17,
+                            fontWeight: FontWeight.w800,
+                            color: item.isOverGoal
+                                ? FigmaColors.dangerRed
+                                : FigmaColors.ink,
+                          ),
+                        ),
+                        TextSpan(
+                          text: ' / ${item.goal}${item.unit}',
+                          style: const TextStyle(
+                            fontSize: 10,
+                            fontWeight: FontWeight.w600,
+                            color: FigmaColors.textMuted,
+                          ),
+                        ),
+                      ],
+                    ),
+                    maxLines: 1,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 3,
+                  ),
+                  decoration: BoxDecoration(
+                    color: statusColor.withValues(alpha: 0.12),
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                  child: Text(
+                    item.isOverGoal
+                        ? '${l.homeGoal} ${l.homeMetricOver}'
+                        : l.homeMetricNormal,
                     style: TextStyle(
-                      fontSize: 12,
+                      fontSize: 10,
                       fontWeight: FontWeight.w800,
-                      color: item.isOverGoal
-                          ? FigmaColors.dangerRed
-                          : FigmaColors.ink,
+                      color: statusColor,
                     ),
                   ),
-                  TextSpan(
-                    text: ' /${item.goal}${item.unit}',
-                    style: kGoalSuffixStyle,
+                ),
+                const SizedBox(height: 7),
+                Text(
+                  differenceText,
+                  style: TextStyle(
+                    fontSize: 10,
+                    fontWeight: FontWeight.w600,
+                    color: item.isOverGoal
+                        ? FigmaColors.dangerRed
+                        : FigmaColors.textBody,
+                    height: 1.3,
                   ),
-                ],
-              ),
-              maxLines: 1,
-            ),
-          ),
-          const SizedBox(height: 5),
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-            decoration: BoxDecoration(
-              color: statusColor.withValues(alpha: 0.12),
-              borderRadius: BorderRadius.circular(999),
-            ),
-            child: Text(
-              item.isOverGoal
-                  ? '${l.homeGoal} ${l.homeMetricOver}'
-                  : l.homeMetricNormal,
-              style: TextStyle(
-                fontSize: 9,
-                fontWeight: FontWeight.w700,
-                color: statusColor,
-              ),
+                ),
+              ],
             ),
           ),
         ],
@@ -858,95 +1030,40 @@ class _NutritionStatusItem extends StatelessWidget {
   }
 }
 
-class _ConcentricNutritionRingPainter extends CustomPainter {
-  const _ConcentricNutritionRingPainter(this.macros);
+class _VerticalNutritionProgressBar extends StatelessWidget {
+  const _VerticalNutritionProgressBar({
+    required this.progress,
+    required this.color,
+    super.key,
+  });
 
-  final List<_MacroProgress> macros;
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final double strokeWidth = (size.shortestSide * 0.055).clamp(8.0, 10.5);
-    final double radiusStep = strokeWidth + 5;
-    final Offset center = Offset(size.width / 2, size.height / 2);
-    final double outerRadius = (size.shortestSide - strokeWidth) / 2;
-    final double middleRadius = outerRadius - radiusStep;
-    final double innerRadius = middleRadius - radiusStep;
-    final _MacroProgress carbsRing = macros[0];
-    final _MacroProgress proteinRing = macros[1];
-    final _MacroProgress fatRing = macros[2];
-
-    // 목표량 규모를 기준으로 탄수화물은 바깥, 단백질은 가운데, 지방은 안쪽에 고정한다.
-    _drawProgressRing(
-      canvas: canvas,
-      center: center,
-      radius: outerRadius,
-      progress: carbsRing.item.ratio,
-      progressColor: carbsRing.color,
-      strokeWidth: strokeWidth,
-    );
-    _drawProgressRing(
-      canvas: canvas,
-      center: center,
-      radius: middleRadius,
-      progress: proteinRing.item.ratio,
-      progressColor: proteinRing.color,
-      strokeWidth: strokeWidth,
-    );
-    _drawProgressRing(
-      canvas: canvas,
-      center: center,
-      radius: innerRadius,
-      progress: fatRing.item.ratio,
-      progressColor: fatRing.color,
-      strokeWidth: strokeWidth,
-    );
-  }
-
-  void _drawProgressRing({
-    required Canvas canvas,
-    required Offset center,
-    required double radius,
-    required double progress,
-    required Color progressColor,
-    required double strokeWidth,
-  }) {
-    final Rect ringRect = Rect.fromCircle(center: center, radius: radius);
-    canvas.drawCircle(
-      center,
-      radius,
-      Paint()
-        ..color = FigmaColors.track.withValues(alpha: 0.55)
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = strokeWidth
-        ..strokeCap = StrokeCap.round,
-    );
-
-    if (progress <= 0) return;
-    const double startAngle = -math.pi / 2;
-    final double sweepAngle = 2 * math.pi * progress.clamp(0.0, 1.0);
-    canvas.drawArc(
-      ringRect,
-      startAngle,
-      sweepAngle,
-      false,
-      Paint()
-        ..color = progressColor
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = strokeWidth
-        ..strokeCap = StrokeCap.round,
-    );
-  }
+  final double progress;
+  final Color color;
 
   @override
-  bool shouldRepaint(covariant _ConcentricNutritionRingPainter oldDelegate) {
-    if (macros.length != oldDelegate.macros.length) return true;
-    for (int index = 0; index < macros.length; index++) {
-      if (macros[index].item.ratio != oldDelegate.macros[index].item.ratio ||
-          macros[index].color != oldDelegate.macros[index].color) {
-        return true;
-      }
-    }
-    return false;
+  Widget build(BuildContext context) {
+    const double barWidth = 8;
+    const double barHeight = 104;
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(999),
+      child: SizedBox(
+        width: barWidth,
+        height: barHeight,
+        child: Stack(
+          children: <Widget>[
+            const Positioned.fill(child: ColoredBox(color: FigmaColors.track)),
+            Align(
+              alignment: Alignment.bottomCenter,
+              child: SizedBox(
+                width: barWidth,
+                height: barHeight * progress.clamp(0.0, 1.0),
+                child: ColoredBox(color: color),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
 

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -602,6 +602,18 @@ abstract class AppLocalizations {
   /// **'On track'**
   String get homeMetricNormal;
 
+  /// No description provided for @dietAmountOver.
+  ///
+  /// In en, this message translates to:
+  /// **'{amount} over the goal'**
+  String dietAmountOver(String amount);
+
+  /// No description provided for @dietAmountRemaining.
+  ///
+  /// In en, this message translates to:
+  /// **'{amount} remaining to the goal'**
+  String dietAmountRemaining(String amount);
+
   /// No description provided for @homeExerciseActiveTime.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -277,6 +277,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get homeMetricNormal => 'On track';
 
   @override
+  String dietAmountOver(String amount) {
+    return '$amount over the goal';
+  }
+
+  @override
+  String dietAmountRemaining(String amount) {
+    return '$amount remaining to the goal';
+  }
+
+  @override
   String get homeExerciseActiveTime => 'Weekly active time';
 
   @override

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -274,6 +274,16 @@ class AppLocalizationsKo extends AppLocalizations {
   String get homeMetricNormal => '정상';
 
   @override
+  String dietAmountOver(String amount) {
+    return '목표보다 $amount 많아요';
+  }
+
+  @override
+  String dietAmountRemaining(String amount) {
+    return '목표까지 $amount 남았어요';
+  }
+
+  @override
   String get homeExerciseActiveTime => '주간 운동 시간';
 
   @override

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -138,6 +138,22 @@
   "homeWeeklyExerciseTrend": "Weekly exercise trend",
   "homeMetricOver": "Over",
   "homeMetricNormal": "On track",
+  "dietAmountOver": "{amount} over the goal",
+  "@dietAmountOver": {
+    "placeholders": {
+      "amount": {
+        "type": "String"
+      }
+    }
+  },
+  "dietAmountRemaining": "{amount} remaining to the goal",
+  "@dietAmountRemaining": {
+    "placeholders": {
+      "amount": {
+        "type": "String"
+      }
+    }
+  },
   "homeExerciseActiveTime": "Weekly active time",
   "homeExerciseBurned": "Weekly calories",
   "homeExerciseCount": "Weekly workouts",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -91,6 +91,22 @@
   "homeWeeklyExerciseTrend": "주간 운동 추이",
   "homeMetricOver": "초과",
   "homeMetricNormal": "정상",
+  "dietAmountOver": "목표보다 {amount} 많아요",
+  "@dietAmountOver": {
+    "placeholders": {
+      "amount": {
+        "type": "String"
+      }
+    }
+  },
+  "dietAmountRemaining": "목표까지 {amount} 남았어요",
+  "@dietAmountRemaining": {
+    "placeholders": {
+      "amount": {
+        "type": "String"
+      }
+    }
+  },
   "homeExerciseActiveTime": "주간 운동 시간",
   "homeExerciseBurned": "주간 소모 칼로리",
   "homeExerciseCount": "주간 운동 횟수",

--- a/frontend/flutter/test/features/diet/diet_macros_display_test.dart
+++ b/frontend/flutter/test/features/diet/diet_macros_display_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
 import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
@@ -22,27 +23,74 @@ Widget _app(Widget home, {List<Override> overrides = const <Override>[]}) {
 }
 
 void main() {
-  testWidgets('nutrition summary renders circular progress on a small screen', (
-    tester,
-  ) async {
-    await tester.binding.setSurfaceSize(const Size(375, 600));
-    addTearDown(() => tester.binding.setSurfaceSize(null));
-    final DietDay day =
-        await tester.runAsync(() => MockDietRepository().fetchToday())
-            as DietDay;
+  testWidgets(
+    'nutrition summary highlights progress and status on a small screen',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(375, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      final DietDay day =
+          await tester.runAsync(() => MockDietRepository().fetchToday())
+              as DietDay;
 
-    await tester.pumpWidget(_app(Scaffold(body: NutritionSummary(day: day))));
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(_app(Scaffold(body: NutritionSummary(day: day))));
+      await tester.pumpAndSettle();
 
-    expect(find.byKey(const Key('nutrition-circular-summary')), findsOneWidget);
-    expect(find.text('1,067 kcal'), findsOneWidget);
-    expect(find.text('목표 2,000 kcal'), findsOneWidget);
-    expect(find.textContaining('3,428 /2,000mg'), findsOneWidget);
-    expect(find.textContaining('17.8 /50g'), findsOneWidget);
-    expect(find.text('목표 초과'), findsOneWidget);
-    expect(find.text('정상'), findsOneWidget);
-    expect(tester.takeException(), isNull);
-  });
+      final Finder summaryCard = find.byKey(
+        const Key('nutrition-summary-card'),
+      );
+      expect(summaryCard, findsOneWidget);
+      expect(
+        find.byKey(const Key('nutrition-calorie-progress')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: summaryCard,
+          matching: find.byType(CircularProgressIndicator),
+        ),
+        findsOneWidget,
+      );
+      expect(find.textContaining('1,067'), findsOneWidget);
+      expect(find.textContaining('2,000 kcal'), findsOneWidget);
+      expect(find.textContaining('3,428'), findsOneWidget);
+      expect(find.textContaining('17.8'), findsOneWidget);
+      expect(find.text('목표 초과'), findsOneWidget);
+      expect(find.text('정상'), findsOneWidget);
+      expect(find.text('목표보다 1,428mg 많아요'), findsOneWidget);
+      expect(find.text('목표까지 32.2g 남았어요'), findsOneWidget);
+      expect(
+        find.byKey(const Key('nutrition-status-vertical-progress-나트륨')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('nutrition-status-vertical-progress-당류')),
+        findsOneWidget,
+      );
+      final List<ColoredBox> sodiumProgressColors = tester
+          .widgetList<ColoredBox>(
+            find.descendant(
+              of: find.byKey(
+                const Key('nutrition-status-vertical-progress-나트륨'),
+              ),
+              matching: find.byType(ColoredBox),
+            ),
+          )
+          .toList();
+      final List<ColoredBox> sugarProgressColors = tester
+          .widgetList<ColoredBox>(
+            find.descendant(
+              of: find.byKey(
+                const Key('nutrition-status-vertical-progress-당류'),
+              ),
+              matching: find.byType(ColoredBox),
+            ),
+          )
+          .toList();
+      expect(sodiumProgressColors.last.color, FigmaColors.dangerRed);
+      expect(sugarProgressColors.last.color, FigmaColors.greenText);
+      expect(tester.takeException(), isNull);
+    },
+  );
 
   testWidgets('today diet shows API macro grams without label percentages', (
     tester,
@@ -63,20 +111,36 @@ void main() {
     // 오늘 3끼 합계 = 탄120·단45·지45g.
     expect(find.text('탄수화물'), findsOneWidget);
     expect(find.textContaining('탄수화물 45%'), findsNothing);
-    expect(find.textContaining('120 /275g'), findsOneWidget);
+    expect(find.textContaining('120 / 275g'), findsOneWidget);
     expect(find.text('단백질'), findsOneWidget);
     expect(find.textContaining('단백질 17%'), findsNothing);
-    expect(find.textContaining('45 /100g'), findsOneWidget); // 단백질 45g
+    expect(find.textContaining('45 / 100g'), findsOneWidget); // 단백질 45g
     expect(find.text('지방'), findsOneWidget);
     expect(find.textContaining('지방 38%'), findsNothing);
-    expect(find.textContaining('45 /55g'), findsOneWidget); // 지방 45g
+    expect(find.textContaining('45 / 55g'), findsOneWidget); // 지방 45g
+    void expectMacroProgressColor(String label, Color expectedColor) {
+      final Finder progress = find.byKey(
+        Key('nutrition-macro-progress-$label'),
+      );
+      final List<ColoredBox> progressColors = tester
+          .widgetList<ColoredBox>(
+            find.descendant(of: progress, matching: find.byType(ColoredBox)),
+          )
+          .toList();
+      expect(progressColors.last.color, expectedColor);
+    }
+
+    final Color macroProgressColor = FigmaColors.primaryA(0.65);
+    expectMacroProgressColor('탄수화물', macroProgressColor);
+    expectMacroProgressColor('단백질', macroProgressColor);
+    expectMacroProgressColor('지방', macroProgressColor);
     expect(
-      tester.getTopLeft(find.text('탄수화물')).dy,
-      lessThan(tester.getTopLeft(find.text('단백질')).dy),
+      tester.getTopLeft(find.text('탄수화물')).dx,
+      lessThan(tester.getTopLeft(find.text('단백질')).dx),
     );
     expect(
-      tester.getTopLeft(find.text('단백질')).dy,
-      lessThan(tester.getTopLeft(find.text('지방')).dy),
+      tester.getTopLeft(find.text('단백질')).dx,
+      lessThan(tester.getTopLeft(find.text('지방')).dx),
     );
     expect(find.text('짬뽕'), findsOneWidget);
   });

--- a/frontend/flutter/test/features/diet/diet_macros_display_test.dart
+++ b/frontend/flutter/test/features/diet/diet_macros_display_test.dart
@@ -26,7 +26,7 @@ void main() {
   testWidgets(
     'nutrition summary highlights progress and status on a small screen',
     (tester) async {
-      await tester.binding.setSurfaceSize(const Size(375, 600));
+      await tester.binding.setSurfaceSize(const Size(340, 900));
       addTearDown(() => tester.binding.setSurfaceSize(null));
       final DietDay day =
           await tester.runAsync(() => MockDietRepository().fetchToday())
@@ -88,6 +88,32 @@ void main() {
           .toList();
       expect(sodiumProgressColors.last.color, FigmaColors.dangerRed);
       expect(sugarProgressColors.last.color, FigmaColors.greenText);
+
+      final Finder carbs = find.byKey(const Key('nutrition-macro-탄수화물'));
+      final Finder protein = find.byKey(const Key('nutrition-macro-단백질'));
+      final Finder fat = find.byKey(const Key('nutrition-macro-지방'));
+      final Finder sodiumCard = find.byKey(
+        const Key('nutrition-sodium-status'),
+      );
+      final Finder sugarCard = find.byKey(const Key('nutrition-sugar-status'));
+
+      // 좁은 화면에서 각 항목이 겹치지 않고 세로로 쌓이는지 확인한다.
+      expect(
+        tester.getBottomLeft(carbs).dy,
+        lessThan(tester.getTopLeft(protein).dy),
+      );
+      expect(
+        tester.getBottomLeft(protein).dy,
+        lessThan(tester.getTopLeft(fat).dy),
+      );
+      expect(
+        tester.getBottomLeft(summaryCard).dy,
+        lessThan(tester.getTopLeft(sodiumCard).dy),
+      );
+      expect(
+        tester.getBottomLeft(sodiumCard).dy,
+        lessThan(tester.getTopLeft(sugarCard).dy),
+      );
       expect(tester.takeException(), isNull);
     },
   );


### PR DESCRIPTION
## Summary

- 식단 화면의 `오늘의 영양 요약`을 목표 달성 상태를 빠르게 파악할 수 있는 진행 그래프 중심 구조로 개선했습니다.
- 기존 동심원 그래프에서 정보 간 우선순위와 수치 비교가 어려웠던 문제를 해결하고, 앱의 기존 카드·색상·상태 디자인을 유지했습니다.

## Changes

- 칼로리는 현재 섭취량과 목표량, 남은 양을 표시하는 원형 달성률 그래프로 구성했습니다.
- 탄수화물·단백질·지방은 목표 대비 독립적인 가로 진행 막대로 변경하고 기존 하늘색 토큰으로 통일했습니다.
- 나트륨과 당류는 각각 별도 상태 카드로 배치하고, 기존 세로 강조선을 목표 대비 세로 진행 그래프로 변경했습니다.
- 나트륨 초과 시 빨간 수치·배지·세로 그래프와 초과량을 표시하고, 당류 정상 상태는 초록색과 남은 양으로 표현했습니다.
- 모든 진행률을 `현재 섭취량 / 목표량`으로 계산하고 `0.0~1.0` 범위로 제한했습니다.
- 작은 화면에서 탄단지와 상태 카드가 자연스럽게 세로 배치되도록 반응형 처리를 유지했습니다.
- 초과량·남은 양 문구를 한·영 지역화 리소스에 추가하고 생성 코드를 갱신했습니다.
- 원형·가로·세로 진행 그래프와 상태 색상을 검증하도록 식단 위젯 테스트를 보강했습니다.

## Commits

- `feat(diet): 오늘의 영양 요약 시각화를 개선`

## Notes

- API, provider, repository, 모델과 영양 데이터 합산 방식은 변경하지 않았습니다.
- 새 패키지와 임의 색상 코드는 추가하지 않았으며 기존 `FigmaColors`와 `kCardShadow`를 재사용했습니다.
- 한글이 포함된 로컬 경로에서는 Flutter 3.44 분석 서버의 LSP JSON 파싱 오류가 발생해, 동일 소스를 임시 영문 경로로 복사한 뒤 `flutter analyze --no-pub`를 실행했습니다.
- UI 결과 스크린샷은 아직 첨부하지 않았습니다.

## Test Plan

- [x] `flutter analyze --no-pub` — No issues found
- [x] `dart analyze` — No issues found
- [x] `flutter test` — 232 tests passed
- [x] `flutter test test/features/diet/diet_macros_display_test.dart` — 3 tests passed
- [x] `git diff --check`

## Related Issues

- Closes #404

## Checklist

- [x] 브랜치명과 PR 제목이 저장소 규칙을 따릅니다.
- [x] 변경 범위를 `오늘의 영양 요약` UI와 관련 지역화·테스트로 제한했습니다.
- [x] 기존 API와 상태관리 구조를 변경하지 않았습니다.
- [x] 새 동작과 진행 그래프 색상을 검증하는 테스트를 갱신했습니다.
- [x] 새 패키지와 임의 색상 코드를 추가하지 않았습니다.
- [ ] UI 변경 결과 스크린샷 또는 녹화를 첨부했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 영양 요약 화면을 칼로리 카드와 가로형 매크로 진행률로 개선했습니다.
  * 나트륨과 당류 상태를 별도 카드와 진행률로 표시합니다.
  * 칼로리 목표 초과·잔여량을 색상과 안내 문구로 제공합니다.
  * 좁은 화면에서는 영양 정보가 세로로 배치되어 가독성이 향상됩니다.
  * 관련 안내 문구를 한국어와 영어로 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->