### PR TITLE
fix(ci): serialize Pages deployments and extend timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ permissions:
 
 concurrency:
   group: pages
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -87,3 +87,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          timeout: 1800000


### PR DESCRIPTION
## Summary

* GitHub Pages 배포가 연속 실행될 때 기존 배포가 중간 취소되는 문제를 방지
* Pages 내부 큐 지연에 대응하도록 배포 제한시간을 10분에서 30분으로 연장
* Flutter 앱 코드는 변경하지 않고 GitHub Actions 배포 워크플로만 수정

---

## Changes

### 🔧 Improvements

* Pages 워크플로의 `cancel-in-progress`를 `true` → `false`로 변경
* 진행 중인 Pages 배포가 완료된 후 후속 배포가 순차적으로 실행되도록 조정
* `actions/deploy-pages@v4`의 `timeout`을 `1800000ms`(30분)로 설정

### 🐛 Fixes

* 연속 배포 시 기존 Pages 배포가 취소되면서 내부 배포 잠금이 남는 문제 완화
* `deployment_queued` 상태가 기본 제한시간 10분을 초과해 자동 취소되는 문제 완화

---

## Commits

1. `ffbe82c` fix(ci): serialize Pages deployments and extend timeout

---

## Notes

* 최근 성공 및 실패 실행의 Pages 아티팩트 크기는 약 `31.64~31.65MB`로 동일해 파일 크기 증가가 원인은 아닙니다.
* Flutter 웹 빌드와 아티팩트 업로드는 정상적으로 완료됐으며, 실패는 GitHub Pages 내부 배포 큐에서 발생했습니다.
* Node.js 20 deprecation 메시지는 경고이며 이번 배포 실패의 원인이 아닙니다.
* 제한시간 연장은 배포 자체를 느리게 만드는 설정이 아니라, Pages 큐가 지연될 때 조기 취소되지 않도록 대기시간을 확보하는 설정입니다.

---

## Test Plan

* [x] 워크플로 YAML 파싱 확인
* [x] `git diff --check` 통과
* [x] 변경 범위가 `.github/workflows/deploy.yml`로 제한됐는지 확인
* [ ] PR 머지 후 GitHub Pages 배포 성공 확인
* [ ] 연속 배포 시 기존 배포가 취소되지 않는지 확인

### Manual Test Steps

1. PR을 `main` 브랜치에 머지
2. `Deploy GitHub Pages` 워크플로 실행 확인
3. Flutter 웹 빌드 및 Pages 아티팩트 업로드 성공 확인
4. Pages 배포가 10분 이상 지연되더라도 자동 취소되지 않는지 확인
5. 최종 배포 완료 및 서비스 URL 접속 확인

---

## Related Issues

Closes #408 

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] Flutter 앱 코드 영향 없음
* [ ] 실제 GitHub Pages 배포 성공 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **배포 개선**
  * 새로운 배포가 진행될 때 이전 배포 작업이 자동으로 취소되지 않도록 변경했습니다.
  * GitHub Pages 배포에 최대 30분의 제한 시간을 추가해 장시간 지연되는 작업을 방지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->