### PR TITLE
fix(exercise): restore date field and whiten date picker dialog

### DIFF
--- a/frontend/flutter/lib/features/exercise/presentation/pages/consultation_request_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/consultation_request_page.dart
@@ -65,6 +65,18 @@ class _ConsultationRequestPageState
       initialDate: _preferredDate ?? today,
       firstDate: today,
       lastDate: DateTime(today.year + 100),
+      builder: (BuildContext context, Widget? child) {
+        return Theme(
+          data: Theme.of(context).copyWith(
+            datePickerTheme: const DatePickerThemeData(
+              backgroundColor: Colors.white,
+              headerBackgroundColor: Colors.white,
+              surfaceTintColor: Colors.transparent,
+            ),
+          ),
+          child: child!,
+        );
+      },
     );
     if (selected != null && mounted) {
       setState(() => _preferredDate = selected);
@@ -506,7 +518,7 @@ class _DateField extends StatelessWidget {
         ? l.exSelectDate
         : MaterialLocalizations.of(context).formatMediumDate(date!);
     return Material(
-      color: Colors.white,
+      color: FigmaColors.softBlue,
       borderRadius: BorderRadius.circular(14),
       child: InkWell(
         onTap: onTap,

--- a/frontend/flutter/test/features/exercise/consultation_request_flow_test.dart
+++ b/frontend/flutter/test/features/exercise/consultation_request_flow_test.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:oncare/app/router/app_router.dart';
 import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/features/exercise/domain/entities/consultation_request.dart';
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/presentation/controllers/consultation_request_controller.dart';
@@ -187,9 +188,16 @@ void main() {
           matching: find.byType(Material),
         )
         .first;
-    expect(tester.widget<Material>(dateMaterial).color, Colors.white);
+    expect(tester.widget<Material>(dateMaterial).color, FigmaColors.softBlue);
     await tester.tap(find.text(l.exSelectDate));
     await tester.pumpAndSettle();
+    final BuildContext pickerContext = tester.element(
+      find.byType(DatePickerDialog),
+    );
+    final DatePickerThemeData pickerTheme = DatePickerTheme.of(pickerContext);
+    expect(pickerTheme.backgroundColor, Colors.white);
+    expect(pickerTheme.headerBackgroundColor, Colors.white);
+    expect(pickerTheme.surfaceTintColor, Colors.transparent);
     await tester.tap(find.text('확인'));
     await tester.pumpAndSettle();
     dateMaterial = find
@@ -198,7 +206,7 @@ void main() {
           matching: find.byType(Material),
         )
         .first;
-    expect(tester.widget<Material>(dateMaterial).color, Colors.white);
+    expect(tester.widget<Material>(dateMaterial).color, FigmaColors.softBlue);
     await _scrollTo(tester, find.text(l.exTimeAfternoon), 180);
     await tester.tap(find.text(l.exTimeAfternoon));
     await _scrollTo(tester, find.text(l.exSendConsultRequest), 220);


### PR DESCRIPTION
## Summary

* 상담 요청 화면의 날짜 선택 버튼 배경을 기존 `softBlue`로 복원했습니다.
* 날짜 선택 달력 팝업의 배경과 헤더를 흰색으로 변경했습니다.
* 버튼 배경과 달력 팝업 테마를 각각 검증하도록 기존 상담 요청 테스트를 수정했습니다.

---

## Changes

### ✨ Features

* 해당 없음

### 🔧 Improvements

* `showDatePicker()`에 화면 한정 `DatePickerThemeData`를 적용했습니다.
* 전역 앱 테마에 영향을 주지 않고 상담 요청 달력만 흰색으로 표시합니다.

### 🎨 UI/UX

* `_DateField`의 배경색을 `FigmaColors.softBlue`로 복원했습니다.
* 달력 팝업의 `backgroundColor`와 `headerBackgroundColor`를 흰색으로 지정했습니다.
* `surfaceTintColor`를 투명하게 설정해 Material 3의 파란 표면 색상 오버레이를 제거했습니다.
* 날짜 선택 및 액션 버튼의 브랜드 파란색은 유지합니다.

### 📝 Docs

* 해당 없음

### 🐛 Fixes

* PR #383에서 달력 팝업 대신 날짜 선택 버튼의 배경이 흰색으로 변경된 적용 범위 문제를 수정했습니다.

---

## Commits

1. `a417f37` fix(exercise): make consultation date picker white

---

## Notes

* 전역 `DatePickerThemeData`는 변경하지 않습니다.
* 다른 화면에서 사용하는 날짜 선택 팝업에는 영향을 주지 않습니다.
* API 및 데이터 모델 변경은 없습니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] UI 확인
* [ ] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 헬스장 상담 요청 화면에 진입합니다.
2. 날짜 선택 버튼이 연한 파란색으로 표시되는지 확인합니다.
3. 날짜 선택 버튼을 눌러 달력 팝업을 엽니다.
4. 팝업 배경과 헤더가 흰색인지 확인합니다.
5. 날짜를 선택한 뒤에도 날짜 버튼이 연한 파란색으로 유지되는지 확인합니다.
6. 선택 날짜 및 취소/확인 액션의 파란 강조색이 유지되는지 확인합니다.

---

## Related Issues

Closes #405

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인