### PR TITLE
fix(ci): verify Pages publish instead of trusting the action timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -106,19 +106,28 @@ jobs:
           SITE_URL: ${{ steps.deployment.outputs.page_url || 'https://ewhasudo.zapto.org/' }}
         run: |
           base="${SITE_URL%/}"
+          # Absolute deadline, not an iteration count: an unresponsive host makes
+          # every curl burn its full --max-time, so counting iterations would let
+          # the poll run ~46 minutes and get killed by timeout-minutes instead.
+          deadline=$(( $(date +%s) + 1200 ))
           echo "deploy-pages did not confirm within its 10 minute cap."
           echo "Polling $base/version.txt for $GITHUB_SHA (up to 20 minutes)."
-          for _ in $(seq 1 80); do
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            left=$(( deadline - $(date +%s) ))
+            budget=$(( left < 20 ? left : 20 ))
+            if [ "$budget" -lt 1 ]; then budget=1; fi
             # -L matters: page_url comes back as http:// on some runs and Pages
             # 301s to https, so without it curl returns the redirect body.
-            live=$(curl -fsSL --max-time 20 -H 'Cache-Control: no-cache' \
+            live=$(curl -fsSL --max-time "$budget" -H 'Cache-Control: no-cache' \
               "$base/version.txt?cachebust=$(date +%s)" 2>/dev/null | tr -d '[:space:]') || live=''
             if [ "$live" = "$GITHUB_SHA" ]; then
               echo "Site is serving $GITHUB_SHA — deployment landed after the action gave up."
               exit 0
             fi
-            echo "  still serving '${live:-<unreachable>}'"
-            sleep 15
+            left=$(( deadline - $(date +%s) ))
+            echo "  still serving '${live:-<unreachable>}' (${left}s left)"
+            if [ "$left" -le 0 ]; then break; fi
+            sleep $(( left < 15 ? left : 15 ))
           done
-          echo "::error::Pages never served $GITHUB_SHA. Check https://www.githubstatus.com before retrying."
+          echo "::error::Pages never served $GITHUB_SHA within 20 minutes. Check https://www.githubstatus.com before retrying."
           exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,12 @@ jobs:
           cp -R frontend/flutter/build/web/* public/frontend/
           mkdir -p public/trainer
           cp -R frontend/flutter_trainer/build/web/* public/trainer/
+          # CanvasKit ships wasm symbol maps for debugging stack traces. They are
+          # never fetched at runtime and cost ~8MB per app, so drop them to keep
+          # the Pages publish as short as possible.
+          find public -name '*.js.symbols' -delete
+          # Deploy marker: lets the verify step below tell which commit is live.
+          echo "$GITHUB_SHA" > public/version.txt
           touch public/.nojekyll
 
       - name: Configure GitHub Pages
@@ -78,12 +84,41 @@ jobs:
     name: Deploy to GitHub Pages
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 35
 
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
+      # actions/deploy-pages clamps its wait to 10 minutes and rejects any higher
+      # `timeout` input, but a degraded Pages backend can take longer and still
+      # publish successfully. So a timeout here is not conclusive — the verify
+      # step decides whether the deployment actually landed.
       - name: Deploy to GitHub Pages
         id: deployment
+        continue-on-error: true
         uses: actions/deploy-pages@v4
+
+      - name: Verify the published site
+        if: steps.deployment.outcome != 'success'
+        env:
+          SITE_URL: ${{ steps.deployment.outputs.page_url || 'https://ewhasudo.zapto.org/' }}
+        run: |
+          base="${SITE_URL%/}"
+          echo "deploy-pages did not confirm within its 10 minute cap."
+          echo "Polling $base/version.txt for $GITHUB_SHA (up to 20 minutes)."
+          for _ in $(seq 1 80); do
+            # -L matters: page_url comes back as http:// on some runs and Pages
+            # 301s to https, so without it curl returns the redirect body.
+            live=$(curl -fsSL --max-time 20 -H 'Cache-Control: no-cache' \
+              "$base/version.txt?cachebust=$(date +%s)" 2>/dev/null | tr -d '[:space:]') || live=''
+            if [ "$live" = "$GITHUB_SHA" ]; then
+              echo "Site is serving $GITHUB_SHA — deployment landed after the action gave up."
+              exit 0
+            fi
+            echo "  still serving '${live:-<unreachable>}'"
+            sleep 15
+          done
+          echo "::error::Pages never served $GITHUB_SHA. Check https://www.githubstatus.com before retrying."
+          exit 1


### PR DESCRIPTION
## Summary

* `actions/deploy-pages`가 대기 시간을 10분으로 하드캡해서, Pages 백엔드가 느릴 때 실제로는 게시에 성공했는데도 워크플로가 실패로 기록되는 문제를 수정합니다.
* 빌드 산출물에 커밋 SHA를 담은 `version.txt`를 게시하고, 액션이 타임아웃하면 라이브 사이트를 최대 20분간 폴링해 실제 게시 여부로 성공/실패를 판정합니다.
* 런타임에 사용하지 않는 CanvasKit wasm 심볼맵을 제거해 게시 작업량을 줄입니다.

---

## Changes

### 🔧 Improvements

* `Prepare GitHub Pages files` 단계에서 `public/version.txt`에 `$GITHUB_SHA` 기록
* `*.js.symbols` 삭제 — 앱당 약 8MB, 파일 6개. 런타임에 참조되지 않음
* deploy 잡에 `timeout-minutes: 35` 추가 (deploy 10분 + verify 20분 + 여유)

### 🐛 Fixes

* deploy 스텝에 `continue-on-error: true` — 액션의 10분 타임아웃이 최종 판정이 되지 않도록
* `Verify the published site` 단계 신설 — 라이브 `version.txt`를 15초 간격으로 최대 20분 폴링해 SHA 일치 시 성공, 끝내 불일치면 실패
* 폴링 `curl`에 `-L` — `page_url`이 실행에 따라 `http://`로 반환되고 Pages가 https로 301하므로, 없으면 리다이렉트 본문을 받아 항상 불일치

---

## Commits

1. `8cfa52e` fix(ci): verify Pages publish instead of trusting the action timeout

---

## Notes

* **근본 원인은 우리 코드가 아닙니다.** GitHub Pages 게시 지연이 원인이고 공식 major_outage로 등록되어 있습니다. 이 PR은 게시를 빠르게 만들지 않고, 게시 결과를 정확히 보고하도록 만듭니다.
* **`-L` 누락은 리뷰 중 발견해 수정했습니다.** 실패한 실행 4건 중 2건에서 `page_url`이 `http://`로 반환됐습니다. 사이트는 `https_enforced: true`라 301을 내는데, `-f`는 3xx에서 실패하지 않으므로 curl이 exit 0과 함께 301 HTML 본문을 반환합니다. 이 상태면 SHA가 영영 일치하지 않아 20분을 태우고 거짓 실패했을 것입니다.
* **verify가 통과해도 `github-pages` 환경에는 실패한 배포로 남습니다.** 액션이 타임아웃 시 배포를 취소하기 때문이며 우리 쪽에서 바꿀 수 없습니다. 워크플로 체크는 초록이 됩니다.
* 크기 절감 효과는 압축 기준 앱당 14.88MB → 13.69MB로 크지 않습니다. 원인 해결이 아니라 10분 캡에 대한 여유분입니다.
* `concurrency.cancel-in-progress: false`와 최대 35분 잡이 겹치면 연속 머지 시 배포가 직렬로 대기합니다. 배포 중 취소가 더 위험하므로 현 설정을 유지했습니다.

---

## Test Plan

* [ ] 기능 정상 동작 확인
* [ ] 예외 케이스 확인
* [ ] 빌드 성공

### Manual Test Steps

1. main 머지 후 Deploy GitHub Pages 실행을 확인한다.
2. deploy 스텝이 10분에 타임아웃되면 `Verify the published site` 단계가 이어서 실행되는지 확인한다.
3. `https://ewhasudo.zapto.org/version.txt` 가 머지 커밋 SHA를 반환하고 잡이 성공으로 끝나는지 확인한다.

---

## Related Issues

Closes #417

## Checklist

* [ ] 코드 리뷰 준비 완료
* [ ] 불필요한 코드 제거
* [ ] 하드코딩 값 점검
* [ ] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 배포된 버전을 보다 쉽게 확인할 수 있도록 현재 버전 정보가 기록됩니다.
  - 배포 과정의 안정성이 향상되어, 일시적인 배포 결과 지연에도 실제 게시 여부를 확인할 수 있습니다.
  - 배포가 제한 시간 내 완료되지 않거나 올바른 버전이 게시되지 않으면 명확하게 실패 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->