### PR TITLE
fix(ci): remove unsupported Pages timeout override

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,5 +87,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-        with:
-          timeout: 1800000


### PR DESCRIPTION
## Summary

* `actions/deploy-pages@v4`에서 허용되지 않는 30분 timeout 설정 제거
* Pages 액션이 최대 10분으로 값을 강제 변경하면서 발생시키던 경고 제거
* 진행 중인 Pages 배포를 보호하는 `cancel-in-progress: false` 설정은 유지

---

## Changes

### ✨ Features

-

### 🔧 Improvements

* Pages 배포 단계에서 `timeout: 1800000` 설정 제거
* 실제로 적용되지 않는 워크플로 설정과 관련 경고 정리
* Pages 배포가 순차적으로 실행되도록 기존 concurrency 설정 유지

### 🎨 UI/UX

-

### 📝 Docs

-

### 🐛 Fixes

* `timeout value is greater than the allowed maximum` 경고 제거
* 설정된 30분 timeout과 실제 적용되는 10분 timeout 사이의 불일치 제거

---

## Commits

1. `db9f704` fix(ci): remove unsupported Pages timeout override

---

## Notes

* `actions/deploy-pages@v4`는 timeout 값을 최대 `600000ms`(10분)까지만 허용합니다.
* 기존 `timeout: 1800000` 설정은 실제로 적용되지 않고 10분으로 강제 조정됐습니다.
* `cancel-in-progress: false`는 연속 배포가 진행 중인 배포를 중간에 취소하지 않도록 유지합니다.
* 현재 발생 중인 `deployment_queued` 타임아웃은 Flutter 코드나 아티팩트 문제가 아니라 GitHub Pages 백엔드의 배포 처리 장애로 확인됐습니다.
* 성공·실패 배포의 아티팩트는 모두 파일 122개, 약 93MB로 동일했습니다.
* Pages 사이트 재생성, 커스텀 도메인 복원 및 인증서 승인 후에도 동일 문제가 재현됐습니다.
* 이 PR은 서버 측 장애를 해결하는 것이 아니라 잘못된 워크플로 설정을 정리하는 후속 수정입니다.

---

## Test Plan

* [x] 워크플로 YAML 파싱 확인
* [x] `git diff --check` 통과
* [x] `cancel-in-progress: false` 유지 확인
* [x] `timeout: 1800000` 제거 확인
* [x] 변경 범위가 `.github/workflows/deploy.yml`로 제한됐는지 확인
* [ ] PR 머지 후 timeout 최대값 경고가 사라지는지 확인
* [ ] GitHub Pages 서비스 복구 후 배포 성공 확인

### Manual Test Steps

1. PR을 `main` 브랜치에 머지
2. `Deploy GitHub Pages` 워크플로 실행
3. 배포 로그에서 timeout 최대값 경고가 발생하지 않는지 확인
4. 연속 배포 시 기존 실행이 중간 취소되지 않는지 확인
5. GitHub Pages 서비스 복구 후 최종 배포 성공 여부 확인

---

## Related Issues

Closes #410

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Flutter 앱 코드 영향 없음
* [x] 기존 미커밋 작업과 분리
* [ ] 실제 GitHub Pages 배포 성공 확인