### PR TITLE
fix(member): 웹 하단 내비게이션 라벨 잘림 수정

### DIFF
--- a/frontend/flutter/lib/app/router/main_shell.dart
+++ b/frontend/flutter/lib/app/router/main_shell.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
@@ -26,6 +27,12 @@ class MainShell extends StatelessWidget {
     final double navBottomPadding = bottomInset > maxNavBottomPadding
         ? maxNavBottomPadding
         : bottomInset;
+    // Mobile safe areas already leave enough room for the destination labels.
+    // Flutter web usually reports a zero bottom inset, so the 4dp paint
+    // translation below can put the web font's descenders beyond the viewport
+    // edge. Reserve web-only paint room without changing the mobile layout.
+    const double webClipGuard = kIsWeb ? 12 : 0;
+    final double effectiveBottomPadding = navBottomPadding + webClipGuard;
     const double barHeight = 56;
     const double lift = 24; // headroom so the + button floats above the bar
     return Scaffold(
@@ -35,7 +42,7 @@ class MainShell extends StatelessWidget {
       body: navigationShell,
       floatingActionButton: OniFab(onTap: () => showCoachingSheet(context)),
       bottomNavigationBar: SizedBox(
-        height: barHeight + lift + navBottomPadding,
+        height: barHeight + lift + effectiveBottomPadding,
         child: Center(
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 672),
@@ -49,8 +56,8 @@ class MainShell extends StatelessWidget {
                   right: 0,
                   bottom: 0,
                   child: Container(
-                    height: barHeight + navBottomPadding,
-                    padding: EdgeInsets.only(bottom: navBottomPadding),
+                    height: barHeight + effectiveBottomPadding,
+                    padding: EdgeInsets.only(bottom: effectiveBottomPadding),
                     decoration: const BoxDecoration(
                       color: AppColors.background,
                       border: Border(top: BorderSide(color: AppColors.border)),


### PR DESCRIPTION
## Summary

* Flutter 웹에서 하단 내비게이션 라벨의 글자 하단이 화면 경계에 잘리던 문제를 수정했습니다.
* 웹에서만 12px의 클리핑 방지 여유 공간을 추가해 destination의 4px 하단 이동을 안전하게 수용합니다.
* 모바일 safe area 처리와 최신 하단 내비게이션 높이 56px은 그대로 유지합니다.

---

## Changes

### ✨ Features

* 없음

### 🔧 Improvements

* 웹 여부에 따라 실제 하단 패딩을 계산하는 `effectiveBottomPadding`을 추가했습니다.
* 내비게이션 전체 높이와 내부 컨테이너 패딩이 같은 계산값을 사용하도록 통일했습니다.

### 🎨 UI/UX

* 웹에서 홈, 식단, 운동, MY 라벨의 descender가 viewport 밖으로 잘리지 않도록 하단 여유 공간을 확보했습니다.
* 모바일의 기존 하단 여백과 중앙 기록 추가 버튼 정렬은 변경하지 않았습니다.

### 📝 Docs

* 없음

### 🐛 Fixes

* Flutter 웹이 하단 safe area를 0으로 반환할 때, 아래로 4px 이동된 내비게이션 라벨이 화면 경계에 잘리던 문제를 수정했습니다.

---

## Commits

1. `4013f92` fix(member): prevent web bottom nav label clipping

---

## Notes

* 최신 `origin/main`에서 분기했으며 기존 `barHeight = 56`과 12px 텍스트 스타일을 유지했습니다.
* 열린 PR #434와 #432는 현재 변경 파일과 겹치지 않습니다.
* 두 PR 브랜치 각각과 `git merge-tree`로 가상 병합했으며 모두 충돌 없이 통과했습니다.
* 전체 `flutter analyze`는 한글 경로가 포함된 분석 서버 요청의 JSON 파싱 오류로 도구가 종료됐습니다. 동일 파일을 `dart analyze`로 직접 분석한 결과는 문제가 없었습니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| 미첨부 | 미첨부 |

---

## Test Plan

* [ ] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] UI 확인
* [ ] 빌드 성공
* [x] 관련 정적 분석 통과

### Manual Test Steps

1. Flutter 웹에서 회원 앱을 실행하고 홈, 식단, 운동, MY 라벨의 하단이 잘리지 않는지 확인합니다.
2. 중앙 기록 추가 버튼과 하단 내비게이션의 정렬이 유지되는지 확인합니다.
3. 모바일에서 기존 safe area와 하단 내비게이션 위치가 달라지지 않았는지 확인합니다.

검증 명령:

* `dart analyze lib/app/router/main_shell.dart` — `No issues found`
* `git diff --check` — 통과
* `git merge-tree --write-tree --messages HEAD origin/fix/home-ai-advice` — 충돌 없음
* `git merge-tree --write-tree --messages HEAD origin/refactor/map-placeholder-cleanup` — 충돌 없음

---

## Related Issues

Closes #436

## Checklist

* [ ] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 웹 환경에서 하단 내비게이션 텍스트가 화면 밖으로 잘리지 않도록 여백과 영역 높이를 조정했습니다.
  * 모바일에서는 기존 안전 영역 처리를 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->