### PR TITLE
fix(my): 동기화 코드 탭 복사 기능 제거

### DIFF
--- a/frontend/flutter/lib/features/my_health/presentation/widgets/trainer_sync_sheet.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/widgets/trainer_sync_sheet.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare/design_system/tokens/colors.dart';
@@ -203,37 +202,24 @@ class _CodeDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final AppLocalizations l = AppLocalizations.of(context);
     return Semantics(
       // 스크린리더가 "구십칠만…" 으로 읽지 않게 한 자씩 끊어 준다.
       label: code.split('').join(' '),
       // 자리마다 Text 가 하나씩 생기므로, 읽어 주는 것은 이 라벨 하나로 둔다.
       excludeSemantics: true,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: dimmed
-            ? null
-            : () async {
-                await Clipboard.setData(ClipboardData(text: code));
-                if (!context.mounted) return;
-                ScaffoldMessenger.of(
-                  context,
-                ).showSnackBar(SnackBar(content: Text(l.trainerSyncCopied)));
-              },
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            for (int i = 0; i < code.length; i++)
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 3),
-                child: _DigitBox(
-                  key: ValueKey<String>('sync-digit-$i'),
-                  digit: code[i],
-                  dimmed: dimmed,
-                ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          for (int i = 0; i < code.length; i++)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 3),
+              child: _DigitBox(
+                key: ValueKey<String>('sync-digit-$i'),
+                digit: code[i],
+                dimmed: dimmed,
               ),
-          ],
-        ),
+            ),
+        ],
       ),
     );
   }

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -3589,12 +3589,6 @@ abstract class AppLocalizations {
   /// **'Get a new code'**
   String get trainerSyncRetry;
 
-  /// No description provided for @trainerSyncCopied.
-  ///
-  /// In en, this message translates to:
-  /// **'Sync code copied'**
-  String get trainerSyncCopied;
-
   /// No description provided for @signUpEmailTaken.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -1962,9 +1962,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get trainerSyncRetry => 'Get a new code';
 
   @override
-  String get trainerSyncCopied => 'Sync code copied';
-
-  @override
   String get signUpEmailTaken =>
       'That email is already registered. Please sign in.';
 

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -1914,9 +1914,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get trainerSyncRetry => '새 코드 받기';
 
   @override
-  String get trainerSyncCopied => '동기화 코드를 복사했어요';
-
-  @override
   String get signUpEmailTaken => '이미 가입된 이메일이에요. 로그인해 주세요.';
 
   @override

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -1068,7 +1068,6 @@
   "trainerSyncExpired": "This code has expired.",
   "trainerSyncFailed": "Could not get a code.",
   "trainerSyncRetry": "Get a new code",
-  "trainerSyncCopied": "Sync code copied",
   "signUpEmailTaken": "That email is already registered. Please sign in.",
   "signUpFailed": "Sign-up failed. Please try again in a moment.",
   "onboardSkip": "Do this later",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -682,7 +682,6 @@
   "trainerSyncExpired": "코드가 만료됐어요.",
   "trainerSyncFailed": "코드를 받지 못했어요.",
   "trainerSyncRetry": "새 코드 받기",
-  "trainerSyncCopied": "동기화 코드를 복사했어요",
   "signUpEmailTaken": "이미 가입된 이메일이에요. 로그인해 주세요.",
   "signUpFailed": "회원가입에 실패했어요. 잠시 후 다시 시도해 주세요.",
   "onboardSkip": "나중에 하기",


### PR DESCRIPTION
## Summary

* 회원 앱 `트레이너와 데이터 동기화` 시트의 6자리 코드 상자에 걸려 있던 **탭-복사**를 제거했다.
* 복사 확인 SnackBar 는 모달 바텀시트에 가려 회원에게 보이지 않았다 — 눌러도 아무 일이 없는 것처럼 보이면서 클립보드만 바뀌는 상태였다.
* 코드는 여섯 자리고 안내부터가 "트레이너에게 이 6자리를 불러 주세요"라, 옮겨 붙일 자리가 없는 값이다.

---

## Changes

### ✨ Features

* 없음

### 🔧 Improvements

* 없음

### 🎨 UI/UX

* `_CodeDisplay` 의 `GestureDetector`·`Clipboard.setData`·확인 SnackBar 제거
* 쓰이지 않게 된 `trainerSyncCopied` 를 `app_ko.arb`·`app_en.arb` 에서 제거하고 l10n 재생성
* `Clipboard` 전용이던 `import 'package:flutter/services.dart'` 제거

### 📝 Docs

* 없음

### 🐛 Fixes

* 없음

---

## Commits

1. `c8e5a0e2` fix(my): 동기화 코드 탭 복사 기능 제거

---

## Notes

* **SnackBar 가 왜 안 보였나** — 시트는 `showModalBottomSheet(useRootNavigator: true, isScrollControlled: true)` 로 열린다. `ScaffoldMessenger.of(context)` 의 SnackBar 는 그 모달 라우트 **아래** Scaffold 에 그려지므로 시트가 덮는다.
* **남긴 것** — 숫자 상자 표시, 카운트다운, 만료 시 흐림 처리, 한 자씩 끊어 읽는 `Semantics` 라벨은 그대로다. 코드를 크게 띄우고 자리마다 상자를 두는 이유(마주 앉아 불러 주는 값)는 변하지 않았다.
* 복사 동작을 검증하던 테스트는 없었다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| 코드 상자 탭 → 클립보드 복사 + 시트에 가려 안 보이는 SnackBar | 코드 상자 탭 → 아무 일도 일어나지 않음 |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 회원 앱 MY → `트레이너와 데이터 동기화` 열기
2. 6자리 코드 상자를 탭 — 아무 반응이 없고 클립보드가 바뀌지 않는지 확인
3. 코드 표시·남은 시간·만료 시 흐림, 스크린리더 낭독이 그대로인지 확인

`flutter analyze` → No issues found. `flutter test` → All tests passed (1100).

---

## Related Issues

Closes #1678

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
